### PR TITLE
[2931] Temp remove Philosophy from subjects list

### DIFF
--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -33,7 +33,7 @@
                 <div class="govuk-checkboxes">
                   <% subject_area.subjects.sort_by{ |subject| subject.subject_name }.each do |subject| %>
                     <%# C# doesn't have a distinct modern languages subject %>
-                    <% unless subject.subject_name == "Modern Languages" %>
+                    <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
                       <div class="govuk-checkboxes__item" data-qa="subject">
                         <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(id: subject.id), data: {qa: "subject__checkbox"}, id: "subject#{subject.id}", class: "govuk-checkboxes__input" }, subject.id, nil) %>
                           <%= f.label(:subjects, {for: "subject#{subject.id}", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>


### PR DESCRIPTION
### Context
Subjects list

### Changes proposed in this pull request
Temporarily remove Philosophy from subjects list until the results page can support it

### Guidance to review
Example - `http://localhost:3002/results/filter/subject?l=2&subjects=31&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False`