### PR TITLE
[2340] Location filter (Across england)

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -1,0 +1,13 @@
+module ResultFilters
+  class LocationController < ApplicationController
+    include FilterParameters
+
+    def new; end
+
+    def create
+      params_without_unsupported_location_params = filter_params.except(:lat, :lng, :rad, :query, :loc, :lq)
+
+      redirect_to results_path(params_without_unsupported_location_params)
+    end
+  end
+end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -5,9 +5,18 @@ module ResultFilters
     def new; end
 
     def create
-      params_without_unsupported_location_params = filter_params.except(:lat, :lng, :rad, :query, :loc, :lq)
+      if(!params[:l])
+        flash[:error] = "Please choose an option"
+        redirect_to location_path(params_without_unsupported_location_params)
+      else
+        redirect_to results_path(params_without_unsupported_location_params)
+      end
+    end
 
-      redirect_to results_path(params_without_unsupported_location_params)
+  private
+
+    def params_without_unsupported_location_params
+      filter_params.except(:lat, :lng, :rad, :query, :loc, :lq)
     end
   end
 end

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -3,6 +3,21 @@
   <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
 <% end %>
 
+<% if flash[:error] %>
+  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
+    <h2 class="govuk-error-summary__title" id="error-summary-title">
+      There is a problem
+    </h2>
+    <div class="govuk-error-summary__body">
+      <ul class="govuk-list govuk-error-summary__list">
+        <li>
+          <a href="#studytype-error"><%= flash[:error] %></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: location_path, method: :post do |form| %>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -1,0 +1,38 @@
+<%= content_for :page_title, "Find courses by location or by training provider" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: location_path, method: :post do |form| %>
+      <%= render 'result_filters/hidden_fields', exclude_keys: ["l"], form: form %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
+        </legend>
+
+        <div class="govuk-form-group">
+          <div class="govuk-radios">
+            <div class="govuk-radios__item">
+              <%=
+                form.radio_button(
+                  :l,
+                  "2",
+                  class: "govuk-radios__input",
+                  data: { qa: "across_england" },
+                  checked: params[:l] == "2"
+                )
+              %>
+              <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
+            </div>
+          </div>
+        </div>
+
+        <div class="govuk-form-group">
+          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+        </div>
+      </fieldset>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,10 +16,15 @@ Rails.application.routes.draw do
   get "/results", to: "results#index", as: "results"
 
   scope module: "result_filters", path: "/results/filter" do
+    get "location", to: "location#new"
+    post "location", to: "location#create"
+
     get "studytype", to: "study_type#new"
     post "studytype", to: "study_type#create"
+
     get "vacancy", to: "vacancy#new"
     post "vacancy", to: "vacancy#create"
+
     get "funding", to: "funding#new"
     post "funding", to: "funding#create"
   end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+feature "Location filter", type: :feature do
+  let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+
+  before do
+    stub_results_page_request
+  end
+
+  describe "back link" do
+    it "navigates back to the results page" do
+      filter_page.load(query: { test: "params" })
+      filter_page.back_link.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: { "test" => "params" },
+      )
+    end
+  end
+
+  describe "Selecting an option" do
+    before { filter_page.load }
+
+    it "Allows the user to select across england" do
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+  end
+
+  describe "Navigating to the page with currently selected filters" do
+    it "Preselects across england" do
+      filter_page.load(query: { l: 2 })
+      expect(filter_page.across_england.checked?).to eq(true)
+    end
+
+    it "Removes the lat filter" do
+      filter_page.load(query: { lat: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+
+    it "Removes the lng filter" do
+      filter_page.load(query: { lng: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+
+    it "Removes the rad filter" do
+      filter_page.load(query: { rad: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+
+    it "Removes the query filter" do
+      filter_page.load(query: { query: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+
+    it "Removes the loc filter" do
+      filter_page.load(query: { loc: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+
+    it "Removes the lq filter" do
+      filter_page.load(query: { lq: "yes" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+        },
+      )
+    end
+  end
+
+  describe "QS parameters" do
+    it "passes querystring parameters to results" do
+      filter_page.load(query: { test: "value" })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+          "test" => "value",
+        },
+      )
+    end
+
+    it "passes arrays correctly" do
+      url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+      PageObjects::Page::ResultFilters::Location.set_url(url_with_array_params)
+
+      filter_page.load
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect(results_page).to be_displayed
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+          "test" => "1,2",
+        },
+      )
+    end
+  end
+end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -121,6 +121,15 @@ feature "Location filter", type: :feature do
     end
   end
 
+  describe "Validation" do
+    it "Displays an error if no option is selected" do
+      filter_page.load
+      filter_page.find_courses.click
+
+      expect(filter_page).to have_error
+    end
+  end
+
   describe "QS parameters" do
     it "passes querystring parameters to results" do
       filter_page.load(query: { test: "value" })

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class Location < SitePrism::Page
+        set_url "/results/filter/location{?query*}"
+
+        element :back_link, '[data-qa="page-back"]'
+        element :error, '[data-qa="error"]'
+        element :across_england, '[data-qa="across_england"]'
+        element :find_courses, '[data-qa="find_courses"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

In order to rewrite find we need to recreate the existing [locations filter](https://find-postgraduate-teacher-training.education.gov.uk/results/filter/location)

As the other two filters require additional support, this PR is only for the easiest option (Across England).

### Changes proposed in this pull request

- Add the location filter page
- Add support for the parameter `l`
- Remove unsupported parameters 
- Display an error when no option is selected