### PR TITLE
[2895] Refactor accordion and checkbox into components

### DIFF
--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -13,7 +13,7 @@ module ResultFilters
     def subject_area_is_selected?(subject_area:)
       return false if params["subjects"].nil?
 
-      (params["subjects"] || subject_area.subjects.map(&:id)).any?
+      (params["subjects"] & subject_area.subjects.map(&:id)).any?
     end
   end
 end

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -20,7 +20,7 @@
 
         <div class="accordion govuk-form-group" data-module="govuk-accordion">
           <% @subject_areas.each_with_index do |subject_area, counter| %>
-            <div class="govuk-accordion__section" data-qa="subject_area">
+            <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) then " govuk-accordion__section--expanded" end %>" data-qa="subject_area">
               <div class="govuk-accordion__section-header">
                 <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
                   <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
@@ -49,7 +49,7 @@
               </div>
             </div>
           <% end %>
-          <div class="govuk-accordion__section" data-qa="send_area">
+          <div class="govuk-accordion__section<%= if params[:senCourses] == "true" then " govuk-accordion__section--expanded" end %>" data-qa="send_area">
             <div class="govuk-accordion__section-header">
               <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
                 <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="send-content" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -60,9 +60,14 @@ feature "Subject filter", type: :feature do
   end
 
   context "with no selected subjects" do
-    it "doesn't expand the accordion" do
+    it "should set assistive technology attributes appropriately" do
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')
       expect(subject_filter_page.send_area.accordion_button).to match_selector('[aria-expanded="false"]')
+    end
+
+    it "should not expand any accordion sections" do
+      expect(subject_filter_page.subject_areas.first).to have_no_css(".govuk-accordion__section--expanded")
+      expect(subject_filter_page.send_area).to have_no_css(".govuk-accordion__section--expanded")
     end
 
     it "displays all subject areas" do
@@ -143,10 +148,17 @@ feature "Subject filter", type: :feature do
       )
     end
 
-    it "auto expands the accordion" do
+    it "should set assistive technology attributes appropriately" do
       subject_filter_page.load(query: { subjects: "1,31", other_param: "param_value", senCourses: "True" })
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="true"]')
       expect(subject_filter_page.send_area.accordion_button).to match_selector('[aria-expanded="true"]')
+    end
+
+    it "should expand any appropriate accordion sections" do
+      subject_filter_page.load(query: { subjects: "1,31", other_param: "param_value", senCourses: "True" })
+      expect(subject_filter_page.subject_areas.first.root_element).to match_selector(".govuk-accordion__section--expanded")
+      expect(subject_filter_page.subject_areas.second.root_element).not_to match_selector(".govuk-accordion__section--expanded")
+      expect(subject_filter_page.send_area.root_element).to match_selector(".govuk-accordion__section--expanded")
     end
   end
 


### PR DESCRIPTION
### Context
We were under the impression that the accordions were expanding due to `aria-expanded=` being set but this was incorrect.  

### Changes proposed in this pull request
Set the class `govuk-accordion__section--expanded` when a subject area is selected.

### Guidance to review  
Example behaviour from C#:
https://www.find-postgraduate-teacher-training.service.gov.uk/results/filter/subject?l=2&subjects=0,1,2&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False