### PR TITLE
[2744] Add cta for dfe apply

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,4 +1,9 @@
 class Provider < Base
   belongs_to :recruitment_cycle, param: :recruitment_cycle_year
   has_many :courses, param: :course_code
+
+  def supporting_dfe_apply?
+    opted_in_providers = %w[R55 1N1 S31 24L 1HQ L06 2LR 254 12K 1OT]
+    opted_in_providers.include?(provider_code)
+  end
 end

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -4,57 +4,76 @@
 
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
-  <p class="govuk-body">
-    <%= link_to 'Apply on the UCAS website', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do', class: 'govuk-link' %>. You’ll need to register with UCAS before you can apply.
-  </p>
-  <p class="govuk-body">
-    Visit Get into Teaching for <%= link_to 'guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply/apply', class: 'govuk-link' %>.
-  </p>
 
-  <p class="govuk-body">
-    When you apply you’ll need these codes for the Choices section of your application form:
-  </p>
-  <div class="govuk-inset-text">
-    <ul class="govuk-list">
-      <li class="govuk-!-margin-bottom-2">
-        Training provider code:
-        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.provider.provider_code %></span>
-      </li>
-      <li>
-        Training programme code:
-        <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.course_code %></span>
-      </li>
-    </ul>
-  </div>
-  <h3 class="govuk-heading-m">Choose a training location</h3>
-  <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+  <% if course.has_vacancies? %>
+    <% if course.provider.supporting_dfe_apply? %>
+      <p class="govuk-body">
+        <%= link_to "Apply for this course", "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}", class: "govuk-button govuk-button--start" %>
+      </p>
+    <% else %>
+      <p class="govuk-body">
+        <%= link_to 'Apply on the UCAS website', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do', class: 'govuk-link' %>. You’ll need to register with UCAS before you can apply.
+      </p>
+      <p class="govuk-body">
+        Visit Get into Teaching for <%= link_to 'guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply/apply', class: 'govuk-link' %>.
+      </p>
 
-  <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
+      <p class="govuk-body">
+        When you apply you’ll need these codes for the Choices section of your application form:
+      </p>
+      <div class="govuk-inset-text">
+        <ul class="govuk-list">
+          <li class="govuk-!-margin-bottom-2">
+            Training provider code:
+            <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.provider.provider_code %></span>
+          </li>
+          <li>
+            Training programme code:
+            <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.course_code %></span>
+          </li>
+        </ul>
+      </div>
 
-  <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th class="govuk-table__header" scope="col">Location</th>
-        <th class="govuk-table__header" scope="col">Vacancies</th>
-        <th class="govuk-table__header" scope="col">Code</th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      <% course.preview_site_statuses.each do |site_status| %>
+    <% end %>
+
+    <h3 class="govuk-heading-m">Choose a training location</h3>
+    <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+
+    <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
+
+    <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
+      <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell">
-            <strong><%= site_status.site.location_name %></strong>
-            <br>
-            <%= site_status.site.decorate.full_address %>
-          </td>
-          <td class="govuk-table__cell">
-            <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
-          </td>
-          <td class="govuk-table__cell"><%= site_status.site.code %></td>
+          <th class="govuk-table__header" scope="col">Location</th>
+          <th class="govuk-table__header" scope="col">Vacancies</th>
+          <th class="govuk-table__header" scope="col">Code</th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% course.preview_site_statuses.each do |site_status| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= site_status.site.location_name %></strong>
+              <br>
+              <%= site_status.site.decorate.full_address %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
+            </td>
+            <td class="govuk-table__cell"><%= site_status.site.code %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="govuk-warning-text">
+      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+      <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        You can't apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to 'Only courses with vacancies'.
+      </strong>
+    </div>
+  <% end %>
 </div>
 
 <script>

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,0 +1,13 @@
+describe Provider do
+  context "#supporting_dfe_apply?" do
+    it "is an opted-in provider" do
+      provider = build(:provider, provider_code: "R55")
+      expect(provider.supporting_dfe_apply?).to eq(true)
+    end
+
+    it "is not an opted-in provider" do
+      provider = build(:provider, provider_code: "122")
+      expect(provider.supporting_dfe_apply?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
### Context
DfE Apply Pilot

### Changes proposed in this pull request
Add CTA for DfE Apply if the provider is opted in to the DfE Apply Pilot

### Guidance to review
Find a course for the following providers `R55 1N1 S31 24L 1HQ L06 2LR 254 12K 1OT` then check in the apply section for a button linking to DfE Apply. All other courses should have a link to UCAS.

Best reviewed if you ignore the whitespace changes i.e. https://github.com/DFE-Digital/find-teacher-training/pull/39/files?utf8=%E2%9C%93&diff=unified&w=1.

Note: I also had to add the missing vacancies if statement