### PR TITLE
[2948] Don't include radius when across England search is selected

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -9,11 +9,12 @@ module ResultFilters
     def create
       if provider_option_selected?
         redirect_to(provider_path(params_for_provider_search)) && return
+      elsif across_england_option_selected?
+        redirect_to(results_path(params_for_across_england_search)) && return
       end
 
       form_params = strip(filter_params.clone)
       form_object = LocationFilterForm.new(form_params)
-
       if form_object.valid?
         all_params = form_params.merge!(form_object.params)
         redirect_to results_path(all_params)
@@ -30,12 +31,20 @@ module ResultFilters
         .query_parameters_with_defaults
     end
 
+    def across_england_option_selected?
+      filter_params[:l] == "2"
+    end
+
     def provider_option_selected?
       filter_params[:l] == "3"
     end
 
     def params_for_provider_search
       filter_params.except(:lat, :lng, :rad, :loc, :lq)
+    end
+
+    def params_for_across_england_search
+      filter_params.except(:lat, :lng, :rad, :loc, :lq, :query)
     end
 
     def strip(params)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ steps:
 - script: |
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
+    set +x
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(Build.SourceVersionMessage)'> $(build.artifactstagingdirectory)/merge.info

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -70,7 +70,6 @@ feature "Location filter", type: :feature do
         page: results_page,
         expected_query_params: {
           "l" => "2",
-          "rad" => "20",
         },
       )
     end
@@ -177,7 +176,6 @@ feature "Location filter", type: :feature do
         expected_query_params: {
           "l" => "2",
           "test" => "value",
-          "rad" => "20",
         },
       )
     end
@@ -195,7 +193,6 @@ feature "Location filter", type: :feature do
         expected_query_params: {
           "l" => "2",
           "test" => "1,2",
-          "rad" => "20",
         },
       )
     end


### PR DESCRIPTION
### Context
Radius, a parameter used when searching by location, was being included when searching across England

### Changes proposed in this pull request
When across England is selected, reject unneeded parameters

### Guidance to review

