### PR TITLE
2829 provider filter show filter on results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -89,6 +89,14 @@ class ResultsView
 &markers=#{latitude},#{longitude}"
   end
 
+  def provider
+    query_parameters["query"]
+  end
+
+  def provider_filter?
+    query_parameters["l"] == "3"
+  end
+
 private
 
   attr_reader :query_parameters

--- a/app/views/results/_location.html.erb
+++ b/app/views/results/_location.html.erb
@@ -16,8 +16,8 @@
       <% end %>
     </li>
   </ul>
-  <%=link_to "Change location or choose a provider",
+  <%= link_to "Change location or choose a provider",
              @results_view.filter_path_with_unescaped_commas(location_path),
              class: "govuk-link",
-             data: { qa: "change_link" }%>
+             data: { qa: "change_link" } %>
 </div>

--- a/app/views/results/_provider.html.erb
+++ b/app/views/results/_provider.html.erb
@@ -1,0 +1,14 @@
+<div class="filter-form" data-qa="filters__provider">
+  <h2 class="govuk-heading-s filter-form__title">
+    Provider name<span class="govuk-visually-hidden">:</span>
+  </h2>
+  <ul class="filter-form__value--list">
+    <li data-qa="provider_name">
+      <%= @results_view.provider %>
+    </li>
+  </ul>
+  <%= link_to "Change provider or choose a location",
+             @results_view.filter_path_with_unescaped_commas(location_path),
+             class: "govuk-link",
+             data: { qa: "change_link" } %>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -3,18 +3,27 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">Teacher training courses</h1>
+      <% if @results_view.provider_filter? %>
+        <h1 class="govuk-heading-xl" data-qa="provider_title">
+          <span class="govuk-caption-l">Teacher training courses</span>
+          <%= @results_view.provider %>
+        </h1>
+      <% else %>
+        <h1 class="govuk-heading-xl">Teacher training courses</h1>
+      <% end %>
     </div>
   </div>
-
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <div class="govuk-toggle" data-module="toggle">
         <button class="govuk-toggle__link js-toggle" aria-expanded="false" aria-controls="searchFilters">
-          Filter the results
         </button>
         <div class="govuk-toggle__target" id="searchFilters" data-qa="filters">
-          <%= render partial: 'results/location' %>
+          <% if @results_view.provider_filter? %>
+            <%= render partial: 'results/provider' %>
+          <% else %>
+            <%= render partial: 'results/location' %>
+          <% end %>
           <%= render partial: 'results/subjects' %>
           <%= render partial: 'results/study_type' %>
           <%= render partial: 'results/qualifications' %>

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -231,18 +231,36 @@ feature "results", type: :feature do
             rad: "10",
             lng: "-27.1504002",
             lat: "-109.3042697",
+            l: "1",
           }
         end
 
         it "displays the location filter" do
           expected_url = "https://maps.googleapis.com/maps/api/staticmap?key=alohomora&center=-109.3042697,-27.1504002&zoom=11&size=300x200&scale=2&markers=-109.3042697,-27.1504002"
+          expect(results_page).to_not have_provider_filter
           expect(results_page.location_filter.name).to have_content("Hogwarts, Reading, UK")
           expect(results_page.location_filter.distance).to have_content("Within 10 miles of the pin")
           expect(results_page.location_filter.map["src"]).to have_content(expected_url)
           results_page.location_filter.link.click
           location_filter_uri = URI(current_url)
           expect(location_filter_uri.path).to eq("/results/filter/location")
-          expect(location_filter_uri.query).to eq("lat=-109.3042697&lng=-27.1504002&loc=Hogwarts,+Reading,+UK&rad=10&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
+          expect(location_filter_uri.query).to eq("l=1&lat=-109.3042697&lng=-27.1504002&loc=Hogwarts,+Reading,+UK&rad=10&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
+        end
+      end
+    end
+
+    describe "provider filter" do
+      context "provider selected" do
+        let(:params) { { query: "Junior Middle Lower Upper Second Fifth High", l: "3" } }
+
+        it "displays the provider filter" do
+          expect(results_page.provider_title).to have_content("Junior Middle Lower Upper Second Fifth High")
+          expect(results_page).to_not have_location_filter
+          expect(results_page.provider_filter.name).to have_content("Junior Middle Lower Upper Second Fifth High")
+          results_page.provider_filter.link.click
+          provider_filter_uri = URI(current_url)
+          expect(provider_filter_uri.path).to eq("/results/filter/location")
+          expect(provider_filter_uri.query).to eq("l=3&query=Junior+Middle+Lower+Upper+Second+Fifth+High&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
         end
       end
     end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -43,6 +43,11 @@ module PageObjects
       element :link, '[data-qa="change_link"]'
     end
 
+    class ProviderSection < SitePrism::Section
+      element :name, '[data-qa="provider_name"]'
+      element :link, '[data-qa="change_link"]'
+    end
+
     class Results < SitePrism::Page
       set_url "/results"
 
@@ -53,7 +58,9 @@ module PageObjects
       section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
       section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
       section :location_filter, LocationSection, '[data-qa="filters__location"]'
+      section :provider_filter, ProviderSection, '[data-qa="filters__provider"]'
 
+      element :provider_title, '[data-qa="provider_title"]'
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -311,4 +311,24 @@ RSpec.describe ResultsView do
 
     it { is_expected.to eq("https://maps.googleapis.com/maps/api/staticmap?key=yellowskullkey&center=-109.3042697,-27.1504002&zoom=11&size=300x200&scale=2&markers=-109.3042697,-27.1504002") }
   end
+
+  describe "#provider" do
+    subject { described_class.new(query_parameters: parameter_hash).provider }
+
+    context "when query is passed" do
+      let(:parameter_hash) { { "query" => "Kamino" } }
+
+      it { is_expected.to eq("Kamino") }
+    end
+  end
+
+  describe "#provider_filter?" do
+    subject { described_class.new(query_parameters: parameter_hash).provider_filter? }
+
+    context "when l param is set to 3" do
+      let(:parameter_hash) { { "l" => "3" } }
+
+      it { is_expected.to be(true) }
+    end
+  end
 end


### PR DESCRIPTION
### Context

[See this Trello Card](https://trello.com/c/wjtu9XYW/2829-m-provider-filter-show-filter-on-results-page) for more details. We're adding the provider filter to the page, which is done through a partial. Have also got some logic on the page to determine which filter is shown (location or provider) depending on the "l" param passed through based on the radio button selected. 

### Changes proposed in this pull request

Adds a provider partial, and a method to the ResultsView to pull through the query param with the provider name. 

### Guidance to review

Selecting Across England will show the location filter on the results page 

![image](https://user-images.githubusercontent.com/25597009/74452239-b6509d80-4e78-11ea-9d63-d17278c86085.png)

Whereas selecting a provider shows the provider filter instead

![image](https://user-images.githubusercontent.com/25597009/74454970-94f1b080-4e7c-11ea-813f-d50bc13c8054.png)

