### PR TITLE
[2343] Add filters for study type

### DIFF
--- a/app/controllers/filters/study_type_controller.rb
+++ b/app/controllers/filters/study_type_controller.rb
@@ -1,0 +1,20 @@
+module Filters
+  class StudyTypeController < ApplicationController
+    def new; end
+
+    def create
+      if !(filter_params[:fulltime] == "True" || filter_params[:parttime] == "True")
+        flash[:error] = "You must make at least one selection"
+        redirect_to studytype_path(filter_params)
+      else
+        redirect_to results_path(filter_params)
+      end
+    end
+
+  private
+
+    def filter_params
+      params.permit(:fulltime, :parttime)
+    end
+  end
+end

--- a/app/views/filters/study_type/new.html.erb
+++ b/app/views/filters/study_type/new.html.erb
@@ -1,0 +1,78 @@
+<%= content_for :page_title, "Filter by study type" %>
+<% content_for :before_content do %>
+  <a href="<%= results_path %>" class="govuk-back-link">Back to search results</a>
+<% end %>
+
+<% if flash[:error] %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#studytype-error"><%= flash[:error] %></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: studytype_path, method: :post do |form| %>
+      <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
+        <legend>
+          <h1 class="govuk-heading-xl">Study type</h1>
+        </legend>
+
+        <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">
+          <% if flash[:error] %>
+            <span id="studytype-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> You must make at least one selection
+            </span>
+          <% end %>
+          <div class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%=
+                form.check_box(
+                  :fulltime,
+                  { class: "govuk-checkboxes__input", data: { qa: 'full_time'}, checked: params[:fulltime] == "True" },
+                  "True",
+                  "False"
+                )
+              %>
+              <%= form.label :fulltime, class: "govuk-label govuk-checkboxes__label" do %>
+                <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">Full time (12 months)</span>
+                <span>
+                  You’ll usually spend 5 days a week on a full-time course.
+                </span>
+              <% end %>
+            </div>
+
+            <div class="govuk-checkboxes__item">
+              <%=
+                form.check_box(
+                  :parttime,
+                  { class: "govuk-checkboxes__input", data: { qa: 'part_time'}, checked: params[:parttime] == "True" },
+                  "True",
+                  "False"
+                )
+              %>
+              <%= form.label :parttime, class: "govuk-label govuk-checkboxes__label" do %>
+                <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">Part time (18 – 24 months)</span>
+                <span>
+                  You’ll usually spend 3 days a week on a part-time course.
+                </span>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,9 @@ Rails.application.routes.draw do
 
   get "/course/:provider_code/:course_code", to: "courses#show", as: "course"
   get "/results", to: "results#index", as: "results"
+
+  scope module: "filters", path: "/results/filter" do
+    get "studytype", to: "study_type#new"
+    post "studytype", to: "study_type#create"
+  end
 end

--- a/spec/features/results/filters/study_type_spec.rb
+++ b/spec/features/results/filters/study_type_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+feature "Study type filter", type: :feature do
+  let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:courses_request) do
+    fields = {
+      courses: %i[provider_code course_code name description funding_type provider accrediting_provider subjects],
+      providers: %i[provider_name address1 address2 address3 address4 postcode],
+    }
+
+    params = {
+      recruitment_cycle_year: Settings.current_cycle,
+      provider_code: nil,
+    }
+
+    pagination = { page: 1, per_page: 10 }
+
+    include = %i[provider accrediting_provider financial_incentive subjects]
+
+    stub_api_v3_resource(
+      type: Course,
+      resources: [],
+      params: params,
+      fields: fields,
+      include: include,
+      pagination: pagination,
+      links: {
+        last: api_v3_url(
+          type: Course,
+          params: params,
+          fields: fields,
+          include: include,
+          pagination: pagination,
+        ),
+      },
+    )
+  end
+
+  before { courses_request }
+
+  describe "Selecting an option" do
+    before { filter_page.load }
+
+    it "Allows the user to select full time" do
+      filter_page.full_time.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query_params(
+        page: results_page,
+        params: {
+          "fulltime" => "True",
+          "parttime" => "False",
+        },
+      )
+    end
+
+    it "Allows the user to select part time" do
+      filter_page.part_time.click
+      filter_page.find_courses.click
+      expect_page_to_be_displayed_with_query_params(
+        page: results_page,
+        params: {
+          "fulltime" => "False",
+          "parttime" => "True",
+        },
+      )
+    end
+
+    it "Allows the user to select both full and part time" do
+      filter_page.full_time.click
+      filter_page.part_time.click
+      filter_page.find_courses.click
+      expect_page_to_be_displayed_with_query_params(
+        page: results_page,
+        params: {
+          "fulltime" => "True",
+          "parttime" => "True",
+        },
+      )
+    end
+  end
+
+  describe "Navigating to the page with currently selected filters" do
+    it "Allows the full time param to be pre-selected" do
+      filter_page.load(query: { fulltime: "True" })
+      expect(filter_page.full_time.checked?).to eq(true)
+    end
+
+    it "Allows the part time param to be pre-selected" do
+      filter_page.load(query: { parttime: "True" })
+      expect(filter_page.part_time.checked?).to eq(true)
+    end
+  end
+
+  describe "Validation" do
+    it "Displays an error if neither option is selected" do
+      filter_page.load
+      filter_page.find_courses.click
+
+      expect(filter_page).to have_error
+    end
+  end
+
+private
+
+  def expect_page_to_be_displayed_with_query_params(page:, params:)
+    expect(page).to be_displayed
+
+    query_params = page.url_matches["query"]
+    params.each do |param_name, param_value|
+      expect(query_params[param_name]).to eq(param_value)
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/result_filters/study_type.rb
+++ b/spec/site_prism/page_objects/page/result_filters/study_type.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class StudyType < SitePrism::Page
+        set_url "/results/filter/studytype{?query*}"
+
+        element :error, '[data-qa="error"]'
+        element :full_time, '[data-qa="full_time"]'
+        element :part_time, '[data-qa="part_time"]'
+        element :find_courses, '[data-qa="find_courses"]'
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -10,6 +10,8 @@ module PageObjects
     end
 
     class Results < SitePrism::Page
+      set_url "/results{?query*}"
+
       sections :courses, CourseSection, '[data-qa="course"]'
 
       element :next_button, '[data-qa="next_button"]'


### PR DESCRIPTION
![study-type-filters](https://user-images.githubusercontent.com/976254/72450661-ab8be580-37b2-11ea-829b-1c39894444f1.gif)

### Context

We need to mirror the study type filter page on the C# application

### Changes proposed in this pull request
- Add a new study type filter page
- Add error handling to filter page

### Guidance to review

