### PR TITLE
[2848] Fix financial information for apprenticeships

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -75,7 +75,7 @@ class CourseDecorator < Draper::Decorator
   end
 
   def salaried?
-    object.funding_type == "salary"
+    object.funding_type == "salary" || object.funding_type == "apprenticeship"
   end
 
   def apprenticeship?

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -64,8 +64,14 @@ describe CourseDecorator do
         it { is_expected.to be_salaried }
       end
 
-      context "course is not salaried" do
+      context "course is an apprenticeship with salary" do
         let(:course) { build :course, funding_type: "apprenticeship" }
+
+        it { is_expected.to be_salaried }
+      end
+
+      context "course is not salaried" do
+        let(:course) { build :course, :with_fees }
 
         it { is_expected.to_not be_salaried }
       end


### PR DESCRIPTION
### Context
Apprenticeships come with a salary so the information shown for these courses should match a standalone salaried course i.e.
https://www.find-postgraduate-teacher-training.service.gov.uk/course/2BZ/39NZ#section-financial-support

### Changes proposed in this pull request
Return `salaried?` true for apprenticeships 

### Guidance to review
Should match -
https://www.find-postgraduate-teacher-training.service.gov.uk/course/2BZ/39NZ#section-financial-support
