### PR TITLE
[2966] change course model link to provider code

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -10,7 +10,6 @@ class ResultsController < ApplicationController
       .includes(:financial_incentive)
       .includes(:subjects)
       .where(recruitment_cycle_year: Settings.current_cycle)
-      .where(provider_code: nil)
       .page(params[:page])
       .per(10)
       .select(courses: %i[

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,6 +1,6 @@
 class Course < Base
   belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
-  belongs_to :provider, param: :provider_code
+  belongs_to :provider, param: :provider_code, shallow_path: true
   has_many :site_statuses
   has_many :sites, through: :site_statuses, source: :site
   has_many :subjects

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -61,10 +61,7 @@ feature "Search results", type: :feature do
       providers: %i[provider_name address1 address2 address3 address4 postcode],
     }
 
-    params = {
-      recruitment_cycle_year: Settings.current_cycle,
-      provider_code: nil,
-    }
+    params = { recruitment_cycle_year: Settings.current_cycle }
 
     pagination = { page: page_index || 1, per_page: 10 }
 


### PR DESCRIPTION
Co-authored-by: Faissal Bensefia <faissal@madetech.com>

### Context

[This](https://trello.com/c/tvPnfnbr/2966-find-breaks-when-making-api-call-using-provider-code) Trello card has it

### Changes proposed in this pull request

Change the course model to use the shallow_path flag for course codes

### Guidance to review
