### PR TITLE
[2341] Add no-js search and filter page for provider filtering

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -1,6 +1,12 @@
 module FilterParameters
   def filter_params
-    custom_params = request.request_parameters.reject do |param|
+    if request.method == "GET"
+      parameters = request.query_parameters
+    elsif request.method == "POST"
+      parameters = request.request_parameters
+    end
+
+    custom_params = parameters.reject do |param|
       param.in? %w(utf8 authenticity_token)
     end
 

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -8,6 +8,8 @@ module ResultFilters
       if(!params[:l])
         flash[:error] = "Please choose an option"
         redirect_to location_path(params_without_unsupported_location_params)
+      elsif params[:l].to_i == 3
+        redirect_to provider_path(query: params[:query])
       else
         redirect_to results_path(params_without_unsupported_location_params)
       end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -8,14 +8,18 @@ module ResultFilters
       if(!params[:l])
         flash[:error] = "Please choose an option"
         redirect_to location_path(params_without_unsupported_location_params)
-      elsif params[:l].to_i == 3
-        redirect_to provider_path(query: params[:query])
+      elsif params[:l] == "3"
+        redirect_to provider_path(params_for_provider_search)
       else
         redirect_to results_path(params_without_unsupported_location_params)
       end
     end
 
   private
+
+    def params_for_provider_search
+      filter_params.except(:lat, :lng, :rad, :loc, :lq)
+    end
 
     def params_without_unsupported_location_params
       filter_params.except(:lat, :lng, :rad, :query, :loc, :lq)

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -23,7 +23,10 @@ module ResultFilters
     end
 
     def redirect_back
-      redirect_to location_path(filter_params.except(:query))
+      redirect_params = filter_params
+      redirect_params = redirect_params.except(:query) if params[:query].blank?
+
+      redirect_to location_path(redirect_params)
     end
   end
 end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -8,10 +8,10 @@ module ResultFilters
         .where(recruitment_cycle_year: "2020")
         .with_params(search: params[:query])
         .all
-    end
 
-    def create
-      redirect_to results_path(filter_params)
+      if @provider_suggestions.count == 1
+        redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))
+      end
     end
   end
 end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -3,6 +3,11 @@ module ResultFilters
     include FilterParameters
 
     def new
+      if params[:query].blank?
+        flash[:error] = "Training provider"
+        return redirect_back
+      end
+
       @provider_suggestions = Provider
         .select(:provider_code, :provider_name)
         .where(recruitment_cycle_year: "2020")
@@ -11,10 +16,14 @@ module ResultFilters
 
       if @provider_suggestions.count.zero?
         flash[:error] = "Training provider"
-        redirect_to location_path(filter_params)
+        redirect_back
       elsif @provider_suggestions.count == 1
         redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))
       end
+    end
+
+    def redirect_back
+      redirect_to location_path(filter_params)
     end
   end
 end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -1,0 +1,17 @@
+module ResultFilters
+  class ProviderController < ApplicationController
+    include FilterParameters
+
+    def new
+      @provider_suggestions = Provider
+        .select(:provider_code, :provider_name)
+        .where(recruitment_cycle_year: "2020")
+        .with_params(search: "ACME")
+        .all
+    end
+
+    def create
+      redirect_to results_path(filter_params)
+    end
+  end
+end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -6,7 +6,7 @@ module ResultFilters
       @provider_suggestions = Provider
         .select(:provider_code, :provider_name)
         .where(recruitment_cycle_year: "2020")
-        .with_params(search: "ACME")
+        .with_params(search: params[:query])
         .all
     end
 

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -10,7 +10,7 @@ module ResultFilters
 
       @provider_suggestions = Provider
         .select(:provider_code, :provider_name)
-        .where(recruitment_cycle_year: "2020")
+        .where(recruitment_cycle_year: Settings.current_cycle)
         .with_params(search: params[:query])
         .all
 

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -23,7 +23,7 @@ module ResultFilters
     end
 
     def redirect_back
-      redirect_to location_path(filter_params)
+      redirect_to location_path(filter_params.except(:query))
     end
   end
 end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -9,7 +9,10 @@ module ResultFilters
         .with_params(search: params[:query])
         .all
 
-      if @provider_suggestions.count == 1
+      if @provider_suggestions.count.zero?
+        flash[:error] = "Training provider"
+        redirect_to location_path(filter_params)
+      elsif @provider_suggestions.count == 1
         redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))
       end
     end

--- a/app/views/result_filters/_error_message.html.erb
+++ b/app/views/result_filters/_error_message.html.erb
@@ -1,12 +1,12 @@
 <% if flash[:error] %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
-    <h2 class="govuk-error-summary__title" id="error-summary-title">
+    <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
       You’ll need to correct some information.
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">
         <li>
-          <a href="#<%=error_anchor_id%>"><%= flash[:error] %></a>
+          <a href="#<%=error_anchor_id%>" data-qa="error__text"><%= flash[:error] %></a>
         </li>
       </ul>
     </div>

--- a/app/views/result_filters/funding/new.html.erb
+++ b/app/views/result_filters/funding/new.html.erb
@@ -36,7 +36,7 @@
           </div>
         </div>
         <br>
-        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
       <% end %>
     </div>
   </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -43,10 +43,17 @@
                   checked: params[:l] == "3"
                 )
               %>
-              <%= form.text_field :query, data: {qa: "provider_search"} %>
-              <%= form.label :query, class: "govuk-label govuk-radios__label" do %>
+              <%= form.label :l_3, class: "govuk-label govuk-radios__label" do %>
                 By school, university or other training provider
               <% end %>
+            </div>
+            
+            <div class="govuk-radios__conditional">
+              <%= form.label :query, class: "govuk-label" do %>
+                School, university or other training provider
+              <% end %>
+              <span class="govuk-hint">Enter the name or provider code</span>
+              <%= form.text_field :query, class: "govuk-input", data: {qa: "provider_search"} %>
             </div>
           </div>
         </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -69,7 +69,7 @@
                 <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>
-              <%= form.text_field :query, class: "govuk-input", data: { qa: "provider-search" } %>
+              <%= form.text_field :query, value: params[:query], class: "govuk-input", data: { qa: "provider-search" } %>
             </div>
           </div>
         </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -19,7 +19,7 @@
               <span class="govuk-visually-hidden">Error:</span> Please choose an option
             </span>
           <% end %>
-          <div class="govuk-radios">
+          <div class="govuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%=
                 form.radio_button(
@@ -39,7 +39,12 @@
                   :l,
                   "3",
                   class: "govuk-radios__input",
-                  data: { qa: "by-provider" },
+                  data: {
+                    qa: "by-provider",
+                  },
+                  aria: {
+                    controls: "query-container",
+                  },
                   checked: params[:l] == "3"
                 )
               %>
@@ -47,8 +52,7 @@
                 By school, university or other training provider
               <% end %>
             </div>
-
-            <div class="govuk-radios__conditional">
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="query-container">
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
                 <% if flash[:error] == "Training provider" %>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -5,7 +5,14 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "result_filters/error_message", locals: { error_anchor_id: "location-error" }%>
+    <%= render partial: "result_filters/error_message", locals: {
+      error_anchor_id:
+        if flash[:error] == "Please choose an option" then
+          "location-error"
+        elsif flash[:error] == "Training provider"
+          "provider-error"
+        end
+    }%>
     <%= form_with url: location_path, method: :post do |form| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["l"], form: form %>
       <fieldset class="govuk-fieldset">
@@ -52,11 +59,13 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="query-container">
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless flash[:error] ==  "Training provider" %>" id="query-container">
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
                 <% if flash[:error] == "Training provider" %>
-                  <span class="govuk-error-message" data-qa="provider-error">Please enter the name of a training provider</span>
+                  <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
+                    <span class="govuk-visually-hidden">Error:</span> Please enter the name of a training provider
+                  </span>
                 <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>
@@ -64,7 +73,6 @@
             </div>
           </div>
         </div>
-
         <div class="govuk-form-group">
           <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
         </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -14,7 +14,7 @@
         </legend>
 
         <div class="govuk-form-group">
-          <% if flash[:error] %>
+          <% if flash[:error] == "Please choose an option" %>
             <span id="location-error" class="govuk-error-message">
               <span class="govuk-visually-hidden">Error:</span> Please choose an option
             </span>
@@ -47,13 +47,16 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            
+
             <div class="govuk-radios__conditional">
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
+                <% if flash[:error] == "Training provider" %>
+                  <span class="govuk-error-message" data-qa="provider_error">Please enter the name of a training provider</span>
+                <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>
-              <%= form.text_field :query, class: "govuk-input", data: {qa: "provider_search"} %>
+              <%= form.text_field :query, class: "govuk-input", data: { qa: "provider_search" } %>
             </div>
           </div>
         </div>

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -32,6 +32,22 @@
               %>
               <%= form.label :l_2, "Across England", class: "govuk-label govuk-radios__label" %>
             </div>
+            <div class="govuk-radios__divider">or</div>
+            <div class="govuk-radios__item">
+              <%=
+                form.radio_button(
+                  :l,
+                  "3",
+                  class: "govuk-radios__input",
+                  data: { qa: "by_provider" },
+                  checked: params[:l] == "3"
+                )
+              %>
+              <%= form.text_field :query, data: {qa: "provider_search"} %>
+              <%= form.label :query, class: "govuk-label govuk-radios__label" do %>
+                By school, university or other training provider
+              <% end %>
+            </div>
           </div>
         </div>
 

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -26,7 +26,7 @@
                   :l,
                   "2",
                   class: "govuk-radios__input",
-                  data: { qa: "across_england" },
+                  data: { qa: "across-england" },
                   checked: params[:l] == "2"
                 )
               %>
@@ -39,7 +39,7 @@
                   :l,
                   "3",
                   class: "govuk-radios__input",
-                  data: { qa: "by_provider" },
+                  data: { qa: "by-provider" },
                   checked: params[:l] == "3"
                 )
               %>
@@ -52,17 +52,17 @@
               <%= form.label :query, class: "govuk-label" do %>
                 School, university or other training provider
                 <% if flash[:error] == "Training provider" %>
-                  <span class="govuk-error-message" data-qa="provider_error">Please enter the name of a training provider</span>
+                  <span class="govuk-error-message" data-qa="provider-error">Please enter the name of a training provider</span>
                 <% end %>
               <% end %>
               <span class="govuk-hint">Enter the name or provider code</span>
-              <%= form.text_field :query, class: "govuk-input", data: { qa: "provider_search" } %>
+              <%= form.text_field :query, class: "govuk-input", data: { qa: "provider-search" } %>
             </div>
           </div>
         </div>
 
         <div class="govuk-form-group">
-          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
         </div>
       </fieldset>
     <% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -19,8 +19,9 @@
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-    <details class="govuk-details" role="group" data-qa="search">
-      <summary class="govuk-details__summary" data-qa="search__expand" role="button">
+    <div data-qa="search">
+    <details class="govuk-details" role="group" data-qa="search__expand">
+      <summary class="govuk-details__summary" role="button">
         <span class="govuk-details__summary-text">Try another provider</span>
       </summary>
       <div class="govuk-details__text">

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -1,12 +1,40 @@
-<% @provider_suggestions.each do |provider| %>
-  <%= form_with url: provider_path, method: :post, data: {qa: "provider_suggestion" } do |form| %>
-    <%= render 'result_filters/hidden_fields', exclude_keys: ["query"], form: form %>
-    <%= form.hidden_field :query, value: provider.provider_name %>
-    <%= form.submit "#{provider.provider_name} (#{provider.provider_code})", name: nil, class: "govuk-button", data: { qa: 'provider_suggestion__submit' } %>
-  <% end %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-heading-xl">Pick a provider</h1>
+    </legend>
+    <p>You searched for ‘<%= params["query"] %>’</p>
+    <p>We found these providers which matched your search:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <% @provider_suggestions.each do |provider| %>
+        <li>
+          <%= form_with url: provider_path, method: :post, data: {qa: "provider_suggestion" } do |form| %>
+            <%= render 'result_filters/hidden_fields', exclude_keys: ["query"], form: form %>
+            <%= form.hidden_field :query, value: provider.provider_name %>
+            <%= form.submit "#{provider.provider_name} (#{provider.provider_code})", name: nil, class: "override-button-default govuk-link", data: { qa: 'provider_suggestion__submit' } %>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
 
-<%= form_with url: provider_path, method: :get, data: { qa: "search" } do |form| %>
-  <%= form.text_field :query, data: { qa: "search__input" } %>
-  <%= form.submit "Search again", name: nil, class: "govuk-button", data: { qa: 'search__submit' } %>
-<% end %>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <details class="govuk-details" role="group" data-qa="search">
+      <summary class="govuk-details__summary" data-qa="search__expand" role="button">
+        <span class="govuk-details__summary-text">Try another provider</span>
+      </summary>
+      <div class="govuk-details__text">
+        <%= form_with url: provider_path, method: :get do |form| %>
+          <fieldset class="govuk-fieldset">
+            <%= form.label :query, class: "govuk-label" do %>
+              <strong>School, university or other training provider</strong>
+              <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
+            <% end %>
+            <%= form.text_field :query, class: "govuk-input", data: { qa: "search__input" } %>
+            <%= form.submit "Search again", name: nil, class: "govuk-button", data: { qa: 'search__submit' } %>
+          </fieldset>
+        <% end %>
+      </div>
+    </details>
+  </div>
+</div>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -1,0 +1,7 @@
+<% @provider_suggestions.each do |provider| %>
+  <%= form_with url: provider_path, method: :post, data: {qa: "provider_suggestion" } do |form| %>
+    <%= render 'result_filters/hidden_fields', exclude_keys: ["query"], form: form %>
+    <%= form.hidden_field :query, value: provider.provider_name %>
+    <%= form.submit "#{provider.provider_name} (#{provider.provider_code})", name: nil, class: "govuk-button", data: { qa: 'provider_suggestion__submit' } %>
+  <% end %>
+<% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -5,3 +5,8 @@
     <%= form.submit "#{provider.provider_name} (#{provider.provider_code})", name: nil, class: "govuk-button", data: { qa: 'provider_suggestion__submit' } %>
   <% end %>
 <% end %>
+
+<%= form_with url: provider_path, method: :get, data: { qa: "search" } do |form| %>
+  <%= form.text_field :query, data: { qa: "search__input" } %>
+  <%= form.submit "Search again", name: nil, class: "govuk-button", data: { qa: 'search__submit' } %>
+<% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -7,12 +7,8 @@
     <p>We found these providers which matched your search:</p>
     <ul class="govuk-list govuk-list--bullet">
       <% @provider_suggestions.each do |provider| %>
-        <li>
-          <%= form_with url: provider_path, method: :post, data: {qa: "provider_suggestion" } do |form| %>
-            <%= render 'result_filters/hidden_fields', exclude_keys: ["query"], form: form %>
-            <%= form.hidden_field :query, value: provider.provider_name %>
-            <%= form.submit "#{provider.provider_name} (#{provider.provider_code})", name: nil, class: "override-button-default govuk-link", data: { qa: 'provider_suggestion__submit' } %>
-          <% end %>
+        <li data-qa="provider_suggestion">
+          <%= govuk_link_to "#{provider.provider_name} (#{provider.provider_code})", results_path(filter_params.merge(query: provider.provider_name)), { class: "govuk-link", data: { qa: "provider_suggestion__link" } } %>
         </li>
       <% end %>
     </ul>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -100,7 +100,7 @@
       </fieldset>
 
       <div class="govuk-form-group">
-        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -59,7 +59,7 @@
       </fieldset>
 
       <div class="govuk-form-group">
-        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+        <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
       </div>
     <% end %>
   </div>

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -43,7 +43,7 @@
         </div>
 
         <div class="govuk-form-group">
-          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: 'find_courses' } %>
+          <%= form.submit "Find courses", name: nil, class: "govuk-button", data: { qa: "find-courses" } %>
         </div>
       </fieldset>
     <% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -135,10 +135,9 @@
 }
 
 .override-button-default {
-  background: none!important;
+  background: none !important;
   border: none;
-  padding: 0!important;
-  color: #069;
+  padding: 0 !important;
   text-decoration: underline;
   cursor: pointer;
 }

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -133,3 +133,12 @@
     }
   }
 }
+
+.override-button-default {
+  background: none!important;
+  border: none;
+  padding: 0!important;
+  color: #069;
+  text-decoration: underline;
+  cursor: pointer;
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ Rails.application.routes.draw do
     post "subject", to: "subject#create"
 
     get "provider", to: "provider#new"
-    post "provider", to: "provider#create"
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,9 @@ Rails.application.routes.draw do
 
     get "subject", to: "subject#new"
     post "subject", to: "subject#create"
+
+    get "provider", to: "provider#new"
+    post "provider", to: "provider#create"
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -203,7 +203,6 @@ feature "Location filter", type: :feature do
 
       expect(results_page).to be_displayed
 
-
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -38,10 +38,11 @@ feature "Location filter", type: :feature do
     end
 
     context "selecting by provider" do
-      it "the user can search by provider" do
+      let(:providers) { [build(:provider), build(:provider)] }
+      it "can search by provider" do
         stub_api_v3_resource(
           type: Provider,
-          resources: [],
+          resources: providers,
           fields: { providers: %i[provider_code provider_name] },
           params: { recruitment_cycle_year: 2020 },
           search: "ACME",
@@ -51,7 +52,7 @@ feature "Location filter", type: :feature do
         filter_page.provider_search.fill_in(with: "ACME")
         filter_page.find_courses.click
 
-        expect(provider_page.url).to eq(current_path)
+        expect(current_path).to eq(provider_page.url)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
           "l" => "3",
           "query" => "ACME",
@@ -64,7 +65,7 @@ feature "Location filter", type: :feature do
         it "preserves other selected options" do
           stub_api_v3_resource(
             type: Provider,
-            resources: [],
+            resources: providers,
             fields: { providers: %i[provider_code provider_name] },
             params: { recruitment_cycle_year: 2020 },
             search: "ACME",
@@ -74,7 +75,7 @@ feature "Location filter", type: :feature do
           filter_page.provider_search.fill_in(with: "ACME")
           filter_page.find_courses.click
 
-          expect(provider_page.url).to eq(current_path)
+          expect(current_path).to eq(provider_page.url)
           expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
             "l" => "3",
             "query" => "ACME",
@@ -195,14 +196,13 @@ feature "Location filter", type: :feature do
     end
 
     it "passes arrays correctly" do
-      url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-      PageObjects::Page::ResultFilters::Location.set_url(url_with_array_params)
-
-      filter_page.load
+      #Site prism does not correctly handle array arguments
+      visit location_path(test: [1, 2])
       filter_page.across_england.click
       filter_page.find_courses.click
 
       expect(results_page).to be_displayed
+
 
       expect_page_to_be_displayed_with_query(
         page: results_page,

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Location filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
+  let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
   before do
@@ -32,6 +33,25 @@ feature "Location filter", type: :feature do
         expected_query_params: {
           "l" => "2",
         },
+      )
+    end
+
+    it "Allows the user to select by provider" do
+      stub_api_v3_resource(
+        type: Provider,
+        resources: [],
+        fields: { providers: %i[provider_code provider_name] },
+        params: { recruitment_cycle_year: 2020 },
+        search: "ACME",
+      )
+
+      filter_page.by_provider.click
+      filter_page.provider_search.fill_in(with: "ACME")
+      filter_page.find_courses.click
+
+      expect(provider_page.url).to eq(current_path)
+      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+        "query" => "ACME",
       )
     end
   end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -10,6 +10,13 @@ feature "Location filter", type: :feature do
     stub_results_page_request
   end
 
+  describe "default text" do
+    it "displays the query text specified in the params if it exists" do
+      filter_page.load(query: { query: "marble" })
+      expect(filter_page.provider_search.value).to eq("marble")
+    end
+  end
+
   describe "back link" do
     it "navigates back to the results page" do
       filter_page.load(query: { test: "params" })

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -39,6 +39,10 @@ feature "Provider filter", type: :feature do
     it "Displays an error if provider search is selected but empty" do
       expect(location_filter_page).to have_error
     end
+
+    it "Does not include the query parameter in the params" do
+      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq({})
+    end
   end
 
   context "with a query" do

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Provider filter", type: :feature do
+feature "Provider filter", :focus, type: :feature do
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
@@ -34,12 +34,12 @@ feature "Provider filter", type: :feature do
 
   context "with a query" do
     it "queries the backend" do
-      expect(provider_filter_page.provider_suggestions.first.submit.value).to eq("#{providers.first.provider_name} (#{providers.first.provider_code})")
-      expect(provider_filter_page.provider_suggestions.second.submit.value).to eq("#{providers.second.provider_name} (#{providers.second.provider_code})")
+      expect(provider_filter_page.provider_suggestions.first.hyperlink.text).to eq("#{providers.first.provider_name} (#{providers.first.provider_code})")
+      expect(provider_filter_page.provider_suggestions.second.hyperlink.text).to eq("#{providers.second.provider_name} (#{providers.second.provider_code})")
     end
 
     it "links to the results page" do
-      provider_filter_page.provider_suggestions.first.submit.click
+      provider_filter_page.provider_suggestions.first.hyperlink.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
@@ -52,12 +52,27 @@ feature "Provider filter", type: :feature do
       let(:query_params) { { other_param: "my other param", query: "ACME" } }
 
       it "preserves previous parameters" do
-        provider_filter_page.provider_suggestions.first.submit.click
+        provider_filter_page.provider_suggestions.first.hyperlink.click
         #We must do this because site_prism's URL system is broken
         expect(results_page.url).to eq(current_path)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
           "other_param" => "my other param",
           "query" => "ACME SCITT 2",
+        )
+      end
+    end
+
+    context "with only one provider" do
+      let(:providers) do
+        [
+          build(:provider, provider_name: "ACME SCITT 4", provider_code: "4"),
+        ]
+      end
+
+      it "is automatically selected" do
+        expect(results_page.url).to eq(current_path)
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          "query" => "ACME SCITT 4",
         )
       end
     end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+feature "Provider filter", :focus, type: :feature do
+  let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+
+  let(:providers) do
+    [
+      build(:provider, provider_name: "ACME SCITT 2", provider_code: "2"),
+      build(:provider, provider_name: "ACME SCITT 3", provider_code: "3"),
+    ]
+  end
+
+  let(:provider_request) do
+    stub_api_v3_resource(
+      type: Provider,
+      resources: providers,
+      fields: { providers: %i[provider_code provider_name] },
+      params: { recruitment_cycle_year: 2020 },
+      search: "ACME",
+    )
+  end
+
+  let(:query_params) { {} }
+  before do
+    stub_results_page_request
+
+    provider_request
+
+    provider_filter_page.load(query: query_params)
+  end
+
+  context "with a query" do
+    it "queries the backend" do
+      expect(provider_filter_page.provider_suggestions.first.submit.value).to eq("#{providers.first.provider_name} (#{providers.first.provider_code})")
+      expect(provider_filter_page.provider_suggestions.second.submit.value).to eq("#{providers.second.provider_name} (#{providers.second.provider_code})")
+    end
+
+    it "links to the results page" do
+      provider_filter_page.provider_suggestions.first.submit.click
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "query" => "ACME SCITT 2",
+        },
+      )
+    end
+
+    context "with existing params" do
+      let(:query_params) { { other_param: "my other param" } }
+
+      it "preserves previous parameters" do
+        provider_filter_page.provider_suggestions.first.submit.click
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "other_param" => "my other param",
+            "query" => "ACME SCITT 2",
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -62,6 +62,7 @@ feature "Provider filter", :focus, type: :feature do
   end
 
   it "has a form with which to search again" do
+    provider_filter_page.search.expand.click
     provider_filter_page.search.input.fill_in(with: "ACME SCITT")
     provider_filter_page.search.submit.click
 

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -94,7 +94,7 @@ feature "Provider filter", type: :feature do
       it "redirects to location page with an error" do
         expect(current_path).to eq(location_filter_page.url)
         expect(location_filter_page.error_text.text).to eq("Training provider")
-        expect(location_filter_page.provider_error.text).to eq("Please enter the name of a training provider")
+        expect(location_filter_page.provider_error.text).to eq("Error: Please enter the name of a training provider")
       end
     end
   end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -49,16 +49,26 @@ feature "Provider filter", :focus, type: :feature do
     context "with existing params" do
       let(:query_params) { { other_param: "my other param" } }
 
-      it "preserves previous parameters" do
+      fit "preserves previous parameters" do
         provider_filter_page.provider_suggestions.first.submit.click
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "other_param" => "my other param",
-            "query" => "ACME SCITT 2",
-          },
+        #We must do this because site_prism's URL system is broken
+        expect(results_page.url).to eq(current_path)
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          "other_param" => "my other param",
+          "query" => "ACME SCITT 2",
         )
       end
     end
+  end
+
+  it "has a form with which to search again" do
+    provider_filter_page.search.input.fill_in(with: "ACME SCITT")
+    provider_filter_page.search.submit.click
+
+    expect(provider_filter_page.url).to eq(current_path)
+    expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+      "query" => "ACME SCITT",
+      "utf8" => "✓",
+    )
   end
 end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -97,6 +97,9 @@ feature "Provider filter", type: :feature do
 
       it "redirects to location page with an error" do
         expect(current_path).to eq(location_filter_page.url)
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          "query" => "ACME",
+        )
         expect(location_filter_page.error_text.text).to eq("Training provider")
         expect(location_filter_page.provider_error.text).to eq("Error: Please enter the name of a training provider")
       end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-feature "Provider filter", :focus, type: :feature do
+feature "Provider filter", type: :feature do
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
@@ -17,11 +17,13 @@ feature "Provider filter", :focus, type: :feature do
       resources: providers,
       fields: { providers: %i[provider_code provider_name] },
       params: { recruitment_cycle_year: 2020 },
-      search: "ACME",
+      search: search_term,
     )
   end
 
-  let(:query_params) { {} }
+  let(:search_term) { "ACME" }
+  let(:query_params) { { query: "ACME" } }
+
   before do
     stub_results_page_request
 
@@ -47,9 +49,9 @@ feature "Provider filter", :focus, type: :feature do
     end
 
     context "with existing params" do
-      let(:query_params) { { other_param: "my other param" } }
+      let(:query_params) { { other_param: "my other param", query: "ACME" } }
 
-      fit "preserves previous parameters" do
+      it "preserves previous parameters" do
         provider_filter_page.provider_suggestions.first.submit.click
         #We must do this because site_prism's URL system is broken
         expect(results_page.url).to eq(current_path)
@@ -62,6 +64,14 @@ feature "Provider filter", :focus, type: :feature do
   end
 
   it "has a form with which to search again" do
+    stub_api_v3_resource(
+      type: Provider,
+      resources: [],
+      fields: { providers: %i[provider_code provider_name] },
+      params: { recruitment_cycle_year: 2020 },
+      search: "ACME SCITT",
+    )
+
     provider_filter_page.search.expand.click
     provider_filter_page.search.input.fill_in(with: "ACME SCITT")
     provider_filter_page.search.submit.click

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -23,7 +23,7 @@ feature "Provider filter", type: :feature do
   end
 
   let(:search_term) { "ACME" }
-  let(:query_params) { { query: "ACME" } }
+  let(:query_params) { { query: search_term } }
 
   before do
     stub_results_page_request
@@ -31,6 +31,14 @@ feature "Provider filter", type: :feature do
     provider_request
 
     provider_filter_page.load(query: query_params)
+  end
+
+  context "with an empty search" do
+    let(:query_params) { "   " }
+
+    it "Displays an error if provider search is selected but empty" do
+      expect(location_filter_page).to have_error
+    end
   end
 
   context "with a query" do

--- a/spec/site_prism/page_objects/page/result_filters/funding.rb
+++ b/spec/site_prism/page_objects/page/result_filters/funding.rb
@@ -7,7 +7,7 @@ module PageObjects
         element :back_link, '[data-qa="page-back"]'
         element :all_courses, '[data-qa="all_courses"]'
         element :salary_courses, '[data-qa="salary_courses"]'
-        element :find_courses, '[data-qa="find_courses"]'
+        element :find_courses, '[data-qa="find-courses"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -7,6 +7,8 @@ module PageObjects
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
         element :across_england, '[data-qa="across_england"]'
+        element :by_provider, '[data-qa="by_provider"]'
+        element :provider_search, '[data-qa="provider_search"]'
         element :find_courses, '[data-qa="find_courses"]'
       end
     end

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -8,11 +8,11 @@ module PageObjects
         element :error, '[data-qa="error"]'
         element :error_text, '[data-qa="error__text"]'
         element :error_heading, '[data-qa="error__heading"]'
-        element :across_england, '[data-qa="across_england"]'
-        element :by_provider, '[data-qa="by_provider"]'
-        element :provider_error, '[data-qa="provider_error"]'
-        element :provider_search, '[data-qa="provider_search"]'
-        element :find_courses, '[data-qa="find_courses"]'
+        element :across_england, '[data-qa="across-england"]'
+        element :by_provider, '[data-qa="by-provider"]'
+        element :provider_error, '[data-qa="provider-error"]'
+        element :provider_search, '[data-qa="provider-search"]'
+        element :find_courses, '[data-qa="find-courses"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -6,8 +6,11 @@ module PageObjects
 
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
+        element :error_text, '[data-qa="error__text"]'
+        element :error_heading, '[data-qa="error__heading"]'
         element :across_england, '[data-qa="across_england"]'
         element :by_provider, '[data-qa="by_provider"]'
+        element :provider_error, '[data-qa="provider_error"]'
         element :provider_search, '[data-qa="provider_search"]'
         element :find_courses, '[data-qa="find_courses"]'
       end

--- a/spec/site_prism/page_objects/page/result_filters/provider_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/provider_page.rb
@@ -13,6 +13,7 @@ module PageObjects
 
         section :search, '[data-qa="search"]' do
           element :input, '[data-qa="search__input"]'
+          element :expand, '[data-qa="search__expand"]'
           element :submit, '[data-qa="search__submit"]'
         end
         sections :provider_suggestions, ProviderSuggestion, '[data-qa="provider_suggestion"]'

--- a/spec/site_prism/page_objects/page/result_filters/provider_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/provider_page.rb
@@ -11,6 +11,10 @@ module PageObjects
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
 
+        section :search, '[data-qa="search"]' do
+          element :input, '[data-qa="search__input"]'
+          element :submit, '[data-qa="search__submit"]'
+        end
         sections :provider_suggestions, ProviderSuggestion, '[data-qa="provider_suggestion"]'
       end
     end

--- a/spec/site_prism/page_objects/page/result_filters/provider_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/provider_page.rb
@@ -1,0 +1,18 @@
+module PageObjects
+  module Page
+    module ResultFilters
+      class ProviderPage < SitePrism::Page
+        set_url "/results/filter/provider{?query*}"
+
+        class ProviderSuggestion < SitePrism::Section
+          element :submit, '[data-qa="provider_suggestion__submit"]'
+        end
+
+        element :back_link, '[data-qa="page-back"]'
+        element :error, '[data-qa="error"]'
+
+        sections :provider_suggestions, ProviderSuggestion, '[data-qa="provider_suggestion"]'
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/result_filters/provider_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/provider_page.rb
@@ -5,7 +5,7 @@ module PageObjects
         set_url "/results/filter/provider{?query*}"
 
         class ProviderSuggestion < SitePrism::Section
-          element :submit, '[data-qa="provider_suggestion__submit"]'
+          element :hyperlink, '[data-qa="provider_suggestion__link"]'
         end
 
         element :back_link, '[data-qa="page-back"]'

--- a/spec/site_prism/page_objects/page/result_filters/qualification.rb
+++ b/spec/site_prism/page_objects/page/result_filters/qualification.rb
@@ -9,7 +9,7 @@ module PageObjects
         element :qts_only, '[data-qa="qts_only"]'
         element :pgde_pgce_with_qts, '[data-qa="pgde_pgce_with_qts"]'
         element :other, '[data-qa="other"]'
-        element :find_courses, '[data-qa="find_courses"]'
+        element :find_courses, '[data-qa="find-courses"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/study_type.rb
+++ b/spec/site_prism/page_objects/page/result_filters/study_type.rb
@@ -8,7 +8,7 @@ module PageObjects
         element :error, '[data-qa="error"]'
         element :full_time, '[data-qa="full_time"]'
         element :part_time, '[data-qa="part_time"]'
-        element :find_courses, '[data-qa="find_courses"]'
+        element :find_courses, '[data-qa="find-courses"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -1,19 +1,20 @@
 module PageObjects
   module Page
     module ResultFilters
-      class Subject < SitePrism::Section
-        element :name, '[data-qa="subject__name"]'
-        element :checkbox, '[data-qa="subject__checkbox"]'
-      end
-
-      class SubjectAreaSection < SitePrism::Section
-        element :name, '[data-qa="subject_area__name"]'
-        element :accordion_button, '[data-qa="subject_area__accordion_button"]'
-        sections :subjects, Subject, '[data-qa="subject"]'
-      end
-
       class SubjectPage < SitePrism::Page
         set_url "/results/filter/subject{?query*}"
+
+        class SubjectAreaSection < SitePrism::Section
+          class Subject < SitePrism::Section
+            element :name, '[data-qa="subject__name"]'
+            element :checkbox, '[data-qa="subject__checkbox"]'
+          end
+
+          element :name, '[data-qa="subject_area__name"]'
+          element :accordion_button, '[data-qa="subject_area__accordion_button"]'
+          sections :subjects, Subject, '[data-qa="subject"]'
+        end
+
         sections :subject_areas, SubjectAreaSection, '[data-qa="subject_area"]'
         element :continue, '[data-qa="continue"]'
       end

--- a/spec/site_prism/page_objects/page/result_filters/vacancy.rb
+++ b/spec/site_prism/page_objects/page/result_filters/vacancy.rb
@@ -8,7 +8,7 @@ module PageObjects
         element :error, '[data-qa="error"]'
         element :with_vacancies, '[data-qa="with_vacancies"]'
         element :with_and_without_vacancies, '[data-qa="with_and_without_vacancies"]'
-        element :find_courses, '[data-qa="find_courses"]'
+        element :find_courses, '[data-qa="find-courses"]'
       end
     end
   end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -10,7 +10,7 @@ module PageObjects
     end
 
     class Results < SitePrism::Page
-      set_url "/results{?query*}"
+      set_url "/results"
 
       sections :courses, CourseSection, '[data-qa="course"]'
 

--- a/spec/support/api_v3_url.rb
+++ b/spec/support/api_v3_url.rb
@@ -1,4 +1,4 @@
-def api_v3_url(type:, params:, fields: nil, include: nil, pagination: nil)
+def api_v3_url(type:, params:, fields: nil, include: nil, pagination: nil, search: nil)
   query_params = {}
   unless fields.nil?
     query_params[:fields] = fields.to_h do |model_name, model_fields|
@@ -7,6 +7,7 @@ def api_v3_url(type:, params:, fields: nil, include: nil, pagination: nil)
   end
   query_params[:include] = include.join(",") unless include.nil?
   query_params[:page] = pagination unless pagination.nil?
+  query_params[:search] = search unless search.nil?
   key = params[type.primary_key]
 
   url = "/#{type.path(**params)}"

--- a/spec/support/stub_api_v3_resource.rb
+++ b/spec/support/stub_api_v3_resource.rb
@@ -1,6 +1,6 @@
-def stub_api_v3_resource(type:, resources:, params: {}, links: nil, fields: nil, include: nil, pagination: nil)
+def stub_api_v3_resource(type:, resources:, params: {}, links: nil, fields: nil, include: nil, pagination: nil, search: nil)
   stub_api_v3_request(
-    api_v3_url(type: type, params: params, fields: fields, include: include, pagination: pagination),
+    api_v3_url(type: type, params: params, fields: fields, include: include, pagination: pagination, search: search),
     resource_to_jsonapi(resources, include: include, links: links),
   )
 end


### PR DESCRIPTION
### Context
As of yet users cannot filter by provider as they can on Search and Compare, in order to replace Search and Compare this functionality should be implemented.
https://www.find-postgraduate-teacher-training.service.gov.uk/?l=3

### Changes proposed in this pull request
Implement a search without Javascript and a filter/search results page for searching by provider.

### Guidance to review

