### PR TITLE
Use qa api in development mode

### DIFF
--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,2 @@
 manage_backend:
-  base_url: http://localhost:3001
+  base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk/


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Use qa api in development mode

So that it works out of the box without having to set up the API too.

If you are actually working on the API then you can override this
setting.

### Guidance to review

:ship: