### PR TITLE
[2839] - Update Azure template for accessing Google geocode api key

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -281,7 +281,7 @@
                 "value": "[parameters('settingsGoogleMapsAPIKey')]"
               },
               {
-                "name": "SETTINGS__GCP_API_KEY",
+                "name": "SETTINGS__GOOGLE__GCP_API_KEY",
                 "value": "[parameters('settingsGoogleGeocodeAPIKey')]"
               },
               {


### PR DESCRIPTION
### Context

This is because the rails settings were updated in https://github.com/DFE-Digital/find-teacher-training/pull/94 .


