### PR TITLE
Fix up website if nil

### DIFF
--- a/app/decorators/provider_decorator.rb
+++ b/app/decorators/provider_decorator.rb
@@ -6,6 +6,8 @@ class ProviderDecorator < Draper::Decorator
   end
 
   def website
+    return if object.website.blank?
+
     object.website.start_with?("http") ? object.website : ("http://" + object.website)
   end
 end

--- a/spec/decorators/provider_decorator_spec.rb
+++ b/spec/decorators/provider_decorator_spec.rb
@@ -11,8 +11,18 @@ describe ProviderDecorator do
 
   let(:decorated_provider) { provider.decorate }
 
-  it "returns a valid website URL" do
-    expect(decorated_provider.website).to eq("http://www.acmescitt.com")
+  describe "#website" do
+    let(:subject) { decorated_provider.website }
+
+    context "with website" do
+      it { is_expected.to eq("http://www.acmescitt.com") }
+    end
+
+    context "without website" do
+      let(:provider) { build(:provider, website: nil) }
+
+      it { is_expected.to eq(nil) }
+    end
   end
 
   it "returns the full address" do


### PR DESCRIPTION
### Context
Website was returning "http://" if `nil`

### Changes proposed in this pull request
Return `nil` from the decorator is website is `nil`

### Guidance to review
### Before
![localhost_3002_course_T92_X130(Laptop with MDPI screen) (4)](https://user-images.githubusercontent.com/3071606/71620714-5e5d2080-2bc3-11ea-87c9-ff42401d1aa9.png)

### After
![localhost_3002_course_T92_X130(Laptop with MDPI screen) (3)](https://user-images.githubusercontent.com/3071606/71620715-6026e400-2bc3-11ea-8f8c-4a9e05be3bbe.png)

