### PR TITLE
2853 add links for filter pages with default filtering params

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -2,6 +2,7 @@ class ResultsController < ApplicationController
   before_action :redirect_to_c_sharp
 
   def index
+    @results_view = ResultsView.new(query_parameters: request.query_parameters)
     @courses = Course
       .includes(:provider)
       .includes(:accrediting_provider)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -1,0 +1,42 @@
+class ResultsView
+  def initialize(query_parameters:)
+    @query_parameters = query_parameters
+  end
+
+  def query_parameters_with_defaults
+    query_parameters.except("utf8", "authenticity_token")
+      .merge(qualifications_parameters)
+      .merge(fulltime_parameters)
+      .merge(parttime_parameters)
+      .merge(hasvacancies_parameters)
+      .merge(sen_courses_parameters)
+  end
+
+  def filter_path_with_unescaped_commas(base_path)
+    "#{base_path}?#{URI.encode_www_form(query_parameters_with_defaults)}".gsub("%2C", ",")
+  end
+
+private
+
+  attr_reader :query_parameters
+
+  def qualifications_parameters
+    { "qualifications" => query_parameters["qualifications"].presence || "QtsOnly,PgdePgceWithQts,Other" }
+  end
+
+  def fulltime_parameters
+    { "fulltime" => query_parameters["fulltime"].presence || "False" }
+  end
+
+  def parttime_parameters
+    { "parttime" => query_parameters["parttime"].presence || "False" }
+  end
+
+  def hasvacancies_parameters
+    { "hasvacancies" => query_parameters["hasvacancies"].presence || "True" }
+  end
+
+  def sen_courses_parameters
+    { "senCourses" => query_parameters["senCourses"].presence || "False" }
+  end
+end

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -10,6 +10,26 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       filters go here
+      <div data-qa="filters">
+        <div>
+          <%=link_to "Change location or choose a provider", @results_view.filter_path_with_unescaped_commas(location_path), class: "govuk-link", data: { qa: "filters__location_link" }%>
+        </div>
+        <div>
+          <%=link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "filters__subject_link" }%>
+        </div>
+        <div>
+          <%=link_to "Change study type", @results_view.filter_path_with_unescaped_commas(studytype_path), class: "govuk-link", data: { qa: "filters__studytype_link" }%>
+        </div>
+        <div>
+          <%=link_to "Change qualifications", @results_view.filter_path_with_unescaped_commas(qualification_path), class: "govuk-link", data: { qa: "filters__qualifications_link" }%>
+        </div>
+        <div>
+          <%=link_to "Change salary option", @results_view.filter_path_with_unescaped_commas(funding_path), class: "govuk-link", data: { qa: "filters__salary_link" }%>
+        </div>
+        <div>
+          <%=link_to "Change vacancies", @results_view.filter_path_with_unescaped_commas(vacancy_path), class: "govuk-link", data: { qa: "filters__vacancy_link" }%>
+        </div>
+      </div>
     </div>
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-row">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,10 +14,8 @@ variables:
 
 steps:
 - script: |
-    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
-    set +x
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(Build.SourceVersionMessage)'> $(build.artifactstagingdirectory)/merge.info

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,11 @@ Rails.application.routes.draw do
 
     get "funding", to: "funding#new"
     post "funding", to: "funding#create"
+
     get "qualification", to: "qualification#new"
     post "qualification", to: "qualification#create"
+
+    get "subject", to: "subject#new"
+    post "subject", to: "subject#create"
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -16,6 +16,13 @@ module PageObjects
 
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
+
+      element :location_link, '[data-qa="filters__location_link"]'
+      element :subject_link, '[data-qa="filters__subject"]'
+      element :study_type_link, '[data-qa="filters__study_type_link"]'
+      element :qualification_link, '[data-qa="filters__qualification_link"]'
+      element :salary_link, '[data-qa="filters__salary_link"]'
+      element :vacancies_link, '[data-qa="filters__vacancies_link"]'
     end
   end
 end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe ResultsView do
+  let(:query_parameters) { ActionController::Parameters.new(parameter_hash) }
+
+  let(:default_parameters) do
+    {
+      "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+      "fulltime" => "False",
+      "parttime" => "False",
+      "hasvacancies" => "True",
+      "senCourses" => "False",
+    }
+  end
+
+  describe "query_parameters_with_defaults" do
+    subject { described_class.new(query_parameters: query_parameters).query_parameters_with_defaults }
+
+    context "params are empty" do
+      let(:parameter_hash) { {} }
+
+      it { is_expected.to eq(default_parameters) }
+    end
+
+    context "query_parameters have qualifications set" do
+      let(:parameter_hash) { { "qualifications" => "Other" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "query_parameters have fulltime set" do
+      let(:parameter_hash) { { "fulltime" => "True" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "query_parameters have parttime set" do
+      let(:parameter_hash) { { "parttime" => "True" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "query_parameters have hasvacancies set" do
+      let(:parameter_hash) { { "hasvacancies" => "False" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "query_parameters have senCourses set" do
+      let(:parameter_hash) { { "senCourses" => "False" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "parameters without default present in query_parameters" do
+      let(:parameter_hash) { {  "lat" => "52.3812321", "lng" => "-3.9440235" } }
+
+      it { is_expected.to eq(default_parameters.merge(parameter_hash)) }
+    end
+
+    context "rails specific parameters are present" do
+      let(:parameter_hash) { { "utf8" => true, "authenticity_token" => "booyah" } }
+
+      it "filters them out" do
+        expect(subject).to eq(default_parameters.merge({}))
+      end
+    end
+  end
+
+  describe "filter_path_with_unescaped_commas" do
+    subject { described_class.new(query_parameters: default_parameters).filter_path_with_unescaped_commas("/test") }
+
+    it "appends an unescaped querystring to the passed path" do
+      expected_path = "/test?qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False"
+      expect(subject).to eq(expected_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

We are rebuilding the results page. The links to the filter pages on the results page need to pass the querystring into the filter pages but also populate some default values if they aren't present.

### Changes proposed in this pull request

* Add `ResultsView` to handle this logic
* Add links for each of the filters. The filter boxes themselves are out of scope for this work. There aren't any feature specs in this PR for the links as they can be added to the filter feature specs once the full feature 'journey' (ie visit results, click filter, fill filter, return to results, check courses returned) is present to test.
* Update the azure config again as the fix we put in seems to no longer be required and now actually breaks CI. 

<img width="1058" alt="Screenshot 2020-01-27 at 15 45 25" src="https://user-images.githubusercontent.com/5216/73195876-85f1cb00-4126-11ea-8eba-5ffe252a7af7.png">

### Guidance to review

The results page redirects to `localhost:5000` in development by default. Temporarily update `config/settings.yml` to test.

