### PR TITLE
Update port to 3002

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 1. Run `bundle install` to install the gem dependencies
 2. Run `yarn` to install node dependencies
-3. Run `bundle exec rails server` to launch the app on http://localhost:3000
+3. Run `bundle exec rails server` to launch the app on http://localhost:3002
 
 ## Running specs, linter(without auto correct) and annotate models and serializers
 

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -8,7 +8,7 @@ CanonicalRails.setup do |config|
   # This is the main host, not just the TLD, omit slashes and protocol. If you have more than one, pick the one you want to rank in search results.
 
   config.host = "www.find-postgraduate-teacher-training.service.gov.uk"
-  config.port# = '3000'
+  config.port# = '3002'
 
   # http://en.wikipedia.org/wiki/URL_normalization
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,9 +8,9 @@ max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
+# Specifies the `port` that Puma will listen on to receive requests; default is 3002.
 #
-port        ENV.fetch("PORT") { 3000 }
+port        ENV.fetch("PORT") { 3002 }
 
 # Specifies the `environment` that Puma will run in.
 #


### PR DESCRIPTION
### Context
The publish/manage apps run on `3000` and `3001` already

### Changes proposed in this pull request
Change default port to `3002`

### Guidance to review
🚢 
