### PR TITLE
2896 - Explain abbreviations for the first time.

### DIFF
--- a/app/views/courses/qualification/_pgce.html.erb
+++ b/app/views/courses/qualification/_pgce.html.erb
@@ -1,6 +1,6 @@
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE</span>
+    <span class="govuk-details__summary-text">Postgraduate Certificate in Education (PGCE)</span>
   </summary>
   <div class="govuk-details__text">
     <p class="govuk-body">

--- a/app/views/courses/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgce_with_qts.html.erb
@@ -1,6 +1,6 @@
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE with QTS</span>
+    <span class="govuk-details__summary-text">Postgraduate certificate in education (PGCE) with qualified teacher status (QTS)</span>
   </summary>
   <div class="govuk-details__text">
     <p class="govuk-body">

--- a/app/views/courses/qualification/_pgde.html.erb
+++ b/app/views/courses/qualification/_pgde.html.erb
@@ -1,6 +1,6 @@
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE</span>
+    <span class="govuk-details__summary-text">Postgraduate diploma in education (PGDE)</span>
   </summary>
   <div class="govuk-details__text">
     <p class="govuk-body">

--- a/app/views/courses/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgde_with_qts.html.erb
@@ -1,6 +1,6 @@
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE with QTS</span>
+    <span class="govuk-details__summary-text">Postgraduate diploma in education (PGDE) with qualified teacher status (QTS)</span>
   </summary>
   <div class="govuk-details__text">
     <p class="govuk-body">

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -1,6 +1,6 @@
 <details class="govuk-details" data-module="govuk-details">
   <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">QTS</span>
+    <span class="govuk-details__summary-text">Qualified teacher status (QTS)</span>
   </summary>
   <div class="govuk-details__text">
     <p class="govuk-body">

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -105,7 +105,7 @@ feature "Course show", type: :feature do
       )
 
       expect(course_page.qualifications).to have_content(
-        "PGCE with QTS",
+        "Postgraduate certificate in education (PGCE) with qualified teacher status (QTS)",
       )
 
       expect(course_page.funding_option).to have_content(


### PR DESCRIPTION
An issue raised in a recent accessibility audit.

There are abbreviated words present on the page (PGCE with QTS) that have
not been explained in their first instance.

### Context

### Changes proposed in this pull request

### Guidance to review

