### PR TITLE
2896 - Add missing id for aria-controls (Accordion component)

### DIFF
--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -19,17 +19,17 @@
 
 
         <div class="accordion govuk-form-group" data-module="govuk-accordion">
-          <% @subject_areas.each do |subject_area| %>
+          <% @subject_areas.each_with_index do |subject_area, counter| %>
             <div class="govuk-accordion__section" data-qa="subject_area">
               <div class="govuk-accordion__section-header">
                 <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                  <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="null-content-1" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
+                  <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
                     <%= subject_area.name %>
                   </button>
                 </h2>
                 <span class="govuk-accordion__icon" aria-hidden="true"></span>
               </div>
-              <div class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
+              <div id="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
                 <div class="govuk-checkboxes">
                   <% subject_area.subjects.sort_by{ |subject| subject.subject_name }.each do |subject| %>
                     <%# C# doesn't have a distinct modern languages subject %>
@@ -52,13 +52,13 @@
           <div class="govuk-accordion__section" data-qa="send_area">
             <div class="govuk-accordion__section-header">
               <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="null-content-1" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">
+                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="send-content" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">
                   Special educational needs and disability (SEND)
                 </button>
               </h2>
               <span class="govuk-accordion__icon" aria-hidden="true"></span>
             </div>
-            <div class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
+            <div id="send-content" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
               <div class="govuk-checkboxes">
                 <div class="govuk-checkboxes__item" data-qa="subject">
                   <%= f.check_box(:senCourses, { checked: params[:senCourses] == "true", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'true', nil) %>

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -42,6 +42,23 @@ feature "Subject filter", type: :feature do
     end
   end
 
+  context "check each accordion section" do
+    it "has aria-control set to the section-content id" do
+      subject_filter_page.subject_areas.each_with_index { |accordion_section, counter|
+        subject_area_name = subject_areas[counter].typename.downcase
+        control_id = "#{subject_area_name}-content-#{counter}"
+        section_button = accordion_section.find(".govuk-accordion__section-button")
+
+        expect(section_button["aria-controls"]).to eq(control_id)
+        expect(accordion_section).to have_selector("div##{control_id}")
+      }
+
+      # Check SEND section
+      expect(subject_filter_page.send_area.accordion_button["aria-controls"]).to eq("send-content")
+      expect(subject_filter_page.send_area).to have_selector("div#send-content")
+    end
+  end
+
   context "with no selected subjects" do
     it "doesn't expand the accordion" do
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')


### PR DESCRIPTION
### Context

Relates to https://trello.com/c/hfgbMP9N/2896-2d-accessibility-audit-followup-find 

A recent accessibility audit completed in December 2019, revealed
that our accordion component was using aria-controls attribut on the
accordion section headings button but no elements on the page had an id
that matched the aria-controls values.

Aria-controls attribute is used by assistive tech to help users understand
what they are interacting with and what elements are responsible for various
actions.

I used govuk-frontend accordion as a reference for this fix. There are
no visual differences but the html should be reviewed to see the changes.

Buttons aria-control value matches the accordion content section for
the specific section it relates too.

### Changes proposed in this pull request
Add a unique id to each accordion section content div and ensure that id is used in the sections heading button aria-control attribute

### Guidance to review
No visual difference but check markup
