### PR TITLE
[2781] Added vacancies filter on the results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -24,6 +24,10 @@ class ResultsView
     query_parameters["parttime"].present? && query_parameters["parttime"].downcase == "true"
   end
 
+  def hasvacancies?
+    query_parameters["hasvacancies"].blank? || query_parameters["hasvacancies"].downcase == "true"
+  end
+
 private
 
   attr_reader :query_parameters
@@ -41,7 +45,7 @@ private
   end
 
   def hasvacancies_parameters
-    { "hasvacancies" => query_parameters["hasvacancies"].presence || "True" }
+    { "hasvacancies" => hasvacancies?.to_s.humanize }
   end
 
   def sen_courses_parameters

--- a/app/views/results/_vacancy.html.erb
+++ b/app/views/results/_vacancy.html.erb
@@ -1,0 +1,15 @@
+<div class="filter-form" data-qa="filters__vacancies">
+  <h2 class="govuk-heading-s filter-form__title">
+    Vacancies<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <li data-qa="vacancies">
+      <% if @results_view.hasvacancies? %>
+        Only courses with vacancies
+      <% else %>
+        Courses with and without vacancies
+      <% end %>
+    </li>
+  </ul>
+  <%= link_to "Change vacancies", @results_view.filter_path_with_unescaped_commas(vacancy_path), class: "govuk-link", data: { qa: "link" } %>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -24,9 +24,7 @@
         <div>
           <%=link_to "Change salary option", @results_view.filter_path_with_unescaped_commas(funding_path), class: "govuk-link", data: { qa: "filters__salary_link" }%>
         </div>
-        <div>
-          <%=link_to "Change vacancies", @results_view.filter_path_with_unescaped_commas(vacancy_path), class: "govuk-link", data: { qa: "filters__vacancy_link" }%>
-        </div>
+        <%= render partial: 'results/vacancy' %>
       </div>
     </div>
     <div class="govuk-grid-column-two-thirds">

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -16,10 +16,16 @@ feature "results", type: :feature do
       expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
       expect(results_page.study_type_filter.link).to have_content("Change study type")
     end
+
+    it "has vacancies filter" do
+      expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
+      expect(results_page.vacancies_filter.vacancies).to have_content("Only courses with vacancies")
+      expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
+    end
   end
 
   describe "filters defaults with query string" do
-    let(:params) { { fulltime: "False", parttime: "False" } }
+    let(:params) { { fulltime: "False", parttime: "False", hasvacancies: "True" } }
 
     it "has study type filter" do
       expect(results_page.study_type_filter.subheading).to have_content("Study type:")
@@ -27,27 +33,59 @@ feature "results", type: :feature do
       expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
       expect(results_page.study_type_filter.link).to have_content("Change study type")
     end
-  end
 
-  describe "filters with query string" do
-    let(:params) { { fulltime: "True", parttime: "False" } }
-
-    it "has study type filter for full time only" do
-      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
-      expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
-      expect(results_page.study_type_filter).not_to have_parttime
-      expect(results_page.study_type_filter.link).to have_content("Change study type")
+    it "has vacancies filter" do
+      expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
+      expect(results_page.vacancies_filter.vacancies).to have_content("Only courses with vacancies")
+      expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
     end
   end
 
   describe "filters with query string" do
-    let(:params) { { fulltime: "False", parttime: "True" } }
+    describe "study type filter" do
+      context "for full time only" do
+        let(:params) { { fulltime: "True", parttime: "False" } }
 
-    it "has study type filter for part time only" do
-      expect(results_page.study_type_filter.subheading).to have_content("Study type:")
-      expect(results_page.study_type_filter).not_to have_fulltime
-      expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
-      expect(results_page.study_type_filter.link).to have_content("Change study type")
+        it "has study type filter for full time only " do
+          expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+          expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
+          expect(results_page.study_type_filter).not_to have_parttime
+          expect(results_page.study_type_filter.link).to have_content("Change study type")
+        end
+      end
+
+      context "for part time only" do
+        let(:params) { { fulltime: "False", parttime: "True" } }
+
+        it "has study type filter for part time only" do
+          expect(results_page.study_type_filter.subheading).to have_content("Study type:")
+          expect(results_page.study_type_filter).not_to have_fulltime
+          expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
+          expect(results_page.study_type_filter.link).to have_content("Change study type")
+        end
+      end
+    end
+
+    describe "vacancies filter" do
+      context "only courses with vacancies" do
+        let(:params) { { hasvacancies: "True" } }
+
+        it "has vacancies filter" do
+          expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
+          expect(results_page.vacancies_filter.vacancies).to have_content("Only courses with vacancies")
+          expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
+        end
+      end
+
+      context "courses with and without vacancies" do
+        let(:params) { { hasvacancies: "False" } }
+
+        it "has vacancies filter" do
+          expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
+          expect(results_page.vacancies_filter.vacancies).to have_content("Courses with and without vacancies")
+          expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
+        end
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -16,12 +16,18 @@ module PageObjects
       element :link, '[data-qa="link"]'
     end
 
+    class VacanciesSection < SitePrism::Section
+      element :subheading, "h2"
+      element :vacancies, '[data-qa="vacancies"]'
+      element :link, '[data-qa="link"]'
+    end
+
     class Results < SitePrism::Page
       set_url "/results{?query*}"
 
       sections :courses, CourseSection, '[data-qa="course"]'
       section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'
-
+      section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
 
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'


### PR DESCRIPTION
### Context

The vacancies filter on the results page

### Changes proposed in this pull request
Added vacancies filter on the results page

### Guidance to review

![image](https://user-images.githubusercontent.com/470137/73558303-ce70f780-444a-11ea-98c8-05bfbf42e8c3.png)

go to `/results` and
`/results/filter/vacancy?`

apart from the actual filtering of the results