### PR TITLE
[2744] Ensure root path is redirected to old find

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
-  def home; end
-
   def terms; end
 
   def privacy; end
@@ -10,12 +8,4 @@ class PagesController < ApplicationController
   def cookies; end
 
   def accessibilty; end
-
-  def show
-    render template: "pages/#{page_param}"
-  end
-
-  def page_param
-    params.require(:page)
-  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,7 +41,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Find postgraduate teacher training", "/", class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Find postgraduate teacher training", Settings.search_and_compare_ui.base_url, class: "govuk-header__link govuk-header__link--service-name" %>
         </div>
       </div>
     </header>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,0 @@
-<div class="govuk-width-container">
-  <p class="govuk-body">Lorem</p>
-</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  root to: "pages#home"
-
-  get "/pages/:page", to: "pages#show"
+  root to: redirect(Settings.search_and_compare_ui.base_url)
 
   get "/terms-conditions", to: "pages#terms", as: "terms"
   get "/accessibility", to: "pages#accessibility", as: "accessibility"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,3 +6,5 @@ google:
   maps_api_key: replace_me
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
+search_and_compare_ui:
+  base_url: http://localhost:5000

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
+search_and_compare_ui:
+  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
+search_and_compare_ui:
+  base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
+search_and_compare_ui:
+  base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -3,12 +3,6 @@
 require "rails_helper"
 
 RSpec.feature "View pages", type: :feature do
-  scenario "Navigate to home" do
-    visit "/pages/home"
-
-    expect(page).to have_text("Lorem")
-  end
-
   scenario "Navigate to cookies" do
     visit cookies_path
 

--- a/spec/requests/pages_spec.rb
+++ b/spec/requests/pages_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "page requests", type: :request do
+  describe "GET root_path" do
+    it "redirects to curent search and compare ui app" do
+      get root_path
+      expect(response).to redirect_to(Settings.search_and_compare_ui.base_url)
+    end
+  end
+end


### PR DESCRIPTION
### Context
Ensure users land back on current FIND if they click the home link or navigate to the root path

### Changes proposed in this pull request
- Add search and compare base URL to settings
- Remove redundant pages#show route and controller actions
- Redirect root path to current FIND
- Add request spec to assert redirect

### Guidance to review
Navigate to the root path or click "Find postgraduate teacher training" in the header

