### PR TITLE
[2843] Add SEND to subject filter

### DIFF
--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -2,6 +2,7 @@ module ResultFilters
   class SubjectController < ApplicationController
     include FilterParameters
     include CsharpRailsSubjectConversionHelper
+    before_action { params["senCourses"].downcase! if params["senCourses"].present? }
 
     def new
       params["subjects"] = convert_csharp_subject_id_params_to_rails if convert_csharp_subject_id_params_to_rails.present?

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -51,7 +51,7 @@
           <div class="govuk-accordion__section" data-qa="send_area">
             <div class="govuk-accordion__section-header">
               <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="null-content-1" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "True" then "true" else "false" end %>">
+                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="null-content-1" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">
                   Special educational needs and disability (SEND)
                 </button>
               </h2>
@@ -60,7 +60,7 @@
             <div class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
               <div class="govuk-checkboxes">
                 <div class="govuk-checkboxes__item" data-qa="subject">
-                  <%= f.check_box(:senCourses, { checked: params[:senCourses] == "True", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'True', nil) %>
+                  <%= f.check_box(:senCourses, { checked: params[:senCourses] == "true", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'true', nil) %>
                   <%= f.label(:subjects, {for: "subject_send", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
                     <span class="govuk-checkboxes__label_text">
                       Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -48,6 +48,29 @@
               </div>
             </div>
           <% end %>
+          <div class="govuk-accordion__section" data-qa="send_area">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
+                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="null-content-1" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "True" then "true" else "false" end %>">
+                  Special educational needs and disability (SEND)
+                </button>
+              </h2>
+              <span class="govuk-accordion__icon" aria-hidden="true"></span>
+            </div>
+            <div class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
+              <div class="govuk-checkboxes">
+                <div class="govuk-checkboxes__item" data-qa="subject">
+                  <%= f.check_box(:senCourses, { checked: params[:senCourses] == "True", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'True', nil) %>
+                  <%= f.label(:subjects, {for: "subject_send", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
+                    <span class="govuk-checkboxes__label_text">
+                      Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
+                    </span>
+                    <span class="govuk-!-display-block"></span>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
 
         <%= f.submit("Find courses", name: nil, data: {qa: "continue"}, class: "govuk-button" )%>

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -37,10 +37,6 @@ feature "Subject filter", type: :feature do
       subject_filter_page.subject_areas.second.then do |subject_area|
         expect(subject_area.name.text).to eq("Secondary")
       end
-
-      subject_filter_page.send_area.then do |subject_area|
-        expect(subject_area.name.text).to eq("Special educational needs and disability (SEND)")
-      end
     end
 
     it "displays all subjects" do

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -26,6 +26,7 @@ feature "Subject filter", type: :feature do
   context "with no selected subjects" do
     it "doesn't expand the accordion" do
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')
+      expect(subject_filter_page.send_area.accordion_button).to match_selector('[aria-expanded="false"]')
     end
 
     it "displays all subject areas" do
@@ -36,6 +37,10 @@ feature "Subject filter", type: :feature do
       subject_filter_page.subject_areas.second.then do |subject_area|
         expect(subject_area.name.text).to eq("Secondary")
       end
+
+      subject_filter_page.send_area.then do |subject_area|
+        expect(subject_area.name.text).to eq("Special educational needs and disability (SEND)")
+      end
     end
 
     it "displays all subjects" do
@@ -45,6 +50,11 @@ feature "Subject filter", type: :feature do
         end
         subject_area.subjects.second.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.second.subject_name)
+        end
+      end
+      subject_filter_page.send_area.then do |subject_area|
+        subject_area.subjects.first.then do |subject|
+          expect(subject.name.text).to eq("Show only courses with a SEND specialism")
         end
       end
     end
@@ -63,11 +73,13 @@ feature "Subject filter", type: :feature do
     it "can select multiple checkboxes and filter appropriately" do
       subject_filter_page.subject_areas.first.subjects.first.checkbox.click
       subject_filter_page.subject_areas.first.subjects.second.checkbox.click
+      subject_filter_page.send_area.subjects.first.checkbox.click
       subject_filter_page.continue.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
           "subjects" => "31,1",
+          "senCourses" => "True",
         },
       )
     end
@@ -75,8 +87,9 @@ feature "Subject filter", type: :feature do
 
   context "with previously selected subjects" do
     it "automatically selects the given checkboxes" do
-      subject_filter_page.load(query: { subjects: "31" })
+      subject_filter_page.load(query: { subjects: "31", senCourses: "True" })
       expect(subject_filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
+      expect(subject_filter_page.send_area.subjects.first.checkbox).to be_checked
     end
   end
 
@@ -94,8 +107,9 @@ feature "Subject filter", type: :feature do
     end
 
     it "auto expands the accordion" do
-      subject_filter_page.load(query: { subjects: "31,1", other_param: "param_value" })
+      subject_filter_page.load(query: { subjects: "31,1", other_param: "param_value", senCourses: "True" })
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="true"]')
+      expect(subject_filter_page.send_area.accordion_button).to match_selector('[aria-expanded="true"]')
     end
   end
 

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -79,7 +79,7 @@ feature "Subject filter", type: :feature do
         page: results_page,
         expected_query_params: {
           "subjects" => "31,1",
-          "senCourses" => "True",
+          "senCourses" => "true",
         },
       )
     end
@@ -87,8 +87,13 @@ feature "Subject filter", type: :feature do
 
   context "with previously selected subjects" do
     it "automatically selects the given checkboxes" do
-      subject_filter_page.load(query: { subjects: "31", senCourses: "True" })
+      subject_filter_page.load(query: { subjects: "31", senCourses: "true" })
       expect(subject_filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
+      expect(subject_filter_page.send_area.subjects.first.checkbox).to be_checked
+    end
+
+    it "automatically selects the given checkboxes with C# casing" do
+      subject_filter_page.load(query: { senCourses: "True" })
       expect(subject_filter_page.send_area.subjects.first.checkbox).to be_checked
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -15,6 +15,7 @@ module PageObjects
       class SubjectPage < SitePrism::Page
         set_url "/results/filter/subject{?query*}"
         sections :subject_areas, SubjectAreaSection, '[data-qa="subject_area"]'
+        section :send_area, SubjectAreaSection, '[data-qa="send_area"]'
         element :continue, '[data-qa="continue"]'
       end
     end


### PR DESCRIPTION
### Context
```
As a user
I need/want to filter my search by whether or not the subject is a SEND course
So that I can find SEND courses
```

### Changes proposed in this pull request

Add the accordion Special educational needs and disabilities (SEND) with a single checkbox: 'Show only courses with a SEND specialism' that passes the `senCourses` parameter as true/false.

<kbd>
<img width="650" alt="send" src="https://user-images.githubusercontent.com/38078064/73736319-7ed74800-4738-11ea-9d35-3626d2670fe5.png">
</kbd>

### Guidance to review

:ship:

* https://s121d02-2843-find-as.azurewebsites.net/results/filter/subject?qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=True