### PR TITLE
2968 - Initial markup and styling of the cookie banner

### DIFF
--- a/app/views/layouts/_cookie-banner.html.erb
+++ b/app/views/layouts/_cookie-banner.html.erb
@@ -1,0 +1,19 @@
+<div class="app-cookie-banner app-cookie-banner--hidden" aria-label="Cookie banner" role="region" data-qa="cookie-banner">
+  <div class="govuk-width-container">
+    <p class="govuk-body">
+      We use cookies to <%= link_to("collect information", cookies_path,
+                                    { class: "govuk-link app-cookie-banner__link",
+                                      data: {qa: "cookie-banner__info-link"}}) %>
+      about how you use this service.
+    </p>
+    <p class="govuk-body govuk-!-margin-bottom-0">
+      <button type="button" class="govuk-button govuk-!-margin-bottom-2"
+              data-qa="cookie-banner__accept">Accept all cookies</button>
+      <span class="app-cookie-banner__line-message">
+        or <%= link_to("set your cookie preferences", cookies_path,
+                       { class: "govuk-link app-cookie-banner__link",
+                         data: {qa: "cookie-banner__preference-link"}}) %>
+      </span>
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
     </script>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-
+    <%= render partial: 'layouts/cookie-banner' %>
     <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">

--- a/app/webpacker/styles/components/_cookie-banner.scss
+++ b/app/webpacker/styles/components/_cookie-banner.scss
@@ -1,17 +1,25 @@
 .app-cookie-banner {
-  @include govuk-font(16);
-  @include govuk-text-colour;
-  box-sizing: border-box;
-  display: none;
-  padding-top: govuk-spacing(3);
-  padding-bottom: govuk-spacing(3);
-  background-color: lighten(desaturate(govuk-colour("light-blue"), 8.46), 42.55);
-  width: 100%;
+  @include govuk-responsive-padding(3, 'top');
+  @include govuk-responsive-padding(2, 'bottom');
+  background-color: govuk-colour('light-grey');
 }
 
-.app-cookie-banner__message {
-  margin: 0;
-  @include govuk-width-container;
+.app-cookie-banner--hidden {
+  display: none;
+}
+
+.app-cookie-banner__line-message {
+  line-height: 2;
+  padding-left: govuk-spacing(0);
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: govuk-spacing(2);
+  }
+}
+
+.app-cookie-banner__link {
+  // To match links styling in the footer
+  color: govuk-colour('black') !important;
 }
 
 @include govuk-media-query($media-type: print) {

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "cookie banner", type: :feature do
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:params) {}
+  let(:subject_areas) do
+    [
+        build(:subject_area, subjects: [
+            build(:subject, :primary, id: 1),
+            build(:subject, :biology, id: 10),
+            build(:subject, :english, id: 21),
+            build(:subject, :mathematics, id: 25),
+            build(:subject, :french, id: 34),
+        ]),
+        build(:subject_area, :secondary),
+    ]
+  end
+
+  before do
+    stub_results_page_request
+
+    stub_api_v3_resource(type: SubjectArea,
+                          resources: subject_areas,
+                          include: [:subjects])
+
+    visit results_path(params)
+  end
+
+  it "displays a cookie banner" do
+    expect(results_page).to have_cookie_banner
+    expect(results_page.cookie_banner).to have_accept_all_cookies
+    expect(results_page.cookie_banner).to have_set_preference_link
+  end
+end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -1,5 +1,11 @@
 module PageObjects
   module Page
+    class CookieBannerSection < SitePrism::Section
+      element :cookies_info_link, '[data-qa="cookie-banner__info-link"]'
+      element :accept_all_cookies, '[data-qa="cookie-banner__accept"]'
+      element :set_preference_link, '[data-qa="cookie-banner__preference-link"]'
+    end
+
     class CourseSection < SitePrism::Section
       element :provider_name, '[data-qa="course__provider_name"]'
       element :description, '[data-qa="course__description"]'
@@ -51,6 +57,7 @@ module PageObjects
     class Results < SitePrism::Page
       set_url "/results"
 
+      section :cookie_banner, CookieBannerSection, '[data-qa="cookie-banner"]'
       sections :courses, CourseSection, '[data-qa="course"]'
       section :subjects_filter, SubjectsSection, '[data-qa="filters__subjects"]'
       section :study_type_filter, StudyTypeSection, '[data-qa="filters__studytype"]'


### PR DESCRIPTION
This is the initial markup and styling needed to support our cookies feature. The banner should not be shown just yet as there is some css that hides it by default. There will be some javascript added later that will determine whether or not to show the banner.

### Guidance to review
The banner should not be visible at this point but you can review it by doing the following (examples of what it should look can be found below):

1. Visit any page
2. Open the dev tools
3. Remove `app-cookie-banner--hidden` class from the cookie banner

Alternatively,

1. edit `app/views/layout/_cookie-banner.html.erb
2. Remove `app-cookie-banner--hidden` css class on the first line


#### Before:
<img width="1127" alt="Screenshot 2020-02-17 at 09 12 35" src="https://user-images.githubusercontent.com/3441519/74639464-e09aa780-5165-11ea-9dff-32d8cdd28156.png">


#### After:
<img width="1127" alt="Screenshot 2020-02-17 at 09 12 17" src="https://user-images.githubusercontent.com/3441519/74639446-d7113f80-5165-11ea-841e-18cbc94a6427.png">

