### PR TITLE
2896 - Place subject areas inside a fieldset

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -4,35 +4,37 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(url: subject_path, method: :post) do |f| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["subjects"], form: f %>
-      <fieldset class="govuk-fieldset">
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-heading-xl">Find courses by subject</h1>
-        </legend>
-        <p class="govuk-body">Select the subjects you want to teach.</p>
-        <h2 class="govuk-heading-m">Get financial support</h2>
-        <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
-        <p class="govuk-body">Visit Get into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
+      <h1 class="govuk-heading-xl">Find courses by subject</h1>
+
+      <p class="govuk-body">Select the subjects you want to teach.</p>
+      <h2 class="govuk-heading-m">Get financial support</h2>
+      <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
+      <p class="govuk-body">Visit Get into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
 
 
-        <div class="accordion govuk-form-group" data-module="govuk-accordion">
-          <% @subject_areas.each_with_index do |subject_area, counter| %>
-            <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) then " govuk-accordion__section--expanded" end %>" data-qa="subject_area">
-              <div class="govuk-accordion__section-header">
-                <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                  <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
-                    <%= subject_area.name %>
-                  </button>
-                </h2>
-                <span class="govuk-accordion__icon" aria-hidden="true"></span>
-              </div>
-              <div id="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
+      <div class="accordion govuk-form-group" data-module="govuk-accordion">
+        <% @subject_areas.each_with_index do |subject_area, counter| %>
+          <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) then " govuk-accordion__section--expanded" end %>" data-qa="subject_area">
+            <div class="govuk-accordion__section-header">
+              <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
+                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
+                  <%= subject_area.name %>
+                </button>
+              </h2>
+              <span class="govuk-accordion__icon" aria-hidden="true"></span>
+            </div>
+            <div id="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-visually-hidden" data-qa="subject_area__legend">
+                  Choose from the following <%= subject_area.name %> subjects
+                </legend>
                 <div class="govuk-checkboxes">
                   <% subject_area.subjects.sort_by{ |subject| subject.subject_name }.each do |subject| %>
                     <%# C# doesn't have a distinct modern languages subject %>
                     <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
                       <div class="govuk-checkboxes__item" data-qa="subject">
                         <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(id: subject.id), data: {qa: "subject__checkbox"}, id: "subject#{subject.id}", class: "govuk-checkboxes__input" }, subject.id, nil) %>
-                          <%= f.label(:subjects, {for: "subject#{subject.id}"}, class: "govuk-label govuk-checkboxes__label") do %>
+                        <%= f.label(:subjects, {for: "subject#{subject.id}"}, class: "govuk-label govuk-checkboxes__label") do %>
                           <span class="govuk-checkboxes__label-text" data-qa="subject__name">
                             <%= subject.subject_name %>
                           </span>
@@ -62,36 +64,36 @@
                     <% end %>
                   <% end %>
                 </div>
-              </div>
+              </fieldset>
             </div>
-          <% end %>
-          <div class="govuk-accordion__section<%= if params[:senCourses] == "true" then " govuk-accordion__section--expanded" end %>" data-qa="send_area">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="send-content" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">
-                  Special educational needs and disability (SEND)
-                </button>
-              </h2>
-              <span class="govuk-accordion__icon" aria-hidden="true"></span>
-            </div>
-            <div id="send-content" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
-              <div class="govuk-checkboxes">
-                <div class="govuk-checkboxes__item" data-qa="subject">
-                  <%= f.check_box(:senCourses, { checked: params[:senCourses] == "true", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'true', nil) %>
-                  <%= f.label(:subjects, {for: "subject_send", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
-                    <span class="govuk-checkboxes__label-text">
-                      Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
-                    </span>
-                    <span class="govuk-!-display-block"></span>
-                  <% end %>
-                </div>
+          </div>
+        <% end %>
+        <div class="govuk-accordion__section<%= if params[:senCourses] == "true" then " govuk-accordion__section--expanded" end %>" data-qa="send_area">
+          <div class="govuk-accordion__section-header">
+            <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
+              <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="send-content" class="govuk-accordion__section-button" aria-expanded="<%= if params[:senCourses] == "true" then "true" else "false" end %>">
+                Special educational needs and disability (SEND)
+              </button>
+            </h2>
+            <span class="govuk-accordion__icon" aria-hidden="true"></span>
+          </div>
+          <div id="send-content" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
+            <div class="govuk-checkboxes">
+              <div class="govuk-checkboxes__item" data-qa="subject">
+                <%= f.check_box(:senCourses, { checked: params[:senCourses] == "true", data: {qa: "subject__checkbox"}, id: "subject_send", class: "govuk-checkboxes__input" }, 'true', nil) %>
+                <%= f.label(:subjects, {for: "subject_send", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
+                  <span class="govuk-checkboxes__label-text">
+                    Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
+                  </span>
+                  <span class="govuk-!-display-block"></span>
+                <% end %>
               </div>
             </div>
           </div>
         </div>
+      </div>
 
-        <%= f.submit(local_assigns[:submit_button_text], name: nil, data: {qa: "continue"}, class: "govuk-button" )%>
-      </fieldset>
+      <%= f.submit(local_assigns[:submit_button_text], name: nil, data: {qa: "continue"}, class: "govuk-button" )%>
     <% end %>
   </div>
 </div>

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -61,6 +61,12 @@ feature "Subject filter", type: :feature do
       expect(subject_filter_page.send_area.accordion_button["aria-controls"]).to eq("send-content")
       expect(subject_filter_page.send_area).to have_selector("div#send-content")
     end
+
+    it "has a fieldset and legend for each subject area" do
+      subject_filter_page.subject_areas.each_with_index { |subject, counter|
+        expect(subject.legend.text).to eq("Choose from the following #{subject_areas[counter].name} subjects")
+      }
+    end
   end
 
   context "on the start page" do

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -12,6 +12,7 @@ module PageObjects
             element :checkbox, '[data-qa="subject__checkbox"]'
           end
 
+          element :legend, '[data-qa="subject_area__legend"]'
           element :name, '[data-qa="subject_area__name"]'
           element :accordion_button, '[data-qa="subject_area__accordion_button"]'
           sections :subjects, Subject, '[data-qa="subject"]'


### PR DESCRIPTION
After an accessibility audit in December 2019, It was suggested
that each subject area should be placed inside its own fieldset
to help screen reader users understand the context of each
subject area options. It was also suggested that we remove the
main fieldset/legend.

### Guidance to review
No visual changes but you should be able to see the fieldset wrapped around the each group of subject are checkboxes
