### PR TITLE
[2771] Added study type filter on the results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -16,6 +16,14 @@ class ResultsView
     "#{base_path}?#{URI.encode_www_form(query_parameters_with_defaults)}".gsub("%2C", ",")
   end
 
+  def fulltime?
+    query_parameters["fulltime"].present? && query_parameters["fulltime"].downcase == "true"
+  end
+
+  def parttime?
+    query_parameters["parttime"].present? && query_parameters["parttime"].downcase == "true"
+  end
+
 private
 
   attr_reader :query_parameters
@@ -25,11 +33,11 @@ private
   end
 
   def fulltime_parameters
-    { "fulltime" => query_parameters["fulltime"].presence || "False" }
+    { "fulltime" => fulltime?.to_s.humanize }
   end
 
   def parttime_parameters
-    { "parttime" => query_parameters["parttime"].presence || "False" }
+    { "parttime" => parttime?.to_s.humanize }
   end
 
   def hasvacancies_parameters

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -21,11 +21,12 @@
             </span>
           <% end %>
           <div class="govuk-checkboxes">
+          <% default_to_true = (params[:fulltime] != "True" && params[:parttime] != "True")%>
             <div class="govuk-checkboxes__item">
               <%=
                 form.check_box(
                   :fulltime,
-                  { class: "govuk-checkboxes__input", data: { qa: 'full_time'}, checked: params[:fulltime] == "True" },
+                  { class: "govuk-checkboxes__input", data: { qa: 'full_time'}, checked: params[:fulltime] == "True" || default_to_true },
                   "True",
                   "False"
                 )
@@ -42,7 +43,7 @@
               <%=
                 form.check_box(
                   :parttime,
-                  { class: "govuk-checkboxes__input", data: { qa: 'part_time'}, checked: params[:parttime] == "True" },
+                  { class: "govuk-checkboxes__input", data: { qa: 'part_time'}, checked: params[:parttime] == "True" || default_to_true },
                   "True",
                   "False"
                 )

--- a/app/views/results/_study_type.html.erb
+++ b/app/views/results/_study_type.html.erb
@@ -1,0 +1,15 @@
+<div class="filter-form" data-qa="filters__studytype">
+  <h2 class="govuk-heading-s filter-form__title">
+    Study type<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <% default_to_true = (!@results_view.fulltime? && !@results_view.parttime?) %>
+    <% if @results_view.fulltime? || default_to_true %>
+      <li data-qa="fulltime">Full time (12 months)</li>
+    <% end %>
+    <% if @results_view.parttime? || default_to_true %>
+      <li data-qa="parttime">Part time (18 - 24 months)</li>
+    <% end %>
+    </ul>
+  <%= link_to "Change study type", @results_view.filter_path_with_unescaped_commas(studytype_path), class: "govuk-link", data: { qa: "link" } %>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -17,9 +17,7 @@
         <div>
           <%=link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "filters__subject_link" }%>
         </div>
-        <div>
-          <%=link_to "Change study type", @results_view.filter_path_with_unescaped_commas(studytype_path), class: "govuk-link", data: { qa: "filters__studytype_link" }%>
-        </div>
+        <%= render partial: 'results/study_type' %>
         <div>
           <%=link_to "Change qualifications", @results_view.filter_path_with_unescaped_commas(qualification_path), class: "govuk-link", data: { qa: "filters__qualifications_link" }%>
         </div>

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -20,25 +20,19 @@ feature "Study type filter", type: :feature do
     end
   end
 
-  describe "Selecting an option" do
+
+  describe "deselecting an option" do
     before { filter_page.load }
 
-    it "Allows the user to select full time" do
+    it "default full time and part time to true" do
+      expect(filter_page.full_time.checked?).to be true
+      expect(filter_page.part_time.checked?).to be true
+    end
+
+    it "Allows the user to deselect full time" do
       filter_page.full_time.click
       filter_page.find_courses.click
 
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "True",
-          "parttime" => "False",
-        },
-      )
-    end
-
-    it "Allows the user to select part time" do
-      filter_page.part_time.click
-      filter_page.find_courses.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
@@ -48,9 +42,19 @@ feature "Study type filter", type: :feature do
       )
     end
 
-    it "Allows the user to select both full and part time" do
-      filter_page.full_time.click
+    it "Allows the user to deselect part time" do
       filter_page.part_time.click
+      filter_page.find_courses.click
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          "fulltime" => "True",
+          "parttime" => "False",
+        },
+      )
+    end
+
+    it "Allows the user to find courses" do
       filter_page.find_courses.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
@@ -77,6 +81,10 @@ feature "Study type filter", type: :feature do
   describe "Validation" do
     it "Displays an error if neither option is selected" do
       filter_page.load
+
+      filter_page.part_time.click
+      filter_page.full_time.click
+
       filter_page.find_courses.click
 
       expect(filter_page).to have_error
@@ -85,8 +93,8 @@ feature "Study type filter", type: :feature do
 
   describe "QS parameters" do
     it "passes querystring parameters to results" do
-      filter_page.load(query: { test: "value" })
-      filter_page.part_time.click
+      filter_page.load(query: { test: "value", parttime: "True" })
+
       filter_page.find_courses.click
 
       expect_page_to_be_displayed_with_query(
@@ -112,8 +120,8 @@ feature "Study type filter", type: :feature do
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          "fulltime" => "False",
-          "parttime" => "True",
+          "fulltime" => "True",
+          "parttime" => "False",
           "test" => "1,2",
         },
       )

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+feature "results", type: :feature do
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:params) {}
+
+  before do
+    stub_results_page_request
+    visit results_path(params)
+  end
+
+  describe "filters defaults without query string" do
+    it "has study type filter" do
+      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+      expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
+      expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
+      expect(results_page.study_type_filter.link).to have_content("Change study type")
+    end
+  end
+
+  describe "filters defaults with query string" do
+    let(:params) { { fulltime: "False", parttime: "False" } }
+
+    it "has study type filter" do
+      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+      expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
+      expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
+      expect(results_page.study_type_filter.link).to have_content("Change study type")
+    end
+  end
+
+  describe "filters with query string" do
+    let(:params) { { fulltime: "True", parttime: "False" } }
+
+    it "has study type filter for full time only" do
+      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+      expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
+      expect(results_page.study_type_filter).not_to have_parttime
+      expect(results_page.study_type_filter.link).to have_content("Change study type")
+    end
+  end
+
+  describe "filters with query string" do
+    let(:params) { { fulltime: "False", parttime: "True" } }
+
+    it "has study type filter for part time only" do
+      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+      expect(results_page.study_type_filter).not_to have_fulltime
+      expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
+      expect(results_page.study_type_filter.link).to have_content("Change study type")
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -9,17 +9,25 @@ module PageObjects
       element :main_address, '[data-qa="course__main_address"]'
     end
 
+    class StudyTypeSection < SitePrism::Section
+      element :subheading, "h2"
+      element :fulltime, '[data-qa="fulltime"]'
+      element :parttime, '[data-qa="parttime"]'
+      element :link, '[data-qa="link"]'
+    end
+
     class Results < SitePrism::Page
       set_url "/results{?query*}"
 
       sections :courses, CourseSection, '[data-qa="course"]'
+      section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'
+
 
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
 
       element :location_link, '[data-qa="filters__location_link"]'
       element :subject_link, '[data-qa="filters__subject"]'
-      element :study_type_link, '[data-qa="filters__study_type_link"]'
       element :qualification_link, '[data-qa="filters__qualification_link"]'
       element :salary_link, '[data-qa="filters__salary_link"]'
       element :vacancies_link, '[data-qa="filters__vacancies_link"]'


### PR DESCRIPTION
### Context
The study type filter on the results page

### Changes proposed in this pull request
Added the study type filter on the results page

if both 'fulltime' and `partime` is omitted or is `False`, the default it to be `true`

### Guidance to review

![image](https://user-images.githubusercontent.com/470137/73463518-4c62cf00-4375-11ea-8d17-9f4c4ea34dc0.png)

:confounded: 

go to `/results` and 
`/results/filter/studytype?`

apart from the actual filtering of the results 