### PR TITLE
Remove Rails-generated ActionMailer file

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
-end


### PR DESCRIPTION
ActionMailer is not yet configured so it blows up in non-dev as code is eager loaded.


