### PR TITLE
Protect pipeline step against PR's containing single quotes in title

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,12 @@ variables:
 
 steps:
 - script: |
+    set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     IMAGE_NAME_WITH_TAG=$(IMAGE_NAME):$GIT_SHORT_SHA
     set +x
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
-    echo '$(Build.SourceVersionMessage)'> $(build.artifactstagingdirectory)/merge.info
     echo '$(System.PullRequest.SourceBranch)'> $(build.artifactstagingdirectory)/prbranch.info
   displayName: 'Set version number'
 


### PR DESCRIPTION
### Context

https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=44747&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=f8ed7bd8-2a7f-56f6-9385-7fc29a8b5b7b

This broken test seems to indicate we have problems when a PR has a single-quote in the title.

### Changes proposed in this pull request

Use `cat` and a here-doc instead of `echo` when creating `merge.info` in the pipeline step.

### Guidance to review

🚢
