### PR TITLE
Make filter error messages consistent

### DIFF
--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -3,23 +3,9 @@
   <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
 <% end %>
 
-<% if flash[:error] %>
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
-    </h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <li>
-          <a href="#studytype-error"><%= flash[:error] %></a>
-        </li>
-      </ul>
-    </div>
-  </div>
-<% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "result_filters/error_message", locals: { error_anchor_id: "location-error" }%>
     <%= form_with url: location_path, method: :post do |form| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["l"], form: form %>
       <fieldset class="govuk-fieldset">
@@ -28,6 +14,11 @@
         </legend>
 
         <div class="govuk-form-group">
+          <% if flash[:error] %>
+            <span id="location-error" class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error:</span> Please choose an option
+            </span>
+          <% end %>
           <div class="govuk-radios">
             <div class="govuk-radios__item">
               <%=

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -3,23 +3,10 @@
   <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
 <% end %>
 
-<% if flash[:error] %>
-  <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
-      There is a problem
-    </h2>
-    <div class="govuk-error-summary__body">
-      <ul class="govuk-list govuk-error-summary__list">
-        <li>
-          <a href="#studytype-error"><%= flash[:error] %></a>
-        </li>
-      </ul>
-    </div>
-  </div>
-<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "result_filters/error_message", locals: { error_anchor_id: "study-type-error" } %>
     <%= form_with url: studytype_path, method: :post do |form| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["fulltime", "parttime"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
@@ -29,7 +16,7 @@
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">
           <% if flash[:error] %>
-            <span id="studytype-error" class="govuk-error-message">
+            <span id="study-type-error" class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span> You must make at least one selection
             </span>
           <% end %>


### PR DESCRIPTION
### Context

We are replacing the search and compare UI filter pages. As they have been built concurrently there are some inconsistencies.

### Changes proposed in this pull request

Make the error message consistent across filters -> 

* User the `result_filters/error_message` partial
* Link in to the error
* Render error messages in the 2/3 column of the page

### Guidance to review

