### PR TITLE
[2905] Add financial and SKE course availability info on Subjects filter page

### DIFF
--- a/app/decorators/subject_decorator.rb
+++ b/app/decorators/subject_decorator.rb
@@ -1,0 +1,19 @@
+class SubjectDecorator < Draper::Decorator
+  delegate_all
+
+  def has_scholarship?
+    object.scholarship.present?
+  end
+
+  def has_bursary?
+    object.bursary_amount.present?
+  end
+
+  def has_scholarship_and_bursary?
+    has_bursary? && has_scholarship?
+  end
+
+  def early_career_payments?
+    object.early_career_payments.present?
+  end
+end

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -36,10 +36,24 @@
                     <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
                       <div class="govuk-checkboxes__item" data-qa="subject">
                         <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(id: subject.id), data: {qa: "subject__checkbox"}, id: "subject#{subject.id}", class: "govuk-checkboxes__input" }, subject.id, nil) %>
-                          <%= f.label(:subjects, {for: "subject#{subject.id}", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
-                          <span class="govuk-checkboxes__label-text">
+                          <%= f.label(:subjects, {for: "subject#{subject.id}"}, class: "govuk-label govuk-checkboxes__label") do %>
+                          <span class="govuk-checkboxes__label-text" data-qa="subject__name">
                             <%= subject.subject_name %>
                           </span>
+
+                          <% if subject.decorate.has_scholarship_and_bursary? %>
+                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} are available" %>
+                          <% elsif subject.decorate.has_scholarship? %>
+                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} are available" %>
+                          <% elsif subject.decorate.has_bursary? %>
+                            <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} available" %>
+                          <% end %>
+                          <% if subject.decorate.early_career_payments? %>
+                            <% financial_info.concat(", \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).") %>
+                          <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
+                            <% financial_info.concat(".") %>
+                          <% end %>
+                          <span class="govuk-body" data-qa="subject__info"><%= financial_info %></span>
                           <span class="govuk-!-display-block"></span>
                         <% end %>
                       </div>

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -54,7 +54,13 @@
                             <% financial_info.concat(".") %>
                           <% end %>
                           <span class="govuk-body" data-qa="subject__info"><%= financial_info %></span>
-                          <span class="govuk-!-display-block"></span>
+
+                          <% if subject.subject_knowledge_enhancement_course_available %>
+                            <span class="govuk-!-display-block" data-qa="subject__ske_course">
+                              You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? "also" : "" %> take a
+                              <%= link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses", class: "govuk-link" %>.
+                            </span>
+                          <% end %>
                         <% end %>
                       </div>
                     <% end %>

--- a/spec/decorators/subject_decorator_spec.rb
+++ b/spec/decorators/subject_decorator_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe SubjectDecorator do
+  let(:subject_with_scholarship) { build(:subject, :mathematics, scholarship: "2000") }
+  let(:subject_with_bursary) { build(:subject, :biology, bursary_amount: "26000") }
+  let(:subject_with_scholarship_and_bursary) { build(:subject, :biology, scholarship: "10000", bursary_amount: "5000") }
+  let(:subject_with_early_career_payments) do
+    build(:subject,
+          :french,
+          scholarship: "10000",
+          bursary_amount: "5000",
+          early_career_payments: "1000")
+  end
+
+  context "financial information" do
+    describe "#has_scholarship?" do
+      it "returns true if the subject has a scholarship" do
+        expect(subject_with_scholarship.decorate.has_scholarship?).to be true
+      end
+
+      it "returns false if the subject doesn't have a scholarship" do
+        expect(subject_with_bursary.decorate.has_scholarship?).to be false
+      end
+    end
+
+    describe "#has_bursary?" do
+      it "returns true if the subject has a bursary" do
+        expect(subject_with_bursary.decorate.has_bursary?).to be true
+      end
+
+      it "returns false if the subject doesn't have a bursary" do
+        expect(subject_with_scholarship.decorate.has_bursary?).to be false
+      end
+    end
+
+    describe "#has_scholarship_and_bursary?" do
+      it "returns true if the subject has a scholarship and a bursary" do
+        expect(subject_with_scholarship_and_bursary.decorate.has_scholarship_and_bursary?).to be true
+      end
+
+      it "returns false if the subject have both scholarship and bursary" do
+        expect(subject_with_scholarship.decorate.has_scholarship_and_bursary?).to be false
+      end
+    end
+
+    describe "#early_career_payments?" do
+      it "returns true if early career payments are available" do
+        expect(subject_with_early_career_payments.decorate.early_career_payments?).to be true
+      end
+
+      it "returns false if early career payments are not available" do
+        expect(subject_with_scholarship.decorate.early_career_payments?).to be false
+      end
+    end
+  end
+end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     bursary_amount { nil }
     scholarship { nil }
     early_career_payments { nil }
+    subject_knowledge_enhancement_course_available { false }
 
     trait :english do
       subject_name { "English" }

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -8,10 +8,10 @@ feature "Subject filter", type: :feature do
     [
       build(:subject_area, subjects: [
         build(:subject, :primary, id: 1, bursary_amount: "1000"),
-        build(:subject, :biology, id: 10, scholarship: "2000"),
+        build(:subject, :biology, id: 10, scholarship: "2000", subject_knowledge_enhancement_course_available: true),
         build(:subject, :russian, id: 38, bursary_amount: "3000", scholarship: "4000", early_career_payments: "1000"),
         ]),
-      build(:subject_area, :secondary, subjects: [build(:subject, :english, id: 12)]),
+      build(:subject_area, :secondary, subjects: [build(:subject, :english, id: 12, subject_knowledge_enhancement_course_available: true)]),
     ]
   end
 
@@ -98,20 +98,24 @@ feature "Subject filter", type: :feature do
         subject_area.subjects.first.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.second.subject_name)
           expect(subject.info.text).to eq(expected_financial_info[0])
+          expect(subject.ske_course.text).to eq("You can also take a subject knowledge enhancement (SKE) course.")
         end
         subject_area.subjects.second.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.first.subject_name)
           expect(subject.info.text).to eq(expected_financial_info[1])
+          expect(subject).not_to have_ske_course
         end
         subject_area.subjects.third.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.third.subject_name)
           expect(subject.info.text).to eq(expected_financial_info[2])
+          expect(subject).not_to have_ske_course
         end
       end
       subject_filter_page.subject_areas.second.then do |subject_area|
         subject_area.subjects.first.then do |subject|
           expect(subject.name.text).to eq(subject_areas.second.subjects.first.subject_name)
           expect(subject.info.text).to eq(expected_financial_info[3])
+          expect(subject.ske_course.text).to eq("You can take a subject knowledge enhancement (SKE) course.")
         end
       end
       subject_filter_page.send_area.then do |subject_area|

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -6,8 +6,12 @@ feature "Subject filter", type: :feature do
 
   let(:subject_areas) do
     [
-      build(:subject_area, subjects: [build(:subject, :primary, id: 1), build(:subject, :biology, id: 10)]),
-      build(:subject_area, :secondary),
+      build(:subject_area, subjects: [
+        build(:subject, :primary, id: 1, bursary_amount: "1000"),
+        build(:subject, :biology, id: 10, scholarship: "2000"),
+        build(:subject, :russian, id: 38, bursary_amount: "3000", scholarship: "4000", early_career_payments: "1000"),
+        ]),
+      build(:subject_area, :secondary, subjects: [build(:subject, :english, id: 12)]),
     ]
   end
 
@@ -60,6 +64,15 @@ feature "Subject filter", type: :feature do
   end
 
   context "with no selected subjects" do
+    let(:expected_financial_info) do
+      [
+        "Scholarships of £2,000 are available.",
+        "Bursaries of £1,000 available.",
+        "Scholarships of £4,000 and bursaries of £3,000 are available, with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).",
+        "",
+      ]
+    end
+
     it "should set assistive technology attributes appropriately" do
       expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')
       expect(subject_filter_page.send_area.accordion_button).to match_selector('[aria-expanded="false"]')
@@ -80,13 +93,25 @@ feature "Subject filter", type: :feature do
       end
     end
 
-    it "displays all subjects" do
+    it "displays all subjects with financial information" do
       subject_filter_page.subject_areas.first.then do |subject_area|
         subject_area.subjects.first.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.second.subject_name)
+          expect(subject.info.text).to eq(expected_financial_info[0])
         end
         subject_area.subjects.second.then do |subject|
           expect(subject.name.text).to eq(subject_areas.first.subjects.first.subject_name)
+          expect(subject.info.text).to eq(expected_financial_info[1])
+        end
+        subject_area.subjects.third.then do |subject|
+          expect(subject.name.text).to eq(subject_areas.first.subjects.third.subject_name)
+          expect(subject.info.text).to eq(expected_financial_info[2])
+        end
+      end
+      subject_filter_page.subject_areas.second.then do |subject_area|
+        subject_area.subjects.first.then do |subject|
+          expect(subject.name.text).to eq(subject_areas.second.subjects.first.subject_name)
+          expect(subject.info.text).to eq(expected_financial_info[3])
         end
       end
       subject_filter_page.send_area.then do |subject_area|

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -7,6 +7,7 @@ module PageObjects
         class SubjectAreaSection < SitePrism::Section
           class Subject < SitePrism::Section
             element :name, '[data-qa="subject__name"]'
+            element :info, '[data-qa="subject__info"]'
             element :checkbox, '[data-qa="subject__checkbox"]'
           end
 

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -8,6 +8,7 @@ module PageObjects
           class Subject < SitePrism::Section
             element :name, '[data-qa="subject__name"]'
             element :info, '[data-qa="subject__info"]'
+            element :ske_course, '[data-qa="subject__ske_course"]'
             element :checkbox, '[data-qa="subject__checkbox"]'
           end
 


### PR DESCRIPTION
### Context
Information about financial incentives and subject knowledge enhancement course availability is not showing on the Subject Filter page.

### Changes proposed in this pull request
Add information under each subject that includes:
- Bursaries 
- Scholarships
- SKE courses

| Before       | After          | 
| ------------- |:-------------:| 
| <img width="572" alt="Screenshot 2020-02-12 at 11 03 34" src="https://user-images.githubusercontent.com/38078064/74332020-d0ad4d00-4d8c-11ea-99fb-e48e381cf774.png">| <img width="587" alt="Screenshot 2020-02-12 at 11 02 55" src="https://user-images.githubusercontent.com/38078064/74332035-d7d45b00-4d8c-11ea-8bf9-421ed21f4314.png"> |

 


### Guidance to review
Dependent on https://github.com/DFE-Digital/teacher-training-api/pull/1168

- run 2905-add-ske-attribute-to-subject branch of teacher-training-api locally
- visit http://localhost:3002/results/filter/subject
- should look like https://find-postgraduate-teacher-training.education.gov.uk/results/filter/subject


