### PR TITLE
[2642] - Run static analysis as part of the build pipeline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,9 @@ group :development, :test do
 end
 
 group :development do
+  # Static analysis
+  gem "brakeman"
+
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem "listen", ">= 3.0.5", "< 3.3"
   gem "web-console", ">= 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
     bindex (0.5.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
+    brakeman (4.7.2)
     builder (3.2.3)
     byebug (11.0.1)
     canonical-rails (0.2.6)
@@ -320,6 +321,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)
+  brakeman
   byebug
   canonical-rails
   capybara (>= 2.15)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,6 +12,10 @@ class PagesController < ApplicationController
   def accessibilty; end
 
   def show
-    render template: "pages/#{params[:page]}"
+    render template: "pages/#{page_param}"
+  end
+
+  def page_param
+    params.require(:page)
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,6 +67,14 @@ steps:
     runInBackground: false
 
 - task: Docker@1
+  displayName: Run Brakeman static analysis
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: brakeman
+    runInBackground: false
+
+- task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)
   inputs:
     command: Tag image


### PR DESCRIPTION
### Context
We want to ensure any newly deployed code is safe

### Changes proposed in this pull request
- Add Brakeman gem
- Run Brakeman as part of the build pipeline 
