### PR TITLE
[2746] Add back to search results link

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,5 +1,9 @@
 <%= content_for :page_title, "#{course.name_and_code} with #{course.provider.provider_name}" %>
 
+<%= content_for(:before_content) do %>
+  <div data-module="back-link"></div>
+<% end %>
+
 <h1 class="govuk-heading-xl">
   <span class="govuk-!-font-size-36" data-qa="course__provider_name"><%= course.provider.provider_name %></span><br>
   <%= course.name_and_code %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,6 +55,7 @@
           </span>
         </p>
       </div>
+      <%= yield(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <%= yield %>
       </main>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -1,7 +1,11 @@
 import "../styles/application.scss";
 import { initAll } from "govuk-frontend";
 import initLocationsMap from "scripts/locations-map";
+import backLink from "scripts/back-link";
 
 initAll();
 
 window.initLocationsMap = initLocationsMap;
+
+const $backLink = document.querySelector('[data-module="back-link"]');
+new backLink($backLink).init();

--- a/app/webpacker/scripts/back-link.js
+++ b/app/webpacker/scripts/back-link.js
@@ -1,0 +1,26 @@
+function BackLink($module) {
+  this.$module = $module
+}
+
+BackLink.prototype.init = function() {
+  var $module = this.$module
+
+  if (!$module) {
+    return
+  }
+
+  window.addEventListener("load", function() {
+    var $isInternalReferrer = document.referrer.indexOf(location.protocol + "//" + location.hostname) === 0
+
+    if ($isInternalReferrer) {
+      var $link = document.createElement("a")
+      $link.setAttribute("href", document.referrer)
+      $link.setAttribute("class", "govuk-back-link")
+      $link.textContent = "Back to search results"
+
+      $module.appendChild($link)
+    }
+  })
+}
+
+export default BackLink


### PR DESCRIPTION
### Context
New FIND 💃 

### Changes proposed in this pull request
Add the same backlink as the current FIND. We can probably do this server-side some once we're fully moved over to Rails.

### Guidance to review
Click on a course from the results page and watch the backlink appear. Navigate directly to a course and the backlink shouldn't appear.

### After
![localhost_3002_course_T92_X130(Laptop with MDPI screen) (5)](https://user-images.githubusercontent.com/3071606/71932221-5854da00-3197-11ea-8f65-c4ba4d0a3152.png)
