### PR TITLE
[2955] Display additional content for Design and tech on Subject page

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -35,6 +35,9 @@
                           <%= f.label(:subjects, {for: "subject#{subject.id}"}, class: "govuk-label govuk-checkboxes__label") do %>
                           <span class="govuk-checkboxes__label-text" data-qa="subject__name">
                             <%= subject.subject_name %>
+                            <% if subject.subject_name == "Design and technology" %>
+                              – also includes food, product design, textiles, and systems and control
+                            <% end %>
                           </span>
 
                           <% if subject.decorate.has_scholarship_and_bursary? %>

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     trait :primary do
       subject_name { "Primary" }
     end
+
+    trait :design_and_technology do
+      subject_name { "Design and technology" }
+    end
   end
 end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -215,4 +215,16 @@ feature "Subject filter", type: :feature do
       expect(subject_filter_page.subject_areas.first.subjects.length).to eq(0)
     end
   end
+
+  context "with the design and technology subject" do
+    let(:subject_areas) do
+      [
+        build(:subject_area, subjects: [build(:subject, :design_and_technology)]),
+      ]
+    end
+
+    it "displays additional content" do
+      expect(subject_filter_page.subject_areas.first.subjects.first.name.text).to eq("Design and technology – also includes food, product design, textiles, and systems and control")
+    end
+  end
 end


### PR DESCRIPTION
### Context
We need to display additional content for "Design and technology" on Subject page.

### Changes proposed in this pull request
| Before       | After          | 
| ------------- |:-------------:| 
|<img width="550" alt="Screenshot 2020-02-13 at 09 50 01" src="https://user-images.githubusercontent.com/38078064/74422366-66f17980-4e46-11ea-9a49-b4daa5e2a9e7.png">|<img width="554" alt="Screenshot 2020-02-13 at 09 49 45" src="https://user-images.githubusercontent.com/38078064/74422384-6bb62d80-4e46-11ea-8918-b40c1b04e99b.png">|
### Guidance to review
- visit http://localhost:3002/results/filter/subject?subjects=8

