### PR TITLE
[2960] Add subject filter validation

### DIFF
--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -14,7 +14,12 @@ module ResultFilters
     def start; end
 
     def create
-      redirect_to results_path(filter_params.merge(subjects: convert_rails_subject_id_params_to_csharp))
+      if params[:subjects].blank? && (params[:senCourses].blank? || params[:senCourses] == "false")
+        flash[:error] = [I18n.t("subject_filter.errors.no_option")]
+        redirect_to subject_path(filter_params)
+      else
+        redirect_to results_path(filter_params.merge(subjects: convert_rails_subject_id_params_to_csharp))
+      end
     end
 
   private

--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -15,5 +15,11 @@ module ResultFilters
 
       (params["subjects"] & subject_area.subjects.map(&:id)).any?
     end
+
+    def no_subject_selected_error?
+      return false if flash[:error].nil?
+
+      flash[:error].include?(I18n.t("subject_filter.errors.no_option"))
+    end
   end
 end

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "result_filters/error_message" %>
+    <%= render partial: "result_filters/error_message", locals: { error_anchor_id: "subject1" } %>
 
     <%= form_with(url: subject_path, method: :post) do |f| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["subjects"], form: f %>
@@ -16,10 +16,10 @@
 
       <div class="accordion govuk-form-group" data-module="govuk-accordion">
         <% @subject_areas.each_with_index do |subject_area, counter| %>
-          <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) then " govuk-accordion__section--expanded" end %>" data-qa="subject_area">
+          <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) || (counter == 0 && no_subject_selected_error?) then " govuk-accordion__section--expanded" end %>" data-qa="subject_area">
             <div class="govuk-accordion__section-header">
               <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) then "true" else "false" end %>">
+                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= if subject_area_is_selected?(subject_area: subject_area) || (counter == 0 && no_subject_selected_error?) then "true" else "false" end %>">
                   <%= subject_area.name %>
                 </button>
               </h2>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -2,6 +2,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render partial: "result_filters/error_message" %>
+
     <%= form_with(url: subject_path, method: :post) do |f| %>
       <%= render 'result_filters/hidden_fields', exclude_keys: ["subjects"], form: f %>
       <h1 class="govuk-heading-xl">Find courses by subject</h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,3 +56,6 @@ en:
     fields:
       location: "Postcode, town or city"
       provider: "Training provider"
+  subject_filter:
+    errors:
+      no_option: "Please choose at least one subject"

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -233,4 +233,17 @@ feature "Subject filter", type: :feature do
       expect(subject_filter_page.subject_areas.first.subjects.first.name.text).to eq("Design and technology – also includes food, product design, textiles, and systems and control")
     end
   end
+
+  describe "Validation" do
+    context "no subject selected" do
+      before do
+        subject_filter_page.load
+        subject_filter_page.continue.click
+      end
+
+      it "displays an error" do
+        expect(subject_filter_page).to have_error
+      end
+    end
+  end
 end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -244,6 +244,14 @@ feature "Subject filter", type: :feature do
       it "displays an error" do
         expect(subject_filter_page).to have_error
       end
+
+      it "expands the first accordion and sets assistive technology attributes appropriately" do
+        expect(subject_filter_page.subject_areas.first.root_element).to match_selector(".govuk-accordion__section--expanded")
+        expect(subject_filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="true"]')
+
+        expect(subject_filter_page.subject_areas.second.root_element).not_to match_selector(".govuk-accordion__section--expanded")
+        expect(subject_filter_page.subject_areas.second.accordion_button).not_to match_selector('[aria-expanded="true"]')
+      end
     end
   end
 end

--- a/spec/helpers/result_filters/subject_helper_spec.rb
+++ b/spec/helpers/result_filters/subject_helper_spec.rb
@@ -12,4 +12,16 @@ feature "ResultFilters::SubjectHelper", type: :helper do
       expect(helper.subject_is_selected?(id: "4")).to eq(false)
     end
   end
+
+  describe "#no_subject_selected_error?" do
+    it "returns true if no subject is selected" do
+      allow(controller).to receive(:flash).and_return(error: I18n.t("subject_filter.errors.no_option"))
+
+      expect(helper.no_subject_selected_error?).to eq(true)
+    end
+
+    it "returns false if there is no subject selected" do
+      expect(helper.no_subject_selected_error?).to eq(false)
+    end
+  end
 end

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -19,6 +19,7 @@ module PageObjects
         end
 
         element :back_link, '[data-qa="page-back"]'
+        element :error, '[data-qa="error"]'
 
         sections :subject_areas, SubjectAreaSection, '[data-qa="subject_area"]'
         section :send_area, SubjectAreaSection, '[data-qa="send_area"]'


### PR DESCRIPTION
### Context
There is no validation on the subject filter, that exists in the [C# version](https://find-postgraduate-teacher-training.education.gov.uk/start/subject?l=2).

### Changes proposed in this pull request
Add validation and display an error to the user. Error messages is linked to the first checkbox.

![subject_validation](https://user-images.githubusercontent.com/38078064/74536290-b495e100-4f2f-11ea-923e-590996a0eb6c.gif)

### Guidance to review
- visit http://localhost:3002/start/subject?l=2
- click Continue
- _error should appear_
- click Please choose at least one subject
- _it should be linked to the first checkbox ([like in this example](https://design-system.service.gov.uk/components/error-summary/linking-checkboxes-radios/index.html)) and the first accordion should be expanded_

**Review questions:**
- Do we need to be testing the error text "Please choose at least one subject" ?
- Should `no_subject_selected_error?` return `false` instead of `nil`?

Note: I will wait for Graham & Toby to merge their changes first and rebase with master (and change the tests in line with that they did).