### PR TITLE
[2779] Add the subjects filter display to the results page

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -34,7 +34,7 @@ class ResultsController < ApplicationController
       if params["subjects"].present?
         SubjectArea.includes(:subjects).all
           .map(&:subjects).flatten
-          .select { |subject| rails_to_csharp_subject_id(id: subject.id).in?(params["subjects"].split(",").map(&:to_s)) }
+          .select { |subject| rails_to_csharp_subject_id(id: subject.id).in?(subjects_params_array) }
           .sort_by(&:subject_name)[0..3]
       else
         SubjectArea.includes(:subjects).all
@@ -56,5 +56,9 @@ private
     redirect_uri.query = query_string.gsub("%2C", ",") if query_string.present?
 
     redirect_to redirect_uri.to_s
+  end
+
+  def subjects_params_array
+    params["subjects"].split(",")
   end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,5 @@
 class ResultsController < ApplicationController
+  include CsharpRailsSubjectConversionHelper
   before_action :redirect_to_c_sharp
 
   def index
@@ -29,6 +30,17 @@ class ResultsController < ApplicationController
           address4
           postcode
         ]).all
+    @subjects =
+      if params["subjects"].present?
+        SubjectArea.includes(:subjects).all
+          .map(&:subjects).flatten
+          .select { |subject| rails_to_csharp_subject_id(id: subject.id).in?(params["subjects"].split(",").map(&:to_s)) }
+          .sort_by(&:subject_name)[0..3]
+      else
+        SubjectArea.includes(:subjects).all
+          .map(&:subjects).flatten
+          .sort_by(&:subject_name)[0..3]
+      end
   end
 
 private

--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -35,7 +35,9 @@ module CsharpRailsSubjectConversionHelper
   end
 
   def csharp_rails_conversion_table
-    [{ csharp_id: "49", rails_id: "42", name: "Modern languages (other)" },
+    [{ csharp_id: nil, rails_id: "27", name: "Philosophy" },
+     { csharp_id: nil, rails_id: "33", name: "Modern Languages" },
+     { csharp_id: "49", rails_id: "42", name: "Modern languages (other)" },
      { csharp_id: "14", rails_id: "43", name: "Further education" },
      { csharp_id: "44", rails_id: "41", name: "Spanish" },
      { csharp_id: "41", rails_id: "40", name: "Russian" },

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -1,4 +1,6 @@
 class ResultsView
+  NUMBER_OF_SUBJECTS_DISPLAYED = 4
+
   def initialize(query_parameters:)
     @query_parameters = query_parameters
   end
@@ -46,6 +48,20 @@ class ResultsView
 
   def with_salaries?
     query_parameters["funding"] == "8"
+  end
+
+
+  def number_of_subjects_selected
+    if query_parameters["subjects"].blank?
+      return SubjectArea.includes(:subjects).all
+        .map(&:subjects).flatten.length
+    end
+
+    query_parameters["subjects"].split(",").count
+  end
+
+  def number_of_extra_subjects
+    number_of_subjects_selected - NUMBER_OF_SUBJECTS_DISPLAYED
   end
 
 private

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -50,6 +50,9 @@ class ResultsView
     query_parameters["funding"] == "8"
   end
 
+  def send_courses?
+    query_parameters["senCourses"].present? && query_parameters["senCourses"].downcase == "true"
+  end
 
   def number_of_subjects_selected
     if query_parameters["subjects"].blank?

--- a/app/views/results/_subjects.html.erb
+++ b/app/views/results/_subjects.html.erb
@@ -8,7 +8,7 @@
     <% end %>
 
     <% @subjects.each do |subject| %>
-        <li data-qa="subjects"><%= subject.subject_name %></li>
+      <li data-qa="subjects"><%= subject.subject_name %></li>
     <% end %>
 
     <% if @results_view.number_of_extra_subjects.positive? %>

--- a/app/views/results/_subjects.html.erb
+++ b/app/views/results/_subjects.html.erb
@@ -1,0 +1,11 @@
+<div class="filter-form" data-qa="filters__subjects">
+  <h2 class="govuk-heading-s filter-form__title">
+    Subjects<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <% @subjects.each do |subject| %>
+        <li data-qa="subjects"><%= subject.subject_name %></li>
+    <% end %>
+  </ul>
+  <%= link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "link" } %>
+</div>

--- a/app/views/results/_subjects.html.erb
+++ b/app/views/results/_subjects.html.erb
@@ -3,6 +3,10 @@
     Subjects<span class="govuk-visually-hidden">:</span>
   </h2>
   <ul class="filter-form__value--list">
+    <% if @results_view.send_courses? %>
+      <li data-qa="send_courses">Only SEND courses</li>
+    <% end %>
+
     <% @subjects.each do |subject| %>
         <li data-qa="subjects"><%= subject.subject_name %></li>
     <% end %>

--- a/app/views/results/_subjects.html.erb
+++ b/app/views/results/_subjects.html.erb
@@ -6,6 +6,10 @@
     <% @subjects.each do |subject| %>
         <li data-qa="subjects"><%= subject.subject_name %></li>
     <% end %>
+
+    <% if @results_view.number_of_extra_subjects.positive? %>
+      <li data-qa="extra_subjects">and <%= @results_view.number_of_extra_subjects %> more...</li>
+    <% end %>
   </ul>
   <%= link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "link" } %>
 </div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -14,9 +14,8 @@
         <div>
           <%=link_to "Change location or choose a provider", @results_view.filter_path_with_unescaped_commas(location_path), class: "govuk-link", data: { qa: "filters__location_link" }%>
         </div>
-        <div>
-          <%=link_to "Change subjects", @results_view.filter_path_with_unescaped_commas(subject_path), class: "govuk-link", data: { qa: "filters__subject_link" }%>
-        </div>
+        <%= render partial: 'results/subjects' %>
+
         <%= render partial: 'results/study_type' %>
 
         <%= render partial: 'results/qualifications' %>

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -89,9 +89,19 @@ feature "Search results", type: :feature do
     )
   end
 
+  let(:subject_request) do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+  end
+
   let(:page_index) { nil }
 
   before do
+    subject_request
+
     courses_request
 
     visit results_path(page: page_index)

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -7,6 +7,14 @@ feature "Funding filter", type: :feature do
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
 
+  before do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+  end
+
   describe "funding page" do
     before { filter_page.load }
 

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -4,6 +4,14 @@ feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
+  before do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+  end
+
   describe "qualification page" do
     before { filter_page.load }
 

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -155,7 +155,8 @@ feature "results", type: :feature do
       context "no subjects selected" do
         let(:params) { { subjects: {} } }
 
-        it "defaults to all subjects" do
+        it "defaults to all subjects without 'Only SEND courses'" do
+          expect(results_page.subjects_filter).not_to have_send_courses
           expect(results_page.subjects_filter).to have_content("Biology")
           expect(results_page.subjects_filter).to have_content("English")
           expect(results_page.subjects_filter).to have_content("French")
@@ -168,6 +169,7 @@ feature "results", type: :feature do
         let(:params) { { subjects: "31,1" } }
 
         it "displays all selected subjects in alphabetical order" do
+          expect(results_page.subjects_filter).not_to have_send_courses
           expect(results_page.subjects_filter).to have_content("Biology")
           expect(results_page.subjects_filter).to have_content("Primary")
           expect("Biology").to appear_before("Primary")
@@ -183,6 +185,20 @@ feature "results", type: :feature do
           expect(results_page.subjects_filter).to have_content("French")
           expect(results_page.subjects_filter).to have_content("Mathematics")
           expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
+        end
+
+        context "'Only SEND courses' selected" do
+          let(:params) { { subjects: "31,1,12,24,13", senCourses: "true" } }
+
+          it "displays 'Only SEND courses' at the top of the list and doesn't count towards 4 items rule" do
+            expect(results_page.subjects_filter.send_courses).to have_content("Only SEND courses")
+            expect(results_page.subjects_filter).to have_content("Biology")
+            expect(results_page.subjects_filter).to have_content("English")
+            expect(results_page.subjects_filter).to have_content("French")
+            expect(results_page.subjects_filter).to have_content("Mathematics")
+            expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
+            expect("Only SEND courses").to appear_before("Biology")
+          end
         end
       end
     end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -160,6 +160,7 @@ feature "results", type: :feature do
           expect(results_page.subjects_filter).to have_content("English")
           expect(results_page.subjects_filter).to have_content("French")
           expect(results_page.subjects_filter).to have_content("Mathematics")
+          expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
         end
       end
 
@@ -176,11 +177,12 @@ feature "results", type: :feature do
       context "more than 4 subjects selected" do
         let(:params) { { subjects: "31,1,12,24,13" } }
 
-        it "displays first 4 subjects" do
+        it "displays first 4 subjects and number of extra courses selected" do
           expect(results_page.subjects_filter).to have_content("Biology")
           expect(results_page.subjects_filter).to have_content("English")
           expect(results_page.subjects_filter).to have_content("French")
           expect(results_page.subjects_filter).to have_content("Mathematics")
+          expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
         end
       end
     end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -161,6 +161,9 @@ feature "results", type: :feature do
           expect(results_page.subjects_filter).to have_content("English")
           expect(results_page.subjects_filter).to have_content("French")
           expect(results_page.subjects_filter).to have_content("Mathematics")
+          expect("Biology").to appear_before("English")
+          expect("English").to appear_before("French")
+          expect("French").to appear_before("Mathematics")
           expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
         end
       end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -10,6 +10,7 @@ module PageObjects
     end
 
     class SubjectsSection < SitePrism::Section
+      element :send_courses, '[data-qa="send_courses"]'
       elements :subjects, '[data-qa="subjects"]'
       element :extra_subjects, '[data-qa="extra_subjects"]'
     end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -9,6 +9,10 @@ module PageObjects
       element :main_address, '[data-qa="course__main_address"]'
     end
 
+    class SubjectsSection < SitePrism::Section
+      elements :subjects, '[data-qa="subjects"]'
+    end
+
     class StudyTypeSection < SitePrism::Section
       element :subheading, "h2"
       element :fulltime, '[data-qa="fulltime"]'
@@ -34,6 +38,7 @@ module PageObjects
       set_url "/results"
 
       sections :courses, CourseSection, '[data-qa="course"]'
+      section :subjects_filter, SubjectsSection, '[data-qa="filters__subjects"]'
       section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'
       section :qualifications_filter, QualificationsSection, '[data-qa="filters__qualifications"]'
       section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -11,6 +11,7 @@ module PageObjects
 
     class SubjectsSection < SitePrism::Section
       elements :subjects, '[data-qa="subjects"]'
+      element :extra_subjects, '[data-qa="extra_subjects"]'
     end
 
     class StudyTypeSection < SitePrism::Section

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,4 +98,10 @@ RSpec.configure do |config|
   require "webmock/rspec"
   require "factory_bot"
   config.include FactoryBot::Syntax::Methods
+
+  RSpec::Matchers.define :appear_before do |later_content|
+    match do |earlier_content|
+      page.body.index(earlier_content) < page.body.index(later_content)
+    end
+  end
 end

--- a/spec/support/stub_results_page.rb
+++ b/spec/support/stub_results_page.rb
@@ -52,4 +52,10 @@ def stub_results_page_request
       ),
     },
   )
+
+  stub_api_v3_resource(
+    type: SubjectArea,
+    resources: nil,
+    include: [:subjects],
+  )
 end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -13,6 +13,27 @@ RSpec.describe ResultsView do
     }
   end
 
+  let(:subject_areas) do
+    [
+      build(:subject_area, subjects: [
+        build(:subject, :primary, id: 1),
+        build(:subject, :biology, id: 2),
+        build(:subject, :english, id: 3),
+        build(:subject, :mathematics, id: 4),
+        build(:subject, :french, id: 5),
+        ]),
+      build(:subject_area, :secondary),
+    ]
+  end
+
+  before do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: subject_areas,
+      include: [:subjects],
+    )
+  end
+
   describe "query_parameters_with_defaults" do
     subject { described_class.new(query_parameters: query_parameters).query_parameters_with_defaults }
 
@@ -153,6 +174,36 @@ RSpec.describe ResultsView do
       it "returns false" do
         expect(results_view.all_qualifications?).to be_falsy
       end
+    end
+  end
+
+  describe "#number_of_subjects_selected" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "query_parameters don't have subjects set" do
+      let(:parameter_hash) { {} }
+
+      it "returns the number of all subjects" do
+        expect(results_view.number_of_subjects_selected).to eq(5)
+      end
+    end
+
+    context "query_parameters have subjects set" do
+      let(:parameter_hash) { { "subjects" => "1,2,3" } }
+
+      it "returns the number of all subjects" do
+        expect(results_view.number_of_subjects_selected).to eq(3)
+      end
+    end
+  end
+
+  describe "#number_of_extra_subjects" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    let(:parameter_hash) { { "subjects" => "1,2,3,4,5" } }
+
+    it "returns the number of the extra subjects" do
+      expect(results_view.number_of_extra_subjects).to eq(1)
     end
   end
 end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -177,6 +177,26 @@ RSpec.describe ResultsView do
     end
   end
 
+  describe "#send_courses?" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "when the senCourses is True" do
+      let(:parameter_hash) { { "senCourses" => "True" } }
+
+      it "returns true" do
+        expect(results_view.send_courses?).to be_truthy
+      end
+    end
+
+    context "when the senCourses is nil" do
+      let(:parameter_hash) { {} }
+
+      it "returns false" do
+        expect(results_view.send_courses?).to be_falsy
+      end
+    end
+  end
+
   describe "#number_of_subjects_selected" do
     let(:results_view) { described_class.new(query_parameters: parameter_hash) }
 


### PR DESCRIPTION
### Context
Displays the filter state as it exists on the [C# results page](https://find-postgraduate-teacher-training.education.gov.uk/results).

### Changes proposed in this pull request

* Subjects are listed in alphabetical order
<img width="306" alt="alphabetical" src="https://user-images.githubusercontent.com/38078064/73954012-213e2980-48f9-11ea-8ff0-f42f16dc6ee4.png">

* "Further education" is treated as just another subject.
* When more than 4 subjects are selected, the first 4 (alphabetically) are listed an the rest are summarised as "and N more..."
<img width="309" alt="more" src="https://user-images.githubusercontent.com/38078064/73954062-32873600-48f9-11ea-952d-728e26209b86.png">

* When SEND is selected the UI displays "Only SEND courses" at the top of the list of subjects, and it does not count towards the list of 4 subjects and the "and N more..." rule.
<img width="308" alt="send" src="https://user-images.githubusercontent.com/38078064/73953691-af65e000-48f8-11ea-8536-53003b407ceb.png">

* Defaults to all subjects, without "Only SEND courses".
<img width="379" alt="defaults" src="https://user-images.githubusercontent.com/38078064/73953603-8cd3c700-48f8-11ea-9af5-6a62e13eb164.png">

### Guidance to review
Compare with [C# version](https://find-postgraduate-teacher-training.education.gov.uk/results?l=3&query=Essex%20Teacher%20Training&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False).
