### PR TITLE
Update filter params

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -2,6 +2,18 @@ module FilterParameters
 private
 
   def filter_params
-    request.request_parameters.reject { |param| param == "utf8" }
+    custom_params = request.request_parameters.reject do |param|
+      param == "utf8"
+    end
+
+    custom_params_with_formatted_arrays = custom_params.to_h do |key, value|
+      if value.is_a? Array
+        [key, value.join(",")]
+      else
+        [key, value]
+      end
+    end
+
+    custom_params_with_formatted_arrays.with_indifferent_access
   end
 end

--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -1,6 +1,4 @@
 module FilterParameters
-private
-
   def filter_params
     custom_params = request.request_parameters.reject do |param|
       param == "utf8"

--- a/app/views/result_filters/_hidden_fields.html.erb
+++ b/app/views/result_filters/_hidden_fields.html.erb
@@ -1,4 +1,4 @@
-<% request.query_parameters.each do |field_name, field_value| %>
+<% request.query_parameters.reject { |key, _value| key.in?(exclude_keys) }.each do |field_name, field_value| %>
   <% if field_value.is_a?(Array) %>
     <% field_value.each do |array_value| %>
       <%= form.hidden_field(field_name, multiple: true, value: array_value) %>

--- a/app/views/result_filters/funding/new.html.erb
+++ b/app/views/result_filters/funding/new.html.erb
@@ -14,7 +14,7 @@
         Salaried courses are not eligible for bursaries, scholarships or student finance. There are usually no course fees to pay.
       </p>
       <%= form_with url: funding_path do |form| %>
-        <%= render 'result_filters/hidden_fields', form: form %>
+        <%= render 'result_filters/hidden_fields', exclude_keys: ["funding"], form: form %>
         <div class="govuk-radios" data-module="govuk-radios">
           <div class="govuk-radios__item">
             <%= form.radio_button :funding,

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -21,7 +21,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: studytype_path, method: :post do |form| %>
-      <%= render 'result_filters/hidden_fields', form: form %>
+      <%= render 'result_filters/hidden_fields', exclude_keys: ["fulltime", "parttime"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend>
           <h1 class="govuk-heading-xl">Study type</h1>

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: vacancy_path, method: :post do |form| %>
-      <%= render 'result_filters/hidden_fields', form: form %>
+      <%= render 'result_filters/hidden_fields', exclude_keys: ["hasvacancies"], form: form %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by vacancies</h1>
@@ -49,4 +49,3 @@
     <% end %>
   </div>
 </div>
-

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -106,7 +106,7 @@ feature "Funding filter", type: :feature do
       end
 
       it "passes arrays correctly" do
-        url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+        url_with_array_params = "#{filter_page.url}?test=1,2"
         PageObjects::Page::ResultFilters::Funding.set_url(url_with_array_params)
 
         filter_page.load
@@ -119,7 +119,7 @@ feature "Funding filter", type: :feature do
           page: results_page,
           expected_query_params: {
             "funding" => all_course_param_value_from_c_sharp,
-            "test" => %w(1 2),
+            "test" => "1,2",
           },
         )
       end

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -114,7 +114,7 @@ feature "Study type filter", type: :feature do
         expected_query_params: {
           "fulltime" => "False",
           "parttime" => "True",
-          "test" => %w(1 2),
+          "test" => "1,2",
         },
       )
     end

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -95,7 +95,7 @@ feature "Vacancy filter", type: :feature do
         page: results_page,
         expected_query_params: {
           "hasvacancies" => "True",
-          "test" => %w(1 2),
+          "test" => "1,2",
         },
       )
     end


### PR DESCRIPTION
### Context

Filter pages have some common functionality. They need to pass parameters they receive to the results page. These parameters have been formatted in the C# version of the app and must match. The current implementation of this functionality has a couple of issues.

* It doesn't support comma separated array parameters
* It doesn't exclude the parameters that are added by the filter page itself from the hidden fields which results in duplicate fields.

### Changes proposed in this pull request

* Add an `exclude` feature to the hidden fields partial to allow the page to filter out the parameters it is adding itself
* Add support for parsing arrays into comma separated strings into the `FilterParameters` concern.

### Guidance to review

