### PR TITLE
[2904] Fix subject filter styling

### DIFF
--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -37,7 +37,7 @@
                       <div class="govuk-checkboxes__item" data-qa="subject">
                         <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(id: subject.id), data: {qa: "subject__checkbox"}, id: "subject#{subject.id}", class: "govuk-checkboxes__input" }, subject.id, nil) %>
                           <%= f.label(:subjects, {for: "subject#{subject.id}", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
-                          <span class="govuk-checkboxes__label_text">
+                          <span class="govuk-checkboxes__label-text">
                             <%= subject.subject_name %>
                           </span>
                           <span class="govuk-!-display-block"></span>
@@ -63,7 +63,7 @@
                 <div class="govuk-checkboxes__item" data-qa="subject">
                   <%= f.check_box(:senCourses, { checked: params[:senCourses] == "true", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'true', nil) %>
                   <%= f.label(:subjects, {for: "subject_send", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
-                    <span class="govuk-checkboxes__label_text">
+                    <span class="govuk-checkboxes__label-text">
                       Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
                     </span>
                     <span class="govuk-!-display-block"></span>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -141,3 +141,9 @@
   text-decoration: underline;
   cursor: pointer;
 }
+
+.govuk-checkboxes__label-text {
+  display: block;
+  font-weight: bold;
+  margin-bottom: govuk-spacing(1);
+}


### PR DESCRIPTION
### Context
The subject page does not style the names of subjects to be bold as is done on Search and Compare.  

### Changes proposed in this pull request
Copy the application specific styling from C#.

### Guidance to review
https://github.com/DFE-Digital/search-and-compare-ui/blob/master/src/Assets/Styles/site.scss#L295  
https://www.find-postgraduate-teacher-training.service.gov.uk/start/subject