### PR TITLE
2344 add qualifications filter

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -1,7 +1,7 @@
 module FilterParameters
   def filter_params
     custom_params = request.request_parameters.reject do |param|
-      param == "utf8"
+      param.in? %w(utf8 authenticity_token)
     end
 
     custom_params_with_formatted_arrays = custom_params.to_h do |key, value|

--- a/app/controllers/result_filters/qualification_controller.rb
+++ b/app/controllers/result_filters/qualification_controller.rb
@@ -1,0 +1,24 @@
+module ResultFilters
+  class QualificationController < ApplicationController
+    include FilterParameters
+
+    before_action :create_view
+
+    def new; end
+
+    def create
+      if @view.qualification_selected?
+        redirect_to results_path(filter_params)
+      else
+        flash[:error] = "Please choose at least one qualification"
+        redirect_to qualification_path(filter_params.merge(qualifications: "none"))
+      end
+    end
+
+  private
+
+    def create_view
+      @view = ResultFilters::QualificationView.new(params: params)
+    end
+  end
+end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -40,7 +40,7 @@ private
 
     redirect_uri = URI(base_url)
     redirect_uri.path = "/results"
-    redirect_uri.query = query_string if query_string.present?
+    redirect_uri.query = query_string.gsub("%2C", ",") if query_string.present?
 
     redirect_to redirect_uri.to_s
   end

--- a/app/view_objects/result_filters/qualification_view.rb
+++ b/app/view_objects/result_filters/qualification_view.rb
@@ -1,0 +1,35 @@
+module ResultFilters
+  class QualificationView
+    def initialize(params:)
+      @qualifications_parameter = params[:qualifications]
+    end
+
+    def qts_only_checked?
+      checked?("QtsOnly")
+    end
+
+    def pgde_pgce_with_qts_checked?
+      checked?("PgdePgceWithQts")
+    end
+
+    def other_checked?
+      checked?("Other")
+    end
+
+    def qualification_selected?
+      parameter_array.any?
+    end
+
+  private
+
+    attr_reader :qualifications_parameter
+
+    def parameter_array
+      qualifications_parameter.present? ? qualifications_parameter.split(",") : []
+    end
+
+    def checked?(param_value)
+      parameter_array.empty? || parameter_array.include?(param_value)
+    end
+  end
+end

--- a/app/views/result_filters/_error_message.html.erb
+++ b/app/views/result_filters/_error_message.html.erb
@@ -1,0 +1,14 @@
+<% if flash[:error] %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      You’ll need to correct some information.
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#<%=error_anchor_id%>"><%= flash[:error] %></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -1,0 +1,107 @@
+<%= content_for :page_title, "Filter by qualification" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "result_filters/error_message", locals: { error_anchor_id: "qualification-error" } %>
+
+    <%= form_with url: qualification_path, method: :post do |form| %>
+      <%= render 'result_filters/hidden_fields', exclude_keys: ["qualifications"], form: form %>
+      <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
+        <legend>
+          <h1 class="govuk-heading-xl">What you will get</h1>
+        </legend>
+
+        <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">
+          <% if flash[:error] %>
+            <span id="qualification-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> You must make at least one selection
+            </span>
+          <% end %>
+          <div class="govuk-checkboxes">
+            <div class="govuk-checkboxes__item">
+              <%=
+                form.check_box(
+                  :qualifications,
+                  { 
+                    class: "govuk-checkboxes__input", 
+                    multiple: true, 
+                    data: { qa: 'qts_only' }, 
+                    checked: @view.qts_only_checked? 
+                  },
+                  "QtsOnly", 
+                  false
+                )
+              %>
+              <%= form.label :qualifications, value: "QtsOnly", class: "govuk-label govuk-checkboxes__label" do %>
+                <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">QTS only</span>
+                <p class="govuk-body">
+                  QTS (qualified teacher status) allows you to teach in state schools in England.
+                </p>
+                <p class="govuk-body">
+                  It may also allow you to teach in <%= link_to "the EU, the EEA and Switzerland", "https://www.gov.uk/eu-eea", class: "govuk-link" %>. You should check with the institution you’d like to teach in for confirmation. The status of QTS in these countries may change after the UK leaves the EU. Please check <%= link_to "GOV.UK", "https://www.gov.uk", class: "govuk-link" %> for updates.
+                </p>
+                <p class="govuk-body">
+                  To teach in the rest of the UK or internationally, you may wish to consider a ‘PGCE (or PGDE) with QTS’ qualification instead.
+                </p>
+              <% end %>
+            </div>
+
+            <div class="govuk-checkboxes__item">
+              <%=
+                form.check_box(
+                  :qualifications,
+                  { 
+                    class: "govuk-checkboxes__input", 
+                    multiple: true, 
+                    data: { qa: 'pgde_pgce_with_qts'}, 
+                    checked: @view.pgde_pgce_with_qts_checked?,
+                  },
+                  "PgdePgceWithQts", 
+                  false
+                )
+              %>
+              <%= form.label :qualifications, value: "PgdePgceWithQts", class: "govuk-label govuk-checkboxes__label" do %>
+                <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">PGCE (or PGDE) with QTS</span>
+                <p class="govuk-body">
+                  A PGCE (postgraduate certificate in education) with QTS allows you to teach in England, Scotland, Wales and Northern Ireland. It’s also recognised internationally. Many PGCE courses include credits that count towards a Master’s degree.
+                </p>
+                <p class="govuk-body">
+                  Some providers offer a PGDE (postgraduate diploma in education) with QTS, which is equivalent to a PGCE. In some cases these courses offer more credits towards a Master’s degree than PGCE courses.
+                </p>
+              <% end %>
+            </div>
+
+            <div class="govuk-checkboxes__item">
+              <%=
+                form.check_box(
+                  :qualifications,
+                  { 
+                    class: "govuk-checkboxes__input",
+                    multiple: true,
+                    data: { qa: 'other'},
+                    checked: @view.other_checked?
+                  },
+                  "Other", 
+                  false
+                )
+              %>
+              <%= form.label :qualifications, value: "Other", class: "govuk-label govuk-checkboxes__label" do %>
+                <span class="govuk-!-font-weight-bold govuk-!-margin-bottom-2 govuk-!-display-block">Further education (PGCE or PGDE without QTS)</span>
+                <p class="govuk-body">
+                  To teach further education you don’t need QTS. Instead you can study for a PGCE or PGDE without QTS.
+                </p>
+              <% end %>
+            </div>
+          </div>
+        </div>
+      </fieldset>
+
+      <div class="govuk-form-group">
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,10 @@ variables:
 
 steps:
 - script: |
+    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
+    set +x
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(Build.SourceVersionMessage)'> $(build.artifactstagingdirectory)/merge.info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,7 @@ Rails.application.routes.draw do
     post "vacancy", to: "vacancy#create"
     get "funding", to: "funding#new"
     post "funding", to: "funding#create"
+    get "qualification", to: "qualification#new"
+    post "qualification", to: "qualification#create"
   end
 end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -1,0 +1,110 @@
+require "rails_helper"
+
+feature "Qualifications filter", type: :feature do
+  let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+
+  describe "qualification page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Filter by qualification")
+      expect(page).to have_content("What you will get")
+    end
+
+    describe "back link" do
+      before do
+        stub_results_page_request
+      end
+
+      it "navigates back to the results page" do
+        filter_page.load(query: { test: "params" })
+        filter_page.back_link.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: { "test" => "params" },
+        )
+      end
+    end
+
+    describe "de-selecting an option" do
+      before do
+        stub_results_page_request
+      end
+
+      it "it removes the option from the parameters" do
+        filter_page.qts_only.click
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "qualifications" => "PgdePgceWithQts,Other",
+          },
+        )
+      end
+    end
+
+    describe "pre-populating values" do
+      context "with no qualifications parameters" do
+        it "checks all boxes" do
+          expect(filter_page.qts_only).to be_checked
+          expect(filter_page.pgde_pgce_with_qts).to be_checked
+          expect(filter_page.other).to be_checked
+        end
+      end
+    end
+
+    describe "validation" do
+      context "when no qualification is selected" do
+        it "shows an error message" do
+          filter_page.qts_only.click
+          filter_page.pgde_pgce_with_qts.click
+          filter_page.other.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_error
+          expect(filter_page.qts_only).not_to be_checked
+          expect(filter_page.pgde_pgce_with_qts).not_to be_checked
+          expect(filter_page.other).not_to be_checked
+        end
+      end
+    end
+
+    describe "QS parameters" do
+      before do
+        stub_results_page_request
+      end
+
+      it "passes querystring parameters to results" do
+        filter_page.load(query: { test: "value" })
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "test" => "value",
+          },
+        )
+      end
+
+      it "passes arrays correctly" do
+        url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+        PageObjects::Page::ResultFilters::Qualification.set_url(url_with_array_params)
+
+        filter_page.load
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "test" => "1,2",
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -14,4 +14,9 @@ RSpec.describe "/results", type: :request do
     get "/results?test=one&test_two=%26booyah"
     expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=%26booyah")
   end
+
+  it "decodes querystring commas" do
+    get "/results?test=one&test_two=booyah%2Ckasha"
+    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=booyah,kasha")
+  end
 end

--- a/spec/site_prism/page_objects/page/result_filters/qualification.rb
+++ b/spec/site_prism/page_objects/page/result_filters/qualification.rb
@@ -1,0 +1,16 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class Qualification < SitePrism::Page
+        set_url "/results/filter/qualification{?query*}"
+
+        element :back_link, '[data-qa="page-back"]'
+        element :error, '[data-qa="error"]'
+        element :qts_only, '[data-qa="qts_only"]'
+        element :pgde_pgce_with_qts, '[data-qa="pgde_pgce_with_qts"]'
+        element :other, '[data-qa="other"]'
+        element :find_courses, '[data-qa="find_courses"]'
+      end
+    end
+  end
+end

--- a/spec/view_objects/result_filters/qualification_view_spec.rb
+++ b/spec/view_objects/result_filters/qualification_view_spec.rb
@@ -1,0 +1,100 @@
+require_relative "../../../app/view_objects/result_filters/qualification_view"
+
+module ResultFilters
+  RSpec.describe QualificationView do
+    describe "qts_only_checked?" do
+      subject { described_class.new(params: params).qts_only_checked? }
+
+      context "when QtsOnly param not present" do
+        let(:params) { { qualifications: "Other,PgdePgceWithQts" } }
+        it { is_expected.to eq(false) }
+      end
+
+      context "when QtsOnly param is present" do
+        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is empty" do
+        let(:params) { { qualifications: "" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is not in the parameters" do
+        let(:params) { {} }
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    describe "pgde_pgce_with_qts_checked" do
+      subject { described_class.new(params: params).pgde_pgce_with_qts_checked? }
+
+      context "when PgdePgceWithQts param not present" do
+        let(:params) { { qualifications: "Other,QtsOnly" } }
+        it { is_expected.to eq(false) }
+      end
+
+      context "when PgdePgceWithQts param is present" do
+        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is empty" do
+        let(:params) { { qualifications: "" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is nil" do
+        let(:params) { {} }
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    describe "pgde_pgce_with_qts_checked" do
+      subject { described_class.new(params: params).other_checked? }
+
+      context "when Other param not present" do
+        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        it { is_expected.to eq(false) }
+      end
+
+      context "when Other param is present" do
+        let(:params) { { qualifications: "QtsOnly,Other" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is empty" do
+        let(:params) { { qualifications: "" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when qualifications is nil" do
+        let(:params) { {} }
+        it { is_expected.to eq(true) }
+      end
+    end
+
+    describe "qualification_selected?" do
+      subject { described_class.new(params: params).qualification_selected? }
+      context "when a parameter is selected" do
+        let(:params) { { qualifications: "Other" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when multiple parameters are selected" do
+        let(:params) { { qualifications: "Other,QtsOnly" } }
+        it { is_expected.to eq(true) }
+      end
+
+      context "when no parameter is selected" do
+        let(:params) { { qualifications: "" } }
+        it { is_expected.to eq(false) }
+      end
+
+      context "when qualifications is nil" do
+        let(:params) { {} }
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Part of the rebuild find epic. This adds the qualification filter page.

### Changes proposed in this pull request

* Add `/results/filter/qualification`
* Add a view object for qualification to handle the checkbox state logic and parameters
* Update `FilterParams` to strip `authenticity_token`. This hasn't come up in the tests as it doesn't seem to be passed by I spotted it when running the app.
* Update azure-pipelines.yml with some magic from @rizzkhan1 as CI was failing this PR.

### Guidance to review

The view object `ResultFilters::QualificationView` is a new pattern for the app. I've added it as it is cleaner and allows us to test the logic that would otherwise be in the view template. This reduces the number of feature specs we need to write to test all scenarios. Performance isn't an issue with the test suite here yet but I think reducing dependence on slow feature tests and replacing with unit tests where appropriate would help to keep it that way.