### PR TITLE
[2970] Return user back to location wizard on validation error

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -30,7 +30,11 @@ module ResultFilters
         redirect_to results_path(all_params)
       else
         flash[:error] = form_object.errors
-        redirect_to location_path(form_params)
+        if flash[:start_wizard]
+          redirect_to root_path(form_params)
+        else
+          redirect_to location_path(form_params)
+        end
       end
     end
 

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -58,6 +58,14 @@ feature "Location filter", type: :feature do
           expect(uri.query).to eq("l=2")
         end
       end
+
+      it "stays on start page after validations" do
+        visit root_path
+        filter_page.find_courses.click
+
+        expect(filter_page).to have_error
+        expect(page).to have_current_path(root_path, ignore_query: true)
+      end
     end
   end
 
@@ -172,6 +180,8 @@ feature "Location filter", type: :feature do
       filter_page.find_courses.click
 
       expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPlease choose an option")
+
+      expect(page).to have_current_path(location_path, ignore_query: true)
     end
 
     it "Displays an error if location is selected but none is entered" do


### PR DESCRIPTION
### Context
Return user back to location wizard on validation error if they started on location wizard and vice versa for location filter page

### Changes proposed in this pull request

Fixed validation
After validation users ends up on the root path instead of location path

### Guidance to review
:shipit: 
