### PR TITLE
[2345] Build salary filter page

### DIFF
--- a/app/controllers/filters/funding_controller.rb
+++ b/app/controllers/filters/funding_controller.rb
@@ -1,0 +1,9 @@
+module Filters
+  class FundingController < ApplicationController
+    def new; end
+
+    def create
+      redirect_to results_path(funding: params[:funding])
+    end
+  end
+end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,6 @@
 class ResultsController < ApplicationController
+  before_action :redirect_to_c_sharp
+
   def index
     @courses = Course
       .includes(:provider)
@@ -26,5 +28,20 @@ class ResultsController < ApplicationController
           address4
           postcode
         ]).all
+  end
+
+private
+
+  def redirect_to_c_sharp
+    return unless Settings.redirect_results_to_c_sharp
+
+    query_string = request.query_string
+    base_url = Settings.search_and_compare_ui.base_url
+
+    redirect_uri = URI(base_url)
+    redirect_uri.path = "/results"
+    redirect_uri.query = query_string if query_string.present?
+
+    redirect_to redirect_uri.to_s
   end
 end

--- a/app/views/filters/funding/new.html.erb
+++ b/app/views/filters/funding/new.html.erb
@@ -1,0 +1,42 @@
+<%= content_for :page_title, "Find courses that pay a salary" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(results_path) %>
+<% end %>
+
+<div class="govuk-width-container">
+  <h1 class="govuk-heading-xl">Find courses that pay a salary</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <p class="govuk-body">
+        On a salaried course you’ll be paid and taxed as an unqualified teacher. The salary awarded will differ between schools – you should check the salary with the school before you apply.
+      </p>
+      <p class="govuk-body">
+        Salaried courses are not eligible for bursaries, scholarships or student finance. There are usually no course fees to pay.
+      </p>
+      <%= form_with url: funding_path do |form| %>
+        <div class="govuk-radios" data-module="govuk-radios">
+          <div class="govuk-radios__item">
+            <%= form.radio_button :funding,
+                                  '15',
+                                  class: 'govuk-radios__input',
+                                  checked: params[:funding] == '15' || params[:funding].blank?,
+                                  data: { qa: 'all_courses'} %>
+
+            <%= form.label :all_courses, "All courses (with or without a salary)", class: 'govuk-label govuk-radios__label' %>
+          </div>
+          <div class="govuk-radios__item">
+            <%= form.radio_button :funding,
+                                  '8',
+                                  class: 'govuk-radios__input',
+                                  checked: params[:funding] == '8',
+                                  data: { qa: 'salary_courses'} %>
+
+            <%= form.label :salary_courses, "Only courses that come with a salary", class: 'govuk-label govuk-radios__label' %>
+          </div>
+        </div>
+        <br>
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,9 @@ Rails.application.routes.draw do
   scope module: "filters", path: "/results/filter" do
     get "studytype", to: "study_type#new"
     post "studytype", to: "study_type#create"
-
     get "vacancy", to: "vacancy#new"
     post "vacancy", to: "vacancy#create"
+    get "funding", to: "funding#new"
+    post "funding", to: "funding#create"
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,3 +8,4 @@ service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 search_and_compare_ui:
   base_url: http://localhost:5000
+redirect_results_to_c_sharp: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,2 +1,3 @@
 manage_backend:
   base_url: http://localhost:3001
+redirect_results_to_c_sharp: false

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -5,6 +5,10 @@ feature "Search results", type: :feature do
     build(:site_status, study_mode, site: build(:site, location_name: name), status: status)
   end
 
+  before do
+    allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(false)
+  end
+
   let(:provider) do
     build(:provider,
           provider_name: "ACME SCITT A0",

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+feature "Funding filter", type: :feature do
+  let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+
+  let(:salary_course_param_value_from_c_sharp) { "8" }
+  let(:all_course_param_value_from_c_sharp) { "15" }
+
+  describe "funding page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Find courses that pay a salary")
+      expect(page).to have_content("Find courses that pay a salary")
+    end
+
+    describe "back link" do
+      before do
+        stub_results_page_request
+      end
+
+      it "navigates back to the results page" do
+        filter_page.back_link.click
+        expect(results_page).to be_displayed
+      end
+    end
+
+    describe "selecting an option" do
+      before do
+        stub_results_page_request
+      end
+
+      let(:qs_params) { "one=two" }
+
+      it "allows the user to select all courses" do
+        filter_page.all_courses.click
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: { "funding" => all_course_param_value_from_c_sharp },
+        )
+      end
+
+      it "allows the user to select salary courses" do
+        filter_page.salary_courses.click
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: { "funding" => salary_course_param_value_from_c_sharp },
+        )
+      end
+    end
+
+    describe "Pre populated value" do
+      context "with no salary_filter parameter" do
+        it "the all_courses button is selected by default" do
+          expect(filter_page.all_courses).to be_checked
+          expect(filter_page.salary_courses).not_to be_checked
+        end
+      end
+
+      context "with the salary filter set to salary courses only" do
+        before { filter_page.load(query: { "funding" => salary_course_param_value_from_c_sharp }) }
+
+        it "the salary_course button is selected" do
+          expect(filter_page.salary_courses).to be_checked
+          expect(filter_page.all_courses).not_to be_checked
+        end
+      end
+
+      context "with the salary filter set to all courses" do
+        before { filter_page.load(query: { "funding" => all_course_param_value_from_c_sharp }) }
+
+        it "the salary_course button is selected" do
+          expect(filter_page.salary_courses).not_to be_checked
+          expect(filter_page.all_courses).to be_checked
+        end
+      end
+    end
+  end
+
+private
+
+  def expect_page_to_be_displayed_with_query(page:, expected_query_params:)
+    current_query_string = current_url.match('\?(.*)$')&.captures&.first
+    expect(page).to be_displayed
+    expect(Rack::Utils.parse_nested_query(current_query_string)).to eq(expected_query_params)
+  end
+end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "/results", type: :request do
+  before do
+    allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(true)
+  end
+
+  it "redirects to c sharp version" do
+    get "/results"
+    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results")
+  end
+
+  it "forwards querystring params" do
+    get "/results?test=one&test_two=%26booyah"
+    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=%26booyah")
+  end
+end

--- a/spec/site_prism/page_objects/page/result_filters/funding.rb
+++ b/spec/site_prism/page_objects/page/result_filters/funding.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class Funding < SitePrism::Page
+        set_url "/results/filter/funding{?query*}"
+
+        element :back_link, '[data-qa="page-back"]'
+        element :all_courses, '[data-qa="all_courses"]'
+        element :salary_courses, '[data-qa="salary_courses"]'
+        element :find_courses, '[data-qa="find_courses"]'
+      end
+    end
+  end
+end

--- a/spec/support/stub_results_page.rb
+++ b/spec/support/stub_results_page.rb
@@ -1,0 +1,55 @@
+def stub_results_page_request
+  current_recruitment_cycle = build(:recruitment_cycle)
+
+  provider = build(
+    :provider,
+    provider_name: "ACME SCITT A0",
+    provider_code: "T92",
+    website: "https://scitt.org",
+    address1: "1 Long Rd",
+    postcode: "E1 ABC",
+  )
+
+  courses = [
+    build(
+      :course,
+      name: "Primary",
+      course_code: "X130",
+      provider: provider,
+      provider_code: provider.provider_code,
+      recruitment_cycle: current_recruitment_cycle,
+    ),
+  ]
+
+  fields = {
+    courses: %i[provider_code course_code name description funding_type provider accrediting_provider subjects],
+    providers: %i[provider_name address1 address2 address3 address4 postcode],
+  }
+
+  params = {
+    recruitment_cycle_year: Settings.current_cycle,
+    provider_code: nil,
+  }
+
+  pagination = { page: 1, per_page: 10 }
+
+  include = %i[provider accrediting_provider financial_incentive subjects]
+
+  stub_api_v3_resource(
+    type: Course,
+    resources: courses,
+    params: params,
+    fields: fields,
+    include: include,
+    pagination: pagination,
+    links: {
+      last: api_v3_url(
+        type: Course,
+        params: params,
+        fields: fields,
+        include: include,
+        pagination: pagination,
+      ),
+    },
+  )
+end


### PR DESCRIPTION
### Context

A user needs to be able to filter courses based on whether they offer a salary or not.

This card implements the salary filter page. 
Passing on additional params is out of scope for this card.

### Changes proposed in this pull request
- Redirect results page to C# in all environments except test
- Disable the redirect in the results page feature spec
- Add salary filter page


