### PR TITLE
[2778] Add the qualifications filter display to the results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -28,6 +28,22 @@ class ResultsView
     query_parameters["hasvacancies"].blank? || query_parameters["hasvacancies"].downcase == "true"
   end
 
+  def qts_only?
+    qualifications_parameters_array.include?("QtsOnly")
+  end
+
+  def pgce_or_pgde_with_qts?
+    qualifications_parameters_array.include?("PgdePgceWithQts")
+  end
+
+  def other_qualifications?
+    qualifications_parameters_array.include?("Other")
+  end
+
+  def all_qualifications?
+    qts_only? && pgce_or_pgde_with_qts? && other_qualifications?
+  end
+
   def with_salaries?
     query_parameters["funding"] == "8"
   end
@@ -54,5 +70,9 @@ private
 
   def sen_courses_parameters
     { "senCourses" => query_parameters["senCourses"].presence || "False" }
+  end
+
+  def qualifications_parameters_array
+    qualifications_parameters["qualifications"].split(",")
   end
 end

--- a/app/views/results/_qualifications.html.erb
+++ b/app/views/results/_qualifications.html.erb
@@ -1,0 +1,21 @@
+<div class="filter-form" data-qa="filters__qualifications">
+  <h2 class="govuk-heading-s filter-form__title">
+    Qualifications<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <% if @results_view.all_qualifications? %>
+      <li data-qa="qualifications">All qualifications</li>
+    <% else %>
+      <% if @results_view.qts_only? %>
+        <li data-qa="qualifications">QTS only</li>
+      <% end %>
+      <% if @results_view.pgce_or_pgde_with_qts?%>
+        <li data-qa="qualifications">PGCE (or PGDE) with QTS</li>
+      <% end %>
+      <% if @results_view.other_qualifications? %>
+        <li data-qa="qualifications">Further Education (PGCE or PGDE without QTS)</li>
+      <% end %>
+    <% end %>
+  </ul>
+  <%= link_to "Change qualifications", @results_view.filter_path_with_unescaped_commas(qualification_path), class: "govuk-link", data: { qa: "link" } %>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -18,9 +18,9 @@
           <%=link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "filters__subject_link" }%>
         </div>
         <%= render partial: 'results/study_type' %>
-        <div>
-          <%=link_to "Change qualifications", @results_view.filter_path_with_unescaped_commas(qualification_path), class: "govuk-link", data: { qa: "filters__qualifications_link" }%>
-        </div>
+
+        <%= render partial: 'results/qualifications' %>
+
         <div>
           <%= render partial: 'results/funding' %>
         </div>

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -111,5 +111,25 @@ feature "results", type: :feature do
         end
       end
     end
+
+    describe "qualifications filter" do
+      context "all selected" do
+        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts,Other" } }
+
+        it "displays text 'All qualifications'" do
+          expect(results_page.qualifications_filter.qualifications.first).to have_content("All qualifications")
+        end
+      end
+
+      context "two selected" do
+        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+
+        it "displays text for each qualification" do
+          expect(results_page.qualifications_filter.qualifications.first).to have_content("QTS only")
+          expect(results_page.qualifications_filter.qualifications.last).to have_content("PGCE (or PGDE) with QTS")
+          expect(results_page.qualifications_filter.qualifications.count).to eq(2)
+        end
+      end
+    end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -22,6 +22,10 @@ module PageObjects
       element :link, '[data-qa="link"]'
     end
 
+    class QualificationsSection < SitePrism::Section
+      elements :qualifications, '[data-qa="qualifications"]'
+    end
+
     class FundingSection < SitePrism::Section
       element :funding, '[data-qa="funding"]'
     end
@@ -31,6 +35,7 @@ module PageObjects
 
       sections :courses, CourseSection, '[data-qa="course"]'
       section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'
+      section :qualifications_filter, QualificationsSection, '[data-qa="filters__qualifications"]'
       section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
       section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -75,4 +75,84 @@ RSpec.describe ResultsView do
       expect(subject).to eq(expected_path)
     end
   end
+
+  describe "#qts_only?" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "when the hash includes 'QTS only'" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly,PgdePgceWithQts" } }
+
+      it "returns true" do
+        expect(results_view.qts_only?).to be_truthy
+      end
+    end
+
+    context "when the hash does not include 'QTS only'" do
+      let(:parameter_hash) { { "qualifications" => "Other" } }
+
+      it "returns false" do
+        expect(results_view.qts_only?).to be_falsy
+      end
+    end
+  end
+
+  describe "#pgce_or_pgde_with_qts?" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "when the hash includes 'PGCE (or PGDE) with QTS'" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly,PgdePgceWithQts" } }
+
+      it "returns true" do
+        expect(results_view.pgce_or_pgde_with_qts?).to be_truthy
+      end
+    end
+
+    context "when the hash does not include 'PGCE (or PGDE) with QTS'" do
+      let(:parameter_hash) { { "qualifications" => "Other" } }
+
+      it "returns false" do
+        expect(results_view.pgce_or_pgde_with_qts?).to be_falsy
+      end
+    end
+  end
+
+  describe "#other_qualifications?" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "when the hash includes 'Further Education (PGCE or PGDE without QTS)'" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly,Other" } }
+
+      it "returns true" do
+        expect(results_view.other_qualifications?).to be_truthy
+      end
+    end
+
+    context "when the hash does not include 'Further Education (PGCE or PGDE without QTS)'" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly" } }
+
+      it "returns false" do
+        expect(results_view.other_qualifications?).to be_falsy
+      end
+    end
+  end
+
+  describe "#all_qualifications?" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "when all selected'" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly,PgdePgceWithQts,Other" } }
+
+      it "returns true" do
+        expect(results_view.all_qualifications?).to be_truthy
+      end
+    end
+
+    context "when not all selected" do
+      let(:parameter_hash) { { "qualifications" => "QtsOnly" } }
+
+      it "returns false" do
+        expect(results_view.all_qualifications?).to be_falsy
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

* Displays the filter state as it exists on the [C# results page](https://www.find-postgraduate-teacher-training.service.gov.uk/results?l=2&subjects=0&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False).
* Defaults to "All qualifications"
* When all three qualifications, the UI displays "All qualifications"
* When not all three qualifications, the UI lists the qualifications selected.

### Changes proposed in this pull request
<img width="316" alt="all" src="https://user-images.githubusercontent.com/38078064/73765393-6123d600-476c-11ea-8452-5d16363c8b4f.png">
<img width="313" alt="two" src="https://user-images.githubusercontent.com/38078064/73765404-684ae400-476c-11ea-8ffb-cfea885ef33f.png">
<img width="323" alt="one" src="https://user-images.githubusercontent.com/38078064/73765413-6bde6b00-476c-11ea-8ba2-d6eb07e6f2f4.png">

### Guidance to review
[https://www.find-postgraduate-teacher-training.service.gov.uk/results](https://www.find-postgraduate-teacher-training.service.gov.uk/results?l=2&subjects=0&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False)

Co-authored-by: Faissal Bensefia <faissal@madetech.com>

