### PR TITLE
[2783] - Filter courses by location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,9 @@ gem "bootsnap", ">= 1.1.0", require: false
 # Manage multiple processes i.e. web server and webpack
 gem "foreman"
 
+# Geocoding
+gem "geocoder"
+
 # Kaminari, pagination templating
 gem "kaminari"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,7 @@ GEM
       faraday (>= 0.7.4, < 1.0)
     ffi (1.11.1)
     foreman (0.86.0)
+    geocoder (1.6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.0)
@@ -370,6 +371,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  geocoder
   json_api_client
   jsonapi-deserializable
   jsonapi-renderer

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -7,13 +7,19 @@ module ResultFilters
     def new; end
 
     def create
-      if(!params[:l])
-        flash[:error] = "Please choose an option"
-        redirect_to location_path(params_without_unsupported_location_params)
-      elsif params[:l] == "3"
+      if params[:l] == "3"
         redirect_to provider_path(params_for_provider_search)
+      end
+
+      form_params = strip(filter_params.clone)
+      form_object = LocationFilterForm.new(form_params)
+
+      if form_object.valid?
+        all_params = form_params.merge!(form_object.params)
+        redirect_to results_path(all_params)
       else
-        redirect_to results_path(params_without_unsupported_location_params)
+        flash[:error] = form_object.errors
+        redirect_to location_path(form_params)
       end
     end
 
@@ -28,8 +34,8 @@ module ResultFilters
       filter_params.except(:lat, :lng, :rad, :loc, :lq)
     end
 
-    def params_without_unsupported_location_params
-      filter_params.except(:lat, :lng, :rad, :query, :loc, :lq)
+    def strip(params)
+      params.reject { |_, v| v == "" }
     end
   end
 end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -7,7 +7,7 @@ module ResultFilters
     def new; end
 
     def create
-      if params[:l] == "3"
+      if provider_option_selected?
         redirect_to(provider_path(params_for_provider_search)) && return
       end
 
@@ -28,6 +28,10 @@ module ResultFilters
     def build_results_filter_query_parameters
       @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
         .query_parameters_with_defaults
+    end
+
+    def provider_option_selected?
+      filter_params[:l] == "3"
     end
 
     def params_for_provider_search

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -8,7 +8,7 @@ module ResultFilters
 
     def create
       if params[:l] == "3"
-        redirect_to provider_path(params_for_provider_search)
+        redirect_to(provider_path(params_for_provider_search)) && return
       end
 
       form_params = strip(filter_params.clone)

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -4,7 +4,7 @@ module ResultFilters
 
     def new
       if params[:query].blank?
-        flash[:error] = "Training provider"
+        flash[:error] = ["Training provider"]
         return redirect_back
       end
 
@@ -15,7 +15,7 @@ module ResultFilters
         .all
 
       if @provider_suggestions.count.zero?
-        flash[:error] = "Training provider"
+        flash[:error] = ["Training provider"]
         redirect_back
       elsif @provider_suggestions.count == 1
         redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -4,7 +4,7 @@ module ResultFilters
 
     def new
       if params[:query].blank?
-        flash[:error] = ["Training provider"]
+        flash[:error] = [I18n.t("location_filter.fields.provider")]
         return redirect_back
       end
 
@@ -15,7 +15,7 @@ module ResultFilters
         .all
 
       if @provider_suggestions.count.zero?
-        flash[:error] = ["Training provider"]
+        flash[:error] = [I18n.t("location_filter.fields.provider")]
         redirect_back
       elsif @provider_suggestions.count == 1
         redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))

--- a/app/form_objects/result_filters/location_filter_form.rb
+++ b/app/form_objects/result_filters/location_filter_form.rb
@@ -7,12 +7,12 @@ module ResultFilters
 
     def initialize(params)
       @params = params
-      @errors = nil
+      @errors = []
     end
 
     def valid?
       validate
-      @errors.nil?
+      @errors.empty?
     end
 
   private
@@ -20,10 +20,10 @@ module ResultFilters
     def validate
       case selected_option
       when NO_OPTION
-        handle_no_option
+        @errors = ["Please choose an option"]
       when LOCATION_OPTION
         if location_query.nil?
-          handle_missing_location
+          @errors = ["Postcode, town, or city", "Please enter a postcode, city or town in England"]
         else
           handle_location_option
         end
@@ -36,16 +36,8 @@ module ResultFilters
         @params.merge!(geocode_params)
         @valid = true
       else
-        @errors = "We couldn't find this location, please check your input and try again"
+        @errors = ["Postcode, town or city", "We couldn't find this location, please check your input and try again"]
       end
-    end
-
-    def handle_missing_location
-      @errors = "Please enter a postcode, town or city in England"
-    end
-
-    def handle_no_option
-      @errors = "Please choose an option"
     end
 
     def geocode_params_for(query)

--- a/app/form_objects/result_filters/location_filter_form.rb
+++ b/app/form_objects/result_filters/location_filter_form.rb
@@ -1,0 +1,76 @@
+module ResultFilters
+  class LocationFilterForm
+    NO_OPTION = nil
+    LOCATION_OPTION = "1".freeze
+
+    attr_reader :params, :errors
+
+    def initialize(params)
+      @params = params
+      @errors = nil
+    end
+
+    def valid?
+      validate
+      @errors.nil?
+    end
+
+  private
+
+    def validate
+      case selected_option
+      when NO_OPTION
+        handle_no_option
+      when LOCATION_OPTION
+        if location_query.nil?
+          handle_missing_location
+        else
+          handle_location_option
+        end
+      end
+    end
+
+    def handle_location_option
+      geocode_params = geocode_params_for(location_query)
+      if geocode_params
+        @params.merge!(geocode_params)
+        @valid = true
+      else
+        @errors = "We couldn't find this location, please check your input and try again"
+      end
+    end
+
+    def handle_missing_location
+      @errors = "Please enter a postcode, town or city in England"
+    end
+
+    def handle_no_option
+      @errors = "Please choose an option"
+    end
+
+    def geocode_params_for(query)
+      results = Geocoder.search(query, components: "country:UK")
+      england_results = results.select { |r| r.state == "England" }.first
+      if england_results
+        {
+            lat: england_results.latitude,
+            lng: england_results.longitude,
+            loc: england_results.address,
+            lq: location_query,
+        }
+      end
+    end
+
+    def selected_option
+      @params[:l]
+    end
+
+    def location_query
+      @params[:lq]
+    end
+
+    def search_radius
+      @params[:rad]
+    end
+  end
+end

--- a/app/form_objects/result_filters/location_filter_form.rb
+++ b/app/form_objects/result_filters/location_filter_form.rb
@@ -20,10 +20,10 @@ module ResultFilters
     def validate
       case selected_option
       when NO_OPTION
-        @errors = ["Please choose an option"]
+        @errors = [I18n.t("location_filter.errors.no_option")]
       when LOCATION_OPTION
         if location_query.nil?
-          @errors = ["Postcode, town, or city", "Please enter a postcode, city or town in England"]
+          @errors = [I18n.t("location_filter.fields.location"), I18n.t("location_filter.errors.missing_location")]
         else
           handle_location_option
         end
@@ -36,7 +36,7 @@ module ResultFilters
         @params.merge!(geocode_params)
         @valid = true
       else
-        @errors = ["Postcode, town or city", "We couldn't find this location, please check your input and try again"]
+        @errors = [I18n.t("location_filter.fields.location"), I18n.t("location_filter.errors.unknown_location")]
       end
     end
 

--- a/app/helpers/result_filters/location_helper.rb
+++ b/app/helpers/result_filters/location_helper.rb
@@ -1,0 +1,15 @@
+module ResultFilters
+  module LocationHelper
+    def provider_error?
+      flash[:error] && flash[:error].include?(I18n.t("location_filter.fields.provider"))
+    end
+
+    def location_error?
+      flash[:error] && flash[:error].include?(I18n.t("location_filter.fields.location"))
+    end
+
+    def no_option_selected?
+      flash[:error] && flash[:error].include?(I18n.t("location_filter.errors.no_option"))
+    end
+  end
+end

--- a/app/views/result_filters/_error_message.html.erb
+++ b/app/views/result_filters/_error_message.html.erb
@@ -6,7 +6,13 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <li>
-          <a href="#<%=error_anchor_id%>" data-qa="error__text"><%= flash[:error].first %></a>
+          <a href="#<%= error_anchor_id %>" data-qa="error__text">
+            <% if flash[:error].kind_of?(Array) %>
+              <%= flash[:error].first %>
+            <% else %>
+              <%= flash[:error] %>
+            <% end %>
+          </a>
         </li>
       </ul>
     </div>

--- a/app/views/result_filters/_error_message.html.erb
+++ b/app/views/result_filters/_error_message.html.erb
@@ -6,7 +6,7 @@
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <li>
-          <a href="#<%=error_anchor_id%>" data-qa="error__text"><%= flash[:error] %></a>
+          <a href="#<%=error_anchor_id%>" data-qa="error__text"><%= flash[:error].first %></a>
         </li>
       </ul>
     </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -8,11 +8,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: "result_filters/error_message", locals: {
       error_anchor_id:
-        if flash[:error] && flash[:error].include?("Please choose an option")
+        if no_option_selected?
           "search-options"
-        elsif flash[:error] && flash[:error].include?("Postcode, town, or city")
+        elsif location_error?
           "location-error"
-        elsif flash[:error] && flash[:error].include?("Training provider")
+        elsif provider_error?
           "provider-error"
         end
     } %>
@@ -38,13 +38,13 @@
               <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
             </div>
             <div
-              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] && flash[:error].include?("Please enter a postcode, city or town in England") %>"
+              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless location_error? %>"
               id="location-conditional">
               <div class="govuk-form-group">
                 <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
-                <% if flash[:error] && flash[:error].count > 1 %>
+                <% if location_error? %>
                   <div class="govuk-error-message" id="location-error" data-qa="location-error">
-                    <span class="govuk-visually-hidden">Error:</span><%= flash[:error].last  %>
+                    <span class="govuk-visually-hidden">Error: </span><%= flash[:error].last  %>
                   </div>
                 <% end %>
                 <%=
@@ -106,13 +106,13 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] && flash[:error].include?("Training provider") %>" id="query-container">
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless provider_error? %>" id="query-container">
 
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
-                <% if flash[:error] && flash[:error].include?("Training provider") %>
+                <% if provider_error? %>
                    <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                     <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
+                     <span class="govuk-visually-hidden">Error: </span><%= I18n.t("location_filter.errors.missing_provider") %>
                    </span>
                 <% end %>
               <% end %>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -8,9 +8,11 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render partial: "result_filters/error_message", locals: {
       error_anchor_id:
-        if flash[:error] == "Please choose an option" then
+        if flash[:error] && flash[:error].include?("Please choose an option")
+          "search-options"
+        elsif flash[:error] && flash[:error].include?("Postcode, town, or city")
           "location-error"
-        elsif flash[:error] == "Training provider"
+        elsif flash[:error] && flash[:error].include?("Training provider")
           "provider-error"
         end
     } %>
@@ -20,14 +22,8 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
         </legend>
-
-        <%# if flash[:error] == "Please choose an option" %>
-        <!--            <span id="location-error" class="govuk-error-message">-->
-        <!--              <span class="govuk-visually-hidden">Error:</span> Please choose an option-->
-        <!--            </span>-->
-        <%# end %>
-        <div class="govuk-form-group">
-          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
+        <div class="govuk-form-group" id="search-options">
+          <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%=
                 form.radio_button(
@@ -41,33 +37,43 @@
               %>
               <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
             </div>
-            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] %>" id="location-conditional">
-              <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
-              <div class="govuk-error-message" id="location-error" data-qa="location-error"><%= flash[:error] %></div>
-              <%=
-                form.text_field(
-                  :lq,
-                  value: "#{request.params[:lq]}",
-                  class: "govuk-input",
-                  data: {qa: "location-query"},
-                )
-              %>
-              <%= form.label :rad, "Within", class: "govuk-label" %>
-              <%= form.select :rad,
-                              options_for_select(
-                                [
-                                  ["5 miles", "5"],
-                                  ["10 miles", "10"],
-                                  ["20 miles", "20"],
-                                  ["50 miles", "50"],
-                                  ["100 miles", "100"],
-                                ],
-                                [request.params[:rad] || "20"]
-                              ),
-                              {include_blank: false},
-                              data: {qa: 'search-radius'},
-                              class: 'govuk-select govuk-!-width-one-half'
-              %>
+            <div
+              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] && flash[:error].include?("Please enter a postcode, city or town in England") %>"
+              id="location-conditional">
+              <div class="govuk-form-group">
+                <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
+                <% if flash[:error] && flash[:error].count > 1 %>
+                  <div class="govuk-error-message" id="location-error" data-qa="location-error">
+                    <span class="govuk-visually-hidden">Error:</span><%= flash[:error].last  %>
+                  </div>
+                <% end %>
+                <%=
+                  form.text_field(
+                    :lq,
+                    value: "#{request.params[:lq]}",
+                    class: "govuk-input",
+                    data: {qa: "location-query"},
+                  )
+                %>
+              </div>
+              <div class="govuk-form-group">
+                <%= form.label :rad, "Within", class: "govuk-label" %>
+                <%= form.select :rad,
+                  options_for_select(
+                    [
+                      ["5 miles", "5"],
+                      ["10 miles", "10"],
+                      ["20 miles", "20"],
+                      ["50 miles", "50"],
+                      ["100 miles", "100"],
+                    ],
+                    [request.params[:rad] || "20"]
+                  ),
+                  {include_blank: false},
+                  data: {qa: 'search-radius'},
+                  class: 'govuk-select govuk-!-width-one-half'
+                %>
+              </div>
             </div>
             <div class="govuk-radios__item">
               <%= form.radio_button(
@@ -100,13 +106,14 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] == "Training provider" %>" id="query-container">
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] && flash[:error].include?("Training provider") %>" id="query-container">
+
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
-                <% if flash[:error] == "Training provider" %>
-                                                                                                                                                                   <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                                                                                                                                                                   <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
-                                                                                                                                                                   </span>
+                <% if flash[:error] && flash[:error].include?("Training provider") %>
+                   <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+                     <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
+                   </span>
                 <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -13,20 +13,20 @@
         elsif flash[:error] == "Training provider"
           "provider-error"
         end
-    }%>
+    } %>
     <%= form_with url: location_path, method: :post do |form| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["l"], form: form %>
-      <fieldset class="govuk-fieldset">
+      <fieldset class="govuk-fieldset" role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
         </legend>
 
+        <%# if flash[:error] == "Please choose an option" %>
+        <!--            <span id="location-error" class="govuk-error-message">-->
+        <!--              <span class="govuk-visually-hidden">Error:</span> Please choose an option-->
+        <!--            </span>-->
+        <%# end %>
         <div class="govuk-form-group">
-          <%# if flash[:error] == "Please choose an option" %>
-<!--            <span id="location-error" class="govuk-error-message">-->
-<!--              <span class="govuk-visually-hidden">Error:</span> Please choose an option-->
-<!--            </span>-->
-          <%# end %>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%=
@@ -34,44 +34,51 @@
                   :l,
                   "1",
                   class: "govuk-radios__input",
-                  data: { qa: "by_postcode_town_or_city" },
+                  data: {qa: "by_postcode_town_or_city"},
                   checked: params[:l] == "1",
-                  aria: { 'controls': "location-conditional" }
+                  aria: {'controls': "location-conditional"}
                 )
               %>
               <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] %>" id="location-conditional">
-              <div class="govuk-form-group">
-                <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
-                <div class="govuk-error-message" id="location-error" data-qa="location-error"><%= flash[:error] %></div>
-                <%=
-                  form.text_field(
-                    :lq,
-                    value: "#{request.params[:lq]}",
-                    class: "govuk-input",
-                    data: { qa: "location-query" },
-                    )
-                %>
-              </div>
-              <div class="govuk-form-group">
-                <%= form.label :rad, "Within", class: "govuk-label" %>
-                <%= form.select :rad,
-                                options_for_select(
-                                  [
-                                    ["5 miles", "5"],
-                                    ["10 miles", "10"],
-                                    ["20 miles", "20"],
-                                    ["50 miles", "50"],
-                                    ["100 miles", "100"],
-                                  ],
-                                  [request.params[:rad] || "20"]
-                                ),
-                                { include_blank: false },
-                                data: { qa: 'search-radius' },
-                                class: 'govuk-select govuk-!-width-one-half'
-                %>
-              </div>
+              <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
+              <div class="govuk-error-message" id="location-error" data-qa="location-error"><%= flash[:error] %></div>
+              <%=
+                form.text_field(
+                  :lq,
+                  value: "#{request.params[:lq]}",
+                  class: "govuk-input",
+                  data: {qa: "location-query"},
+                )
+              %>
+              <%= form.label :rad, "Within", class: "govuk-label" %>
+              <%= form.select :rad,
+                              options_for_select(
+                                [
+                                  ["5 miles", "5"],
+                                  ["10 miles", "10"],
+                                  ["20 miles", "20"],
+                                  ["50 miles", "50"],
+                                  ["100 miles", "100"],
+                                ],
+                                [request.params[:rad] || "20"]
+                              ),
+                              {include_blank: false},
+                              data: {qa: 'search-radius'},
+                              class: 'govuk-select govuk-!-width-one-half'
+              %>
+            </div>
+            <div class="govuk-radios__item">
+              <%= form.radio_button(
+                    :l,
+                    "2",
+                    class: "govuk-radios__input",
+                    data: {qa: "across-england"},
+                    checked: params[:l] == "2"
+                  )
+              %>
+              <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
             </div>
             <div class="govuk-radios__divider">or</div>
             <div class="govuk-radios__item">
@@ -93,43 +100,24 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] ==  "Training provider" %>" id="query-container">
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] == "Training provider" %>" id="query-container">
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
                 <% if flash[:error] == "Training provider" %>
-                  <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                    <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
-                  </span>
+                                                                                                                                                                   <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+                                                                                                                                                                   <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
+                                                                                                                                                                   </span>
                 <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>
-              <%= form.text_field :query, value: params[:query], class: "govuk-input", data: { qa: "provider-search" } %>
+              <%= form.text_field :query, value: params[:query], class: "govuk-input", data: {qa: "provider-search"} %>
             </div>
-          </div>
-        </div>
-        <div class="govuk-form-group">
-          <div class="govuk-form-group">
-            <div class="govuk-radios">
-              <div class="govuk-radios__item">
-                <%=
-                  form.radio_button(
-                    :l,
-                    "2",
-                    class: "govuk-radios__input",
-                    data: { qa: "across-england" },
-                    checked: params[:l] == "2"
-                  )
-                %>
-                <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
-              </div>
-            </div>
-          </div>
-
-          <div class="govuk-form-group">
-            <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find-courses' } %>
           </div>
         </div>
       </fieldset>
+      <div class="govuk-form-group">
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: {qa: 'find-courses'} %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -22,23 +22,56 @@
         </legend>
 
         <div class="govuk-form-group">
-          <% if flash[:error] == "Please choose an option" %>
-            <span id="location-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> Please choose an option
-            </span>
-          <% end %>
+          <%# if flash[:error] == "Please choose an option" %>
+<!--            <span id="location-error" class="govuk-error-message">-->
+<!--              <span class="govuk-visually-hidden">Error:</span> Please choose an option-->
+<!--            </span>-->
+          <%# end %>
           <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%=
                 form.radio_button(
                   :l,
-                  "2",
+                  "1",
                   class: "govuk-radios__input",
-                  data: { qa: "across-england" },
-                  checked: params[:l] == "2"
+                  data: { qa: "by_postcode_town_or_city" },
+                  checked: params[:l] == "1",
+                  aria: { 'controls': "location-conditional" }
                 )
               %>
-              <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
+              <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
+            </div>
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] %>" id="location-conditional">
+              <div class="govuk-form-group">
+                <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
+                <div class="govuk-error-message" id="location-error" data-qa="location-error"><%= flash[:error] %></div>
+                <%=
+                  form.text_field(
+                    :lq,
+                    value: "#{request.params[:lq]}",
+                    class: "govuk-input",
+                    data: { qa: "location-query" },
+                    )
+                %>
+              </div>
+              <div class="govuk-form-group">
+                <%= form.label :rad, "Within", class: "govuk-label" %>
+                <%= form.select :rad,
+                                options_for_select(
+                                  [
+                                    ["5 miles", "5"],
+                                    ["10 miles", "10"],
+                                    ["20 miles", "20"],
+                                    ["50 miles", "50"],
+                                    ["100 miles", "100"],
+                                  ],
+                                  [request.params[:rad] || "20"]
+                                ),
+                                { include_blank: false },
+                                data: { qa: 'search-radius' },
+                                class: 'govuk-select govuk-!-width-one-half'
+                %>
+              </div>
             </div>
             <div class="govuk-radios__divider">or</div>
             <div class="govuk-radios__item">
@@ -75,7 +108,26 @@
           </div>
         </div>
         <div class="govuk-form-group">
-          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
+          <div class="govuk-form-group">
+            <div class="govuk-radios">
+              <div class="govuk-radios__item">
+                <%=
+                  form.radio_button(
+                    :l,
+                    "2",
+                    class: "govuk-radios__input",
+                    data: { qa: "across-england" },
+                    checked: params[:l] == "2"
+                  )
+                %>
+                <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
+              </div>
+            </div>
+          </div>
+
+          <div class="govuk-form-group">
+            <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find-courses' } %>
+          </div>
         </div>
       </fieldset>
     <% end %>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,13 @@
+Geocoder.configure(
+  timeout: 3,                         # geocoding service timeout (secs)
+  lookup: :google,                    # name of geocoding service (symbol)
+  use_https: true, # use HTTPS for lookup requests? (if supported)
+  api_key: Settings.gcp_api_key, # API key for geocoding service
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  always_raise: :all,
+
+  units: :mi, # :km for kilometers or :mi for miles
+)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -47,3 +47,12 @@ en:
     pgce_with_qts: "PGCE with QTS"
     pgde: "PGDE"
     pgde_with_qts: "PGDE with QTS"
+  location_filter:
+    errors:
+      no_option: "Please choose an option"
+      unknown_location: "We couldn't find this location, please check your input and try again"
+      missing_location: "Please enter a postcode, city or town in England"
+      missing_provider: "Please enter the name of a training provider"
+    fields:
+      location: "Postcode, town or city"
+      provider: "Training provider"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,3 +7,4 @@ google:
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 redirect_results_to_c_sharp: true
+gcp_api_key: please_change_me

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -136,7 +136,7 @@ feature "Location filter", type: :feature do
       filter_page.load
       filter_page.find_courses.click
 
-      expect(filter_page).to have_error
+      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPlease choose an option")
     end
 
     it "Displays an error if location is selected but none is entered" do
@@ -146,8 +146,8 @@ feature "Location filter", type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page).to have_error
-      expect(filter_page).to have_location_error
+      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPostcode, town or city")
+      expect(filter_page.location_error.text).to eq("Error: Please enter a postcode, city or town in England")
       expect(filter_page).to have_location_query
       expect(filter_page).to have_select("rad", selected: "5 miles")
     end
@@ -159,8 +159,8 @@ feature "Location filter", type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page).to have_error
-      expect(filter_page).to have_location_error
+      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPostcode, town or city")
+      expect(filter_page.location_error.text).to eq("Error: We couldn't find this location, please check your input and try again")
       expect(filter_page).to have_location_query
       expect(filter_page).to have_unknown_location
     end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -52,14 +52,27 @@ feature "Location filter", type: :feature do
       expect_page_to_be_displayed_with_query(
         page: location_filter_results_page,
         expected_query_params: {
-            "l" => "1",
-            "lat" => "51.4980188",
-            "lng" => "-0.1300436",
-            "loc" => "Westminster, London SW1P 3BT, UK",
-            "lq" => "SW1P 3BT",
-            "rad" => "5",
+          "l" => "1",
+          "lat" => "51.4980188",
+          "lng" => "-0.1300436",
+          "loc" => "Westminster, London SW1P 3BT, UK",
+          "lq" => "SW1P 3BT",
+          "rad" => "5",
         },
-          )
+      )
+    end
+
+    it "Allows the user to select across england" do
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "l" => "2",
+          "rad" => "20",
+        },
+      )
     end
 
     context "selecting by provider" do
@@ -115,26 +128,6 @@ feature "Location filter", type: :feature do
     it "Preselects across england" do
       filter_page.load(query: { l: 2 })
       expect(filter_page.across_england.checked?).to eq(true)
-    end
-
-    it "Allows the user to select across england" do
-      filter_page.across_england.click
-      filter_page.find_courses.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "l" => "2",
-          "rad" => "20",
-        },
-      )
-    end
-  end
-
-  describe "Navigating to the page with currently selected filters" do
-    it "Preselects across england" do
-      filter_page.load(query: { l: 2 })
-      expect(filter_page.across_england).to be_checked
     end
   end
 

--- a/spec/form_objects/result_filters/location_filter_form_spec.rb
+++ b/spec/form_objects/result_filters/location_filter_form_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+module ResultFilters
+  describe LocationFilterForm do
+    before do
+      stub_geocoder
+    end
+
+    describe "Validation" do
+      subject { described_class.new(params) }
+      context "no option selected" do
+        let(:params) { {} }
+        it "is not valid" do
+          expect(subject.valid?).to eq(false)
+        end
+
+        it "has error" do
+          subject.valid?
+          expect(subject.errors).to eq("Please choose an option")
+        end
+
+        it "has empty params" do
+          subject.valid?
+          expect(subject.params).to be_empty
+        end
+      end
+
+      context "unknown location" do
+        let(:params) { { l: "1", lq: "Unknown location" } }
+
+        it "is not valid" do
+          expect(subject.valid?).to eq(false)
+        end
+
+        it "has error" do
+          subject.valid?
+          expect(subject.errors).to eq("We couldn't find this location, please check your input and try again")
+        end
+
+        it "has params" do
+          subject.valid?
+          expect(subject.params).to eq(params)
+        end
+      end
+
+      context "known location" do
+        let(:params) { { l: "1", lq: "SW1P 3BT" } }
+
+        it "is not valid" do
+          expect(subject.valid?).to eq(true)
+        end
+
+        it "has no errors" do
+          subject.valid?
+          expect(subject.errors).to be_nil
+        end
+
+        it "has params" do
+          subject.valid?
+          expect(subject.params).to eq(params)
+        end
+      end
+    end
+  end
+end

--- a/spec/form_objects/result_filters/location_filter_form_spec.rb
+++ b/spec/form_objects/result_filters/location_filter_form_spec.rb
@@ -16,7 +16,7 @@ module ResultFilters
 
         it "has error" do
           subject.valid?
-          expect(subject.errors).to eq("Please choose an option")
+          expect(subject.errors).to eq(["Please choose an option"])
         end
 
         it "has empty params" do
@@ -34,7 +34,7 @@ module ResultFilters
 
         it "has error" do
           subject.valid?
-          expect(subject.errors).to eq("We couldn't find this location, please check your input and try again")
+          expect(subject.errors).to eq(["Postcode, town or city", "We couldn't find this location, please check your input and try again"])
         end
 
         it "has params" do
@@ -52,7 +52,7 @@ module ResultFilters
 
         it "has no errors" do
           subject.valid?
-          expect(subject.errors).to be_nil
+          expect(subject.errors).to be_empty
         end
 
         it "has params" do

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -13,6 +13,11 @@ module PageObjects
         element :provider_error, '[data-qa="provider-error"]'
         element :provider_search, '[data-qa="provider-search"]'
         element :find_courses, '[data-qa="find-courses"]'
+        element :location_error, '[data-qa="location-error"]'
+        element :by_postcode_town_or_city, '[data-qa="by_postcode_town_or_city"]'
+        element :location_query, '[data-qa="location-query"]'
+        element :unknown_location, 'input[value="Unknown location"]'
+        element :search_radius, '[data-qa="search-radius"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/location_filter_results.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location_filter_results.rb
@@ -1,0 +1,9 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class LocationFilterResults < SitePrism::Page
+        set_url "/results?l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=5"
+      end
+    end
+  end
+end

--- a/spec/support/geocoder_helper.rb
+++ b/spec/support/geocoder_helper.rb
@@ -1,0 +1,34 @@
+def stub_geocoder
+  Geocoder.configure(lookup: :test)
+
+  Geocoder::Lookup::Test.set_default_stub(
+    [
+      {
+        "coordinates" => [51.4524877, -0.1204749],
+        "address" => "AA Teamworks W Yorks SCITT, School Street, Greetland, Halifax, West Yorkshire HX4 8JB",
+        "state" => "England",
+        "country" => "United Kingdom",
+        "country_code" => "UK",
+      },
+    ],
+  )
+
+  Geocoder::Lookup::Test.add_stub(
+    "SW1P 3BT",
+    [
+      {
+        "coordinates" => [51.4980188, -0.1300436],
+        "address" => "Westminster, London SW1P 3BT, UK",
+        "state" => "England",
+        "state_code" => "England",
+        "country" => "United Kingdom",
+        "country_code" => "UK",
+      },
+    ],
+  )
+
+  Geocoder::Lookup::Test.add_stub(
+    "Unknown location",
+    [],
+  )
+end


### PR DESCRIPTION
### Context
Adds an option to the `/results/filter/location` to allow users to filter requests by location.

### Changes proposed in this pull request
- Upon submitting the form, the location query is geocoded and the params are populated with additional key/values (:lq, :lat, :lng)
- If a user's location query returns no results from the Google API then the user is redirected back to the page and an error displays
- Same deal if no option is selected

### Show the thing

#### 1. Unknown location
![error](https://user-images.githubusercontent.com/5256922/73352717-a1291b80-4289-11ea-89c4-d0e7930374de.gif)

#### 2. Known location
![success](https://user-images.githubusercontent.com/5256922/73352816-dc2b4f00-4289-11ea-8b45-bb6477b29128.gif)

### Guidance to review
- After some feedback on the approach taken in certain areas. See comments below
