### PR TITLE
2737 spot check fixes

### DIFF
--- a/app/views/courses/_about_course.html.erb
+++ b/app/views/courses/_about_course.html.erb
@@ -1,10 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-about">About the course</h2>
   <div data-qa="course__about_course">
-    <% if course.about_course.present? %>
-      <%= markdown(course.about_course) %>
-    <% else %>
-      <p class="app-missing-section">Please add details for this section.</p>
-    <% end %>
+    <%= markdown(course.about_course) %>
   </div>
 </div>

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,10 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools">How school placements work</h2>
   <div data-qa="course__about_schools">
-    <% if course.how_school_placements_work.present? %>
-      <%= markdown(course.how_school_placements_work) %>
-    <% else %>
-      <p class="app-missing-section">Please add details for this section.</p>
-    <% end %>
+    <%= markdown(course.how_school_placements_work) %>
   </div>
 </div>

--- a/app/views/courses/_about_the_provider.html.erb
+++ b/app/views/courses/_about_the_provider.html.erb
@@ -1,12 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-about-provider">About the training provider</h2>
-  <div data-qa="course__about_provider">
-    <% if course.provider.train_with_us.present? %>
+  <% if course.provider.train_with_us.present? %>
+    <h2 class="govuk-heading-l" id="section-about-provider">About the training provider</h2>
+    <div data-qa="course__about_provider">
       <%= markdown(course.provider.train_with_us) %>
-    <% else %>
-      <p class="app-missing-section">Please add details <%= link_to 'about your organisation', about_provider_recruitment_cycle_path(course.provider.provider_code, course.provider.recruitment_cycle_year) %>.</p>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <% if course.about_accrediting_body.present? %>
     <div data-qa="course__about_accrediting_body">

--- a/app/views/courses/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/_entry_requirements_qualifications.html.erb
@@ -1,13 +1,11 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Requirements</h2>
-  <h3 class="govuk-heading-m">Qualifications</h3>
-  <div data-qa="course__required_qualifications">
-    <% if course.required_qualifications.present? %>
+  <% if course.required_qualifications.present? %>
+    <h3 class="govuk-heading-m">Qualifications</h3>
+    <div data-qa="course__required_qualifications">
       <%= markdown(course.required_qualifications) %>
-    <% else %>
-      <p class="app-missing-section">Please add details for this section.</p>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <% if course.personal_qualities.present? %>
     <h3 class="govuk-heading-m">Personal qualities</h3>

--- a/app/views/courses/_fees.html.erb
+++ b/app/views/courses/_fees.html.erb
@@ -35,7 +35,5 @@
         <%= markdown(course.fee_details) %>
       </div>
     <% end %>
-  <% else %>
-    <p class="app-missing-section">Please add details for this section.</p>
   <% end %>
 </div>

--- a/app/views/courses/_salary.html.erb
+++ b/app/views/courses/_salary.html.erb
@@ -2,7 +2,5 @@
   <h2 class="govuk-heading-l" id="section-salary">Salary</h2>
   <% if course.salary_details.present? %>
     <%= markdown(course.salary_details) %>
-  <% else %>
-    <p class="app-missing-section">Please add details for this section.</p>
   <% end %>
 </div>

--- a/app/views/courses/_train_with_disabilities.html.erb
+++ b/app/views/courses/_train_with_disabilities.html.erb
@@ -1,10 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-train-with-disabilities">Training with disabilities and other needs</h2>
   <div data-qa="course__train_with_disabilities">
-    <% if course.provider.train_with_disability.present? %>
-      <%= markdown(course.provider.train_with_disability) %>
-    <% else %>
-      <p class="app-missing-section">Please add details about <%= link_to 'training with disabilities', about_provider_recruitment_cycle_path(course.provider.provider_code, course.provider.recruitment_cycle_year) %>.</p>
-    <% end %>
+    <%= markdown(course.provider.train_with_disability) %>
   </div>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -46,11 +46,15 @@
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m">Contents</h2>
     <ul class="govuk-list govuk-list--dash course-contents govuk-!-margin-bottom-8">
-      <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
+      <% if course.about_course.present? %>
+        <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
+      <% end %>
       <% if course.interview_process.present? %>
         <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
       <% end %>
-      <li><%= link_to 'How school placements work', '#section-schools', class: 'govuk-link' %></li>
+      <% if course.how_school_placements_work.present? %>
+        <li><%= link_to 'How school placements work', '#section-schools', class: 'govuk-link' %></li>
+      <% end %>
       <% if course.has_fees? %>
         <li><%= link_to 'Fees', '#section-fees', class: 'govuk-link' %></li>
       <% else %>
@@ -58,20 +62,28 @@
       <% end %>
       <li><%= link_to 'Financial support', '#section-financial-support', class: 'govuk-link' %></li>
       <li><%= link_to 'Requirements', '#section-entry', class: 'govuk-link' %></li>
-      <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
-      <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
+      <% if course.provider.train_with_us.present? ||  course.about_accrediting_body.present? %>
+        <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
+      <% end %>
+      <% if course.provider.train_with_disability.present? %>
+        <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
+      <% end %>
       <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
       <li><%= link_to 'Apply', '#section-apply', class: 'govuk-link' %></li>
       <li><%= link_to 'Support and advice', '#section-advice', class: 'govuk-link' %></li>
     </ul>
 
-    <%= render partial: 'courses/about_course' %>
+    <% if course.about_course.present? %>
+      <%= render partial: 'courses/about_course' %>
+    <% end %>
 
     <% if course.interview_process.present? %>
       <%= render partial: 'courses/interview_process' %>
     <% end %>
 
-    <%= render partial: 'courses/about_schools' %>
+    <% if course.how_school_placements_work.present? %>
+      <%= render partial: 'courses/about_schools' %>
+    <% end %>
 
     <% if course.has_fees? %>
       <%= render partial: 'courses/fees' %>
@@ -83,9 +95,13 @@
 
     <%= render partial: 'courses/entry_requirements_qualifications' %>
 
-    <%= render partial: 'courses/about_the_provider' %>
+    <% if course.provider.train_with_us.present? ||  course.about_accrediting_body.present? %>
+      <%= render partial: 'courses/about_the_provider' %>
+    <% end %>
 
-    <%= render partial: 'courses/train_with_disabilities' %>
+    <% if course.provider.train_with_disability.present? %>
+      <%= render partial: 'courses/train_with_disabilities' %>
+    <% end %>
 
     <%= render partial: 'courses/contact_details' %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -43,7 +43,7 @@ en:
       short: "%B %Y"
   qualifications:
     qts: "QTS"
-    pgce: "PGCE only (without QTS)"
+    pgce: "PGCE"
     pgce_with_qts: "PGCE with QTS"
-    pgde: "PGDE only (without QTS)"
+    pgde: "PGDE"
     pgde_with_qts: "PGDE with QTS"


### PR DESCRIPTION
### Context
New course page

### Changes proposed in this pull request
- Fix course outcome/qualification
- Remove "Missing" sections accidentally copied from the preview page in manage courses frontend

### Guidance to review
- An FE course to check the qualification displays
- A course with missing information i.e. about this course shouldn't render the section or in the anchor 
- Changes best viewed ignoring white space - https://github.com/DFE-Digital/find-teacher-training/pull/42/files?utf8=%E2%9C%93&diff=unified&w=1