### PR TITLE
add missing properties to course model

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,15 +1,35 @@
 class Course < Base
+  belongs_to :accrediting_provider, through: :accrediting_provider_code
   belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
   belongs_to :provider, param: :provider_code
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
   has_many :subjects
 
+  property :about_course, type: :string
+  property :about_accrediting_body, type: :string
+  property :applications_open_from, type: :timestamp
+  property :course_code, type: :string
+  property :course_length, type: :string
+  property :description, type: :string
+  property :english, type: :string
+  property :fee_details, type: :string
   property :fee_international, type: :string
   property :fee_uk_eu, type: :string
+  property :financial_support, type: :string
+  property :funding_type, type: :string
+  property :has_vacancies?, type: :boolean
+  property :how_school_placements_work, type: :string
+  property :interview_process, type: :string
   property :maths, type: :string
-  property :english, type: :string
+  property :name, type: :string
+  property :other_requirements, type: :string
+  property :personal_qualities, type: :string
+  property :provider_code, type: :string
+  property :qualification, type: :string
+  property :required_qualifications, type: :string
   property :science, type: :string
+  property :start_date, type: :timestamp
 
   self.primary_key = :course_code
 


### PR DESCRIPTION
### Context

As stated in the JsonApiClient docs, defining the schema for a model is
optional. However, it helps us understand what properties are available, and I
had to do this as part of the investigation into how API v3 is being used, so I
thought it may be worth adding.

https://github.com/JsonApiClient/json_api_client#schema

### Changes proposed in this pull request

Add a bunch of properties to the `Course` model. These are already being used throughout the app. Also, alphabetise them.

### Guidance to review

Tests pass, so this should be fine, right??! I did have to guess at the types for these, but they seemed sensible (to me).
