### PR TITLE
2896 fix focus colour for pagination link

### DIFF
--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,5 +1,5 @@
 <li class="pub-c-pagination__item pub-c-pagination__item--next">
-  <%= link_to url, rel: 'next', remote: remote, class: "pub-c-pagination__link" do %>
+  <%= link_to url, rel: 'next', remote: remote, class: "pub-c-pagination__link govuk-link" do %>
     <span class="pub-c-pagination__link-title">
       Next page
       <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,5 +1,5 @@
 <li class="pub-c-pagination__item pub-c-pagination__item--previous">
-  <%= link_to url, rel: 'prev', remote: remote, class: "pub-c-pagination__link" do %>
+  <%= link_to url, rel: 'prev', remote: remote, class: "pub-c-pagination__link govuk-link" do %>
     <span class="pub-c-pagination__link-title">
       <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
         <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>

--- a/app/webpacker/styles/patterns/_pagination.scss
+++ b/app/webpacker/styles/patterns/_pagination.scss
@@ -1,3 +1,5 @@
+// TODO rewrite this to use more of GOVUK Frontend  mixin and styling
+
 .pub-c-pagination {
   display: block;
   margin-top: 30px;
@@ -42,15 +44,6 @@
   display: block;
   padding: 15px;
   text-decoration: none;
-}
-
-.pub-c-pagination__link:visited {
-  color: $govuk-link-colour;
-}
-
-.pub-c-pagination__link:hover,
-.pub-c-pagination__link:active {
-  background-color: govuk-colour("light-grey");
 }
 
 .pub-c-pagination__link-title {


### PR DESCRIPTION
### Context

Part of https://trello.com/c/hfgbMP9N/2896-2d-accessibility-audit-followup-find

While looking at [accessibility ticket](https://trello.com/c/hfgbMP9N) I noticed that Rails version of the pagination links were not styled correctly. Along with the text colour the focus styling was not consistent with the rest of the site and it would also fail WCAG 2.1 colour contrast check.

It will not be fixed in the C# version which currently looks like this:
![pagination-c](https://user-images.githubusercontent.com/3441519/74174079-3ed9fe80-4c2b-11ea-8f69-ecfea00ba417.gif)


### Changes proposed in this pull request

#### Before
![pagination-before](https://user-images.githubusercontent.com/3441519/74173865-cd01b500-4c2a-11ea-8b75-6c3981f5416f.gif)

#### After
![pagination-after](https://user-images.githubusercontent.com/3441519/74173870-d25eff80-4c2a-11ea-824e-192cf10f3c66.gif)

### Guidance to review
- May need to test this locally so that you can access the rails version on prot 3002 without being redirected to the C# version