### PR TITLE
[2901] Fixed backlink for filter pages

### DIFF
--- a/app/controllers/result_filters/funding_controller.rb
+++ b/app/controllers/result_filters/funding_controller.rb
@@ -1,10 +1,20 @@
 module ResultFilters
   class FundingController < ApplicationController
     include FilterParameters
+
+    before_action :build_results_filter_query_parameters
+
     def new; end
 
     def create
       redirect_to results_path(filter_params)
+    end
+
+  private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
     end
   end
 end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -2,6 +2,8 @@ module ResultFilters
   class LocationController < ApplicationController
     include FilterParameters
 
+    before_action :build_results_filter_query_parameters
+
     def new; end
 
     def create
@@ -16,6 +18,11 @@ module ResultFilters
     end
 
   private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
+    end
 
     def params_for_provider_search
       filter_params.except(:lat, :lng, :rad, :loc, :lq)

--- a/app/controllers/result_filters/qualification_controller.rb
+++ b/app/controllers/result_filters/qualification_controller.rb
@@ -2,7 +2,7 @@ module ResultFilters
   class QualificationController < ApplicationController
     include FilterParameters
 
-    before_action :create_view
+    before_action :create_view, :build_results_filter_query_parameters
 
     def new; end
 
@@ -16,6 +16,11 @@ module ResultFilters
     end
 
   private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
+    end
 
     def create_view
       @view = ResultFilters::QualificationView.new(params: params)

--- a/app/controllers/result_filters/study_type_controller.rb
+++ b/app/controllers/result_filters/study_type_controller.rb
@@ -2,6 +2,8 @@ module ResultFilters
   class StudyTypeController < ApplicationController
     include FilterParameters
 
+    before_action :build_results_filter_query_parameters
+
     def new; end
 
     def create
@@ -11,6 +13,13 @@ module ResultFilters
         flash[:error] = "You must make at least one selection"
         redirect_to studytype_path(filter_params)
       end
+    end
+
+  private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
     end
   end
 end

--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -2,6 +2,9 @@ module ResultFilters
   class SubjectController < ApplicationController
     include FilterParameters
     include CsharpRailsSubjectConversionHelper
+
+    before_action :build_results_filter_query_parameters
+
     before_action { params["senCourses"].downcase! if params["senCourses"].present? }
 
     def new
@@ -11,6 +14,13 @@ module ResultFilters
 
     def create
       redirect_to results_path(filter_params.merge(subjects: convert_rails_subject_id_params_to_csharp))
+    end
+
+  private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
     end
   end
 end

--- a/app/controllers/result_filters/vacancy_controller.rb
+++ b/app/controllers/result_filters/vacancy_controller.rb
@@ -2,10 +2,19 @@ module ResultFilters
   class VacancyController < ApplicationController
     include FilterParameters
 
+    before_action :build_results_filter_query_parameters
+
     def new; end
 
     def create
       redirect_to results_path(filter_params)
+    end
+
+  private
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+        .query_parameters_with_defaults
     end
   end
 end

--- a/app/views/result_filters/funding/new.html.erb
+++ b/app/views/result_filters/funding/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Find courses that pay a salary" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-width-container">

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Find courses by location or by training provider" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Filter by qualification" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Filter by study type" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Find course by subject" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -1,6 +1,7 @@
 <%= content_for :page_title, "Find courses by vacancies" %>
+
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(request.query_parameters), "Back to search results") %>
+  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -26,7 +26,14 @@ feature "Funding filter", type: :feature do
 
         expect_page_to_be_displayed_with_query(
           page: results_page,
-          expected_query_params: { "test" => "params" },
+          expected_query_params:  {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
         )
       end
     end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -24,7 +24,14 @@ feature "Location filter", type: :feature do
 
       expect_page_to_be_displayed_with_query(
         page: results_page,
-        expected_query_params: { "test" => "params" },
+        expected_query_params: {
+          "fulltime" => "False",
+          "hasvacancies" => "True",
+          "parttime" => "False",
+          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+          "senCourses" => "False",
+          "test" => "params",
+        },
       )
     end
   end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -23,7 +23,14 @@ feature "Qualifications filter", type: :feature do
 
         expect_page_to_be_displayed_with_query(
           page: results_page,
-          expected_query_params: { "test" => "params" },
+          expected_query_params:  {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
         )
       end
     end

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -15,7 +15,14 @@ feature "Study type filter", type: :feature do
 
       expect_page_to_be_displayed_with_query(
         page: results_page,
-        expected_query_params: { "test" => "params" },
+        expected_query_params:  {
+          "fulltime" => "False",
+          "hasvacancies" => "True",
+          "parttime" => "False",
+          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+          "senCourses" => "False",
+          "test" => "params",
+        },
       )
     end
   end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -23,6 +23,25 @@ feature "Subject filter", type: :feature do
     subject_filter_page.load
   end
 
+  describe "back link" do
+    it "navigates back to the results page" do
+      subject_filter_page.load(query: { test: "params" })
+      subject_filter_page.back_link.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params:  {
+          "fulltime" => "False",
+          "hasvacancies" => "True",
+          "parttime" => "False",
+          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+          "senCourses" => "False",
+          "test" => "params",
+        },
+      )
+    end
+  end
+
   context "with no selected subjects" do
     it "doesn't expand the accordion" do
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -22,7 +22,14 @@ feature "Vacancy filter", type: :feature do
 
       expect_page_to_be_displayed_with_query(
         page: results_page,
-        expected_query_params: { "test" => "params" },
+        expected_query_params:  {
+          "fulltime" => "False",
+          "hasvacancies" => "True",
+          "parttime" => "False",
+          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+          "senCourses" => "False",
+          "test" => "params",
+        },
       )
     end
   end

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -15,6 +15,8 @@ module PageObjects
           sections :subjects, Subject, '[data-qa="subject"]'
         end
 
+        element :back_link, '[data-qa="page-back"]'
+
         sections :subject_areas, SubjectAreaSection, '[data-qa="subject_area"]'
         section :send_area, SubjectAreaSection, '[data-qa="send_area"]'
         element :continue, '[data-qa="continue"]'


### PR DESCRIPTION
### Context
Filter pages needs to have default or updated query parameters otherwise you lose the agility to go back to the previous search result page

### Changes proposed in this pull request
Fixed backlink for filter pages

### Guidance to review
transverse the site from 
1. results page to a filter, 
2. change the filter value / valid and invalid values
3. click back to search results
4. go back to 1 and repeat