### PR TITLE
[2950] Conditionally reveal the content of Location page radios

### DIFF
--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -34,7 +34,7 @@
               <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
             </div>
             <div
-              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless location_error? || params[:l] == "1" %>"
+              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "1" %>"
               id="location-conditional" data-qa="location-conditional">
               <div class="govuk-form-group <%= "govuk-form-group--error" if location_error? %>">
                 <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -34,8 +34,8 @@
               <%= form.label :l_1, "By postcode, town or city", class: "govuk-label govuk-radios__label" %>
             </div>
             <div
-              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless location_error? %>"
-              id="location-conditional">
+              class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless location_error? || params[:l] == "1" %>"
+              id="location-conditional" data-qa="location-conditional">
               <div class="govuk-form-group <%= "govuk-form-group--error" if location_error? %>">
                 <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
                 <% if location_error? %>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -102,7 +102,8 @@
                 By school, university or other training provider
               <% end %>
             </div>
-            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless request.params[:query] || provider_error? %>" id="query-container">
+            <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "3" %>"
+              id="query-container" data-qa="by-provider-conditional">
               <div class="govuk-form-group <%= "govuk-form-group--error" if provider_error? %>">
                 <%= form.label :query, class: "govuk-label" do %>
                   School, university or other training provider

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -158,6 +158,12 @@ feature "Location filter", type: :feature do
       filter_page.load(query: { l: 2 })
       expect(filter_page.across_england.checked?).to eq(true)
     end
+
+    it "Preselects by school, university or other training provider and reveals the content" do
+      filter_page.load(query: { l: 3 })
+      expect(filter_page.by_provider.checked?).to eq(true)
+      expect(filter_page.by_provider_conditional).not_to match_selector(".govuk-radios__conditional--hidden")
+    end
   end
 
   describe "Validation" do

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -148,6 +148,12 @@ feature "Location filter", type: :feature do
   end
 
   describe "Navigating to the page with currently selected filters" do
+    it "Preselects by postcode, town or city and reveals the content" do
+      filter_page.load(query: { l: 1 })
+      expect(filter_page.by_postcode_town_or_city.checked?).to eq(true)
+      expect(filter_page.location_conditional).not_to match_selector(".govuk-radios__conditional--hidden")
+    end
+
     it "Preselects across england" do
       filter_page.load(query: { l: 2 })
       expect(filter_page.across_england.checked?).to eq(true)

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -10,6 +10,7 @@ module PageObjects
         element :error_heading, '[data-qa="error__heading"]'
         element :across_england, '[data-qa="across-england"]'
         element :by_provider, '[data-qa="by-provider"]'
+        element :by_provider_conditional, '[data-qa="by-provider-conditional"]'
         element :provider_error, '[data-qa="provider-error"]'
         element :provider_search, '[data-qa="provider-search"]'
         element :find_courses, '[data-qa="find-courses"]'

--- a/spec/site_prism/page_objects/page/result_filters/location.rb
+++ b/spec/site_prism/page_objects/page/result_filters/location.rb
@@ -13,6 +13,7 @@ module PageObjects
         element :provider_error, '[data-qa="provider-error"]'
         element :provider_search, '[data-qa="provider-search"]'
         element :find_courses, '[data-qa="find-courses"]'
+        element :location_conditional, '[data-qa="location-conditional"]'
         element :location_error, '[data-qa="location-error"]'
         element :by_postcode_town_or_city, '[data-qa="by_postcode_town_or_city"]'
         element :location_query, '[data-qa="location-query"]'


### PR DESCRIPTION
### Context
When the location was preselected in the query string, the content of the 'By postcode, town or city' radio was not showing.

Selecting 'By postcode, town or city' sets the `l` query param to "1". When this param appears in the query we want to reveal the content of this radio.

### Changes proposed in this pull request
| Before       | After          | 
| ------------- |:-------------:| 
| <img width="1084" alt="Screenshot 2020-02-12 at 15 03 21" src="https://user-images.githubusercontent.com/38078064/74350965-60172800-4dae-11ea-8bd4-89f450eb3bf2.png">| <img width="1039" alt="Screenshot 2020-02-12 at 15 03 53" src="https://user-images.githubusercontent.com/38078064/74350976-64434580-4dae-11ea-9605-7ad0445bf5be.png">|

### Guidance to review
- visit http://localhost:3002/results/filter/location?l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster,+London+SW1P+3BT,+UK&lq=SW1P+3BT&rad=20&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False
- or just http://localhost:3002/results/filter/location?l=1
- the content for the first radio button should be showing like in [the c# version](https://find-postgraduate-teacher-training.education.gov.uk/?l=1)

