### PR TITLE
2787 l location filter show filter on results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -67,6 +67,28 @@ class ResultsView
     number_of_subjects_selected - NUMBER_OF_SUBJECTS_DISPLAYED
   end
 
+  def location
+    query_parameters["loc"] || "Across England"
+  end
+
+  def distance
+    query_parameters["rad"]
+  end
+
+  def show_map?
+    latitude.present? && longitude.present? && distance.present?
+  end
+
+  def map_image_url
+    "#{Settings.google.maps_api_url}\
+?key=#{Settings.google.maps_api_key}\
+&center=#{latitude},#{longitude}\
+&zoom=#{google_map_zoom}\
+&size=300x200\
+&scale=2\
+&markers=#{latitude},#{longitude}"
+  end
+
 private
 
   attr_reader :query_parameters
@@ -93,5 +115,30 @@ private
 
   def qualifications_parameters_array
     qualifications_parameters["qualifications"].split(",")
+  end
+
+  def latitude
+    query_parameters["lat"]
+  end
+
+  def longitude
+    query_parameters["lng"]
+  end
+
+  def google_map_zoom
+    case distance
+    when "5"
+      "12"
+    when "10"
+      "11"
+    when "20"
+      "10"
+    when "50"
+      "9"
+    when "100"
+      "8"
+    else
+      "14"
+    end
   end
 end

--- a/app/views/results/_location.html.erb
+++ b/app/views/results/_location.html.erb
@@ -1,0 +1,23 @@
+<div class="filter-form" data-qa="filters__location">
+  <h2 class="govuk-heading-s filter-form__title">
+    Location<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <li data-qa="location_name">
+      <%= @results_view.location %>
+      <% if @results_view.show_map? %>
+        <span class="govuk-caption-m" data-qa="distance">Within
+          <%= @results_view.distance %>
+         miles of the pin</span>
+        <img src="<%= @results_view.map_image_url %>"
+             alt="Map showing <%= @results_view.distance %> miles
+             of <%= @results_view.location %>"class="filter-form__map"
+             data-qa="map" />
+      <% end %>
+    </li>
+  </ul>
+  <%=link_to "Change location or choose a provider",
+             @results_view.filter_path_with_unescaped_commas(location_path),
+             class: "govuk-link",
+             data: { qa: "change_link" }%>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -9,20 +9,17 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
-      filters go here
       <div data-qa="filters">
-        <div>
-          <%=link_to "Change location or choose a provider", @results_view.filter_path_with_unescaped_commas(location_path), class: "govuk-link", data: { qa: "filters__location_link" }%>
-        </div>
+        <%= render partial: 'results/location' %>
+
         <%= render partial: 'results/subjects' %>
 
         <%= render partial: 'results/study_type' %>
 
         <%= render partial: 'results/qualifications' %>
 
-        <div>
-          <%= render partial: 'results/funding' %>
-        </div>
+        <%= render partial: 'results/funding' %>
+
         <%= render partial: 'results/vacancy' %>
       </div>
     </div>

--- a/app/webpacker/styles/patterns/_filters.scss
+++ b/app/webpacker/styles/patterns/_filters.scss
@@ -34,6 +34,10 @@
     }
   }
 
+  &__map {
+    width: 100%;
+  }
+
   .govuk-input {
     background: govuk-colour("white");
     margin-bottom: 8px;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ manage_backend:
 current_cycle: 2020
 google:
   maps_api_key: replace_me
+  maps_api_url: https://maps.googleapis.com/maps/api/staticmap
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 redirect_results_to_c_sharp: true

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -36,6 +36,13 @@ module PageObjects
       element :funding, '[data-qa="funding"]'
     end
 
+    class LocationSection < SitePrism::Section
+      element :name, '[data-qa="location_name"]'
+      element :distance, '[data-qa="distance"]'
+      element :map, '[data-qa="map"]'
+      element :link, '[data-qa="change_link"]'
+    end
+
     class Results < SitePrism::Page
       set_url "/results"
 
@@ -45,6 +52,7 @@ module PageObjects
       section :qualifications_filter, QualificationsSection, '[data-qa="filters__qualifications"]'
       section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
       section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
+      section :location_filter, LocationSection, '[data-qa="filters__location"]'
 
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'


### PR DESCRIPTION
### Context

[This trello card](https://trello.com/c/I3JgPSeB/2787-l-location-filter-show-filter-on-results-page)

As part of rebuilding this application, adding a location filter to the results page.

### Changes proposed in this pull request

Added a location filter to the ResultsView

Add components to render it to the results page 

### Guidance to review
