### PR TITLE
[2776] Add the salary filter display to the results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -28,6 +28,10 @@ class ResultsView
     query_parameters["hasvacancies"].blank? || query_parameters["hasvacancies"].downcase == "true"
   end
 
+  def with_salaries?
+    query_parameters["funding"] == "8"
+  end
+
 private
 
   attr_reader :query_parameters

--- a/app/views/results/_funding.html.erb
+++ b/app/views/results/_funding.html.erb
@@ -1,0 +1,15 @@
+<div class="filter-form" data-qa="filters__funding">
+  <h2 class="govuk-heading-s filter-form__title">
+    Salary<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <li data-qa="funding">
+      <% if @results_view.with_salaries? %>
+        Only courses with a salary
+      <% else %>
+        Courses with and without salary
+      <% end %>
+    </li>
+  </ul>
+  <%= link_to "Change salary option", @results_view.filter_path_with_unescaped_commas(funding_path), class: "govuk-link", data: { qa: "link" } %>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -22,7 +22,7 @@
           <%=link_to "Change qualifications", @results_view.filter_path_with_unescaped_commas(qualification_path), class: "govuk-link", data: { qa: "filters__qualifications_link" }%>
         </div>
         <div>
-          <%=link_to "Change salary option", @results_view.filter_path_with_unescaped_commas(funding_path), class: "govuk-link", data: { qa: "filters__salary_link" }%>
+          <%= render partial: 'results/funding' %>
         </div>
         <%= render partial: 'results/vacancy' %>
       </div>

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -86,6 +86,30 @@ feature "results", type: :feature do
           expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
         end
       end
+
+      describe "salary filter" do
+        context "only courses with salaries" do
+          let(:params) { { funding: "8" } }
+
+          it "has salaries filter" do
+            expect(results_page.funding_filter.funding).to have_content("Only courses with a salary")
+          end
+        end
+
+        context "courses with and without salaries" do
+          let(:params) { { funding: "15" } }
+
+          it "has salaries filter" do
+            expect(results_page.funding_filter.funding).to have_content("Courses with and without salary")
+          end
+        end
+
+        context "without any parameters" do
+          it "defaults to courses with and without salaries" do
+            expect(results_page.funding_filter.funding).to have_content("Courses with and without salary")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -23,9 +23,7 @@ module PageObjects
     end
 
     class FundingSection < SitePrism::Section
-      element :subheading, "h2"
       element :funding, '[data-qa="funding"]'
-      element :link, '[data-qa="link"]'
     end
 
     class Results < SitePrism::Page
@@ -44,7 +42,6 @@ module PageObjects
       element :qualification_link, '[data-qa="filters__qualification_link"]'
       element :salary_link, '[data-qa="filters__salary_link"]'
       element :vacancies_link, '[data-qa="filters__vacancies_link"]'
-      element :funding_link, '[data-qa="filters__funding_link"]'
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -22,12 +22,19 @@ module PageObjects
       element :link, '[data-qa="link"]'
     end
 
+    class FundingSection < SitePrism::Section
+      element :subheading, "h2"
+      element :funding, '[data-qa="funding"]'
+      element :link, '[data-qa="link"]'
+    end
+
     class Results < SitePrism::Page
       set_url "/results{?query*}"
 
       sections :courses, CourseSection, '[data-qa="course"]'
       section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'
       section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
+      section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
 
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
@@ -37,6 +44,7 @@ module PageObjects
       element :qualification_link, '[data-qa="filters__qualification_link"]'
       element :salary_link, '[data-qa="filters__salary_link"]'
       element :vacancies_link, '[data-qa="filters__vacancies_link"]'
+      element :funding_link, '[data-qa="filters__funding_link"]'
     end
   end
 end


### PR DESCRIPTION
### Context

* Displays the filter state as it exists on the [C# results page](https://find-postgraduate-teacher-training.education.gov.uk/results?lat=55.953252&lng=-3.188267&rad=100&loc=Edinburgh,%20UK&lq=Edinburgh,%20UK&l=1&subjects=44&sortby=2&funding=8&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False).
* Wording is (as appropriate):
  - "Courses with and without salary"
  - "Only courses with a salary"
* Defaults to "Courses with and without salary"

### Changes proposed in this pull request
<img width="317" alt="all" src="https://user-images.githubusercontent.com/38078064/73745737-99ff8300-474b-11ea-8719-d55e7d4aa4c5.png">
<img width="317" alt="with" src="https://user-images.githubusercontent.com/38078064/73745739-9c61dd00-474b-11ea-9da3-32039db5dc46.png">

Co-authored with @faissalMT 