### PR TITLE
Send all applicants to Apply

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -1,10 +1,4 @@
 class Provider < Base
   belongs_to :recruitment_cycle, param: :recruitment_cycle_year
   has_many :courses, param: :course_code
-
-  def supporting_dfe_apply?
-    opted_in_providers = %w[R55 1N1 S31 24L 1HQ L06 2LR 254 12K 1OT N83 2B2 255 2ET T25 1OS S17 C76 2DB M82 2B5 2GU 1ZN]
-
-    opted_in_providers.include?(provider_code)
-  end
 end

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -6,35 +6,12 @@
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
 
   <% if course.has_vacancies? %>
-    <% if course.provider.supporting_dfe_apply? %>
-      <p class="govuk-body">
-        <%= link_to "Apply for this course", "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}", class: "govuk-button govuk-button--start" %>
-      </p>
-    <% else %>
-      <p class="govuk-body">
-        <%= link_to 'Apply on the UCAS website', 'https://2020.teachertraining.apply.ucas.com/apply/student/login.do', class: 'govuk-link' %>. You’ll need to register with UCAS before you can apply.
-      </p>
-      <p class="govuk-body">
-        Visit Get into Teaching for <%= link_to 'guidance on applying for teacher training', 'https://getintoteaching.education.gov.uk/how-to-apply/apply', class: 'govuk-link' %>.
-      </p>
-
-      <p class="govuk-body">
-        When you apply you’ll need these codes for the Choices section of your application form:
-      </p>
-      <div class="govuk-inset-text">
-        <ul class="govuk-list">
-          <li class="govuk-!-margin-bottom-2">
-            Training provider code:
-            <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.provider.provider_code %></span>
-          </li>
-          <li>
-            Training programme code:
-            <span class="govuk-!-display-block govuk-!-font-size-36 govuk-!-font-weight-bold"><%= course.course_code %></span>
-          </li>
-        </ul>
-      </div>
-
-    <% end %>
+    <p class="govuk-body">
+      <%= link_to "Apply for this course",
+                  "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}",
+                  class: "govuk-button govuk-button--start",
+                  data: { qa: 'course__apply_link' } %>
+    </p>
 
     <h3 class="govuk-heading-m">Choose a training location</h3>
     <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -229,6 +229,12 @@ feature "Course show", type: :feature do
       expect(course_page).to have_locations_map
 
       expect(course_page).to have_course_advice
+
+      expect(course_page.apply_link.text).to eq("Apply for this course")
+
+      expect(course_page.apply_link[:href]).to eq("https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
+
+      expect(course_page).not_to have_content("When you apply you’ll need these codes for the Choices section of your application form")
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -1,13 +1,2 @@
 describe Provider do
-  context "#supporting_dfe_apply?" do
-    it "is an opted-in provider" do
-      provider = build(:provider, provider_code: "R55")
-      expect(provider.supporting_dfe_apply?).to eq(true)
-    end
-
-    it "is not an opted-in provider" do
-      provider = build(:provider, provider_code: "122")
-      expect(provider.supporting_dfe_apply?).to eq(false)
-    end
-  end
 end

--- a/spec/site_prism/page_objects/page/course.rb
+++ b/spec/site_prism/page_objects/page/course.rb
@@ -42,6 +42,7 @@ module PageObjects
       element :course_apply, "#section-apply"
       element :choose_a_training_location_table, "[data-qa=course__choose_a_training_location]"
       element :locations_map, "[data-qa=course__locations_map]"
+      element :apply_link, "a[data-qa=course__apply_link]"
     end
   end
 end


### PR DESCRIPTION
### Context
Apply now has logic in place to direct the appropriate users to
the UCAS Apply service.

### Changes proposed in this pull request

-  All users should now see the big green apply button which directs them to the Apply service

### Guidance

**Do not merge as the implementation has not been deployed on Apply yet**
