### PR TITLE
[2979] - add filtering for salary, qualification, vacancies & study type

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -4,31 +4,7 @@ class ResultsController < ApplicationController
 
   def index
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
-    @courses = Course
-      .includes(:provider)
-      .includes(:accrediting_provider)
-      .includes(:financial_incentive)
-      .includes(:subjects)
-      .where(recruitment_cycle_year: Settings.current_cycle)
-      .page(params[:page])
-      .per(10)
-      .select(courses: %i[
-          provider_code
-          course_code
-          name
-          description
-          funding_type
-          provider
-          accrediting_provider
-          subjects
-        ], providers: %i[
-          provider_name
-          address1
-          address2
-          address3
-          address4
-          postcode
-        ]).all
+
     @subjects =
       if params["subjects"].present?
         SubjectArea.includes(:subjects).all

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -105,6 +105,7 @@ class ResultsView
 
                    base_query = base_query.where(funding: "salary") if with_salaries?
                    base_query = base_query.where(vacancies: hasvacancies?)
+                   base_query = base_query.where(study_type: study_type) if study_type.present?
 
                    base_query
                      .page(query_parameters[:page] || 1)
@@ -167,5 +168,11 @@ private
     else
       "14"
     end
+  end
+
+  def study_type
+    return "full_time,part_time" if fulltime? && parttime?
+    return "full_time" if fulltime?
+    return "part_time" if parttime?
   end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -114,8 +114,8 @@ class ResultsView
                  end
   end
 
-  def total_course_count
-    courses.total_count
+  def course_count
+    courses.count
   end
 
 private

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -104,6 +104,7 @@ class ResultsView
                      .where(recruitment_cycle_year: Settings.current_cycle)
 
                    base_query = base_query.where(funding: "salary") if with_salaries?
+                   base_query = base_query.where(vacancies: hasvacancies?)
 
                    base_query
                      .page(query_parameters[:page] || 1)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -81,12 +81,12 @@ class ResultsView
 
   def map_image_url
     "#{Settings.google.maps_api_url}\
-    ?key=#{Settings.google.maps_api_key}\
-    &center=#{latitude},#{longitude}\
-    &zoom=#{google_map_zoom}\
-    &size=300x200\
-    &scale=2\
-    &markers=#{latitude},#{longitude}"
+?key=#{Settings.google.maps_api_key}\
+&center=#{latitude},#{longitude}\
+&zoom=#{google_map_zoom}\
+&size=300x200\
+&scale=2\
+&markers=#{latitude},#{longitude}"
   end
 
   def provider

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -106,7 +106,7 @@ class ResultsView
                    base_query = base_query.where(funding: "salary") if with_salaries?
                    base_query = base_query.where(vacancies: hasvacancies?)
                    base_query = base_query.where(study_type: study_type) if study_type.present?
-                   base_query = base_query.where(qualifications: query_parameters["qualifications"]) if query_parameters["qualifications"].present?
+                   base_query = base_query.where(qualifications: qualifications)
 
                    base_query
                      .page(query_parameters[:page] || 1)
@@ -178,6 +178,6 @@ private
   end
 
   def qualifications
-    query_parameters["qualifications"].present? && query_parameters["qualifications"]
+    query_parameters["qualifications"] || "QtsOnly,PgdePgceWithQts,Other"
   end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -106,6 +106,7 @@ class ResultsView
                    base_query = base_query.where(funding: "salary") if with_salaries?
                    base_query = base_query.where(vacancies: hasvacancies?)
                    base_query = base_query.where(study_type: study_type) if study_type.present?
+                   base_query = base_query.where(qualifications: query_parameters["qualifications"]) if query_parameters["qualifications"].present?
 
                    base_query
                      .page(query_parameters[:page] || 1)
@@ -174,5 +175,9 @@ private
     return "full_time,part_time" if fulltime? && parttime?
     return "full_time" if fulltime?
     return "part_time" if parttime?
+  end
+
+  def qualifications
+    query_parameters["qualifications"].present? && query_parameters["qualifications"]
   end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -81,12 +81,12 @@ class ResultsView
 
   def map_image_url
     "#{Settings.google.maps_api_url}\
-?key=#{Settings.google.maps_api_key}\
-&center=#{latitude},#{longitude}\
-&zoom=#{google_map_zoom}\
-&size=300x200\
-&scale=2\
-&markers=#{latitude},#{longitude}"
+    ?key=#{Settings.google.maps_api_key}\
+    &center=#{latitude},#{longitude}\
+    &zoom=#{google_map_zoom}\
+    &size=300x200\
+    &scale=2\
+    &markers=#{latitude},#{longitude}"
   end
 
   def provider
@@ -95,6 +95,24 @@ class ResultsView
 
   def provider_filter?
     query_parameters["l"] == "3"
+  end
+
+  def courses
+    @courses ||= begin
+                   base_query = Course
+                     .includes(:provider)
+                     .where(recruitment_cycle_year: Settings.current_cycle)
+
+                   base_query = base_query.where(funding: "salary") if with_salaries?
+
+                   base_query
+                     .page(query_parameters[:page] || 1)
+                     .per(10)
+                 end
+  end
+
+  def total_course_count
+    courses.total_count
   end
 
 private

--- a/app/views/result_filters/funding/new.html.erb
+++ b/app/views/result_filters/funding/new.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <div class="govuk-width-container">
-  <h1 class="govuk-heading-xl">Find courses that pay a salary</h1>
+  <h1 class="govuk-heading-xl" data-qa="heading">Find courses that pay a salary</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -12,7 +12,7 @@
       <%= render 'result_filters/hidden_fields', exclude_keys: ["qualifications"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend>
-          <h1 class="govuk-heading-xl">What you will get</h1>
+          <h1 class="govuk-heading-xl" data-qa="heading">What you will get</h1>
         </legend>
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -11,7 +11,7 @@
       <%= render 'result_filters/hidden_fields', exclude_keys: ["fulltime", "parttime"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend>
-          <h1 class="govuk-heading-xl">Study type</h1>
+          <h1 class="govuk-heading-xl" data-qa="heading">Study type</h1>
         </legend>
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -10,7 +10,7 @@
       <%= render 'result_filters/hidden_fields', exclude_keys: ["hasvacancies"], form: form %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-heading-xl">Find courses by vacancies</h1>
+          <h1 class="govuk-heading-xl" data-qa="heading">Find courses by vacancies</h1>
         </legend>
 
         <div class="govuk-form-group">

--- a/app/views/results/_funding.html.erb
+++ b/app/views/results/_funding.html.erb
@@ -3,13 +3,15 @@
     Salary<span class="govuk-visually-hidden">:</span>
   </h2>
   <ul class="filter-form__value--list">
-    <li data-qa="funding">
-      <% if @results_view.with_salaries? %>
+    <% if @results_view.with_salaries? %>
+      <li data-qa="with-salary">
         Only courses with a salary
-      <% else %>
+      </li>
+    <% else %>
+      <li data-qa="with-or-without-salary">
         Courses with and without salary
-      <% end %>
-    </li>
+      </li>
+    <% end %>
   </ul>
   <%= link_to "Change salary option", @results_view.filter_path_with_unescaped_commas(funding_path), class: "govuk-link", data: { qa: "link" } %>
 </div>

--- a/app/views/results/_qualifications.html.erb
+++ b/app/views/results/_qualifications.html.erb
@@ -7,13 +7,13 @@
       <li data-qa="qualifications">All qualifications</li>
     <% else %>
       <% if @results_view.qts_only? %>
-        <li data-qa="qualifications">QTS only</li>
+        <li data-qa="qts_only">QTS only</li>
       <% end %>
       <% if @results_view.pgce_or_pgde_with_qts?%>
-        <li data-qa="qualifications">PGCE (or PGDE) with QTS</li>
+        <li data-qa="pgde_pgce_with_qts">PGCE (or PGDE) with QTS</li>
       <% end %>
       <% if @results_view.other_qualifications? %>
-        <li data-qa="qualifications">Further Education (PGCE or PGDE without QTS)</li>
+        <li data-qa="other_qualifications">Further Education (PGCE or PGDE without QTS)</li>
       <% end %>
     <% end %>
   </ul>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{number_with_delimiter(@results_view.total_course_count)} courses" %>
+<%= content_for :page_title, "#{number_with_delimiter(@results_view.course_count)} courses" %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
@@ -35,7 +35,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__count"><%= number_with_delimiter(@results_view.total_course_count) %> courses found</p>
+          <p class="govuk-body search-results__count" data-qa="course-count"><%= number_with_delimiter(@results_view.course_count) %> courses found</p>
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body search-results__new-search">

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{number_with_delimiter(@courses.total_count)} courses" %>
+<%= content_for :page_title, "#{number_with_delimiter(@results_view.total_course_count)} courses" %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
@@ -9,7 +9,7 @@
           <%= @results_view.provider %>
         </h1>
       <% else %>
-        <h1 class="govuk-heading-xl">Teacher training courses</h1>
+        <h1 class="govuk-heading-xl" data-qa="heading">Teacher training courses</h1>
       <% end %>
     </div>
   </div>
@@ -35,7 +35,7 @@
     <div class="govuk-grid-column-two-thirds">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__count"><%= number_with_delimiter(@courses.total_count) %> courses found</p>
+          <p class="govuk-body search-results__count"><%= number_with_delimiter(@results_view.total_course_count) %> courses found</p>
         </div>
         <div class="govuk-grid-column-one-half">
           <p class="govuk-body search-results__new-search">
@@ -44,7 +44,7 @@
         </div>
       </div>
       <ul class="govuk-list search-results">
-        <% @courses.each do |course| %>
+        <% @results_view.courses.each do |course| %>
           <li data-qa="course">
             <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
               <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link  search-result-link", rel: "prev", data: { qa: "course__link" } do %>
@@ -70,7 +70,7 @@
           </li>
         <% end %>
       </ul>
-      <%= paginate @courses %>
+      <%= paginate @results_view.courses %>
     </div>
   </div>
 </div>

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -15,9 +15,27 @@ feature "cookie banner", type: :feature do
         build(:subject_area, :secondary),
     ]
   end
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
 
   before do
-    stub_results_page_request
+    stub_request(:get, default_url)
+      .with(query: base_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
 
     stub_api_v3_resource(type: SubjectArea,
                           resources: subject_areas,

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -1,90 +1,24 @@
 require "rails_helper"
 
 feature "Search results", type: :feature do
-  def jsonapi_site_status(name, study_mode, status)
-    build(:site_status, study_mode, site: build(:site, location_name: name), status: status)
-  end
-
-  before do
-    allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(false)
-  end
-
-  let(:provider) do
-    build(:provider,
-          provider_name: "ACME SCITT A0",
-          provider_code: "T92",
-          website: "https://scitt.org",
-          address1: "1 Long Rd",
-          postcode: "E1 ABC")
-  end
-
-  let(:provider2) do
-    build(:provider,
-          provider_name: "ACME SCITT A0",
-          provider_code: "T92",
-          website: "https://scitt.org",
-          address1: "Building 64",
-          address2: "32 Copton Lane",
-          address3: "Bracknel",
-          address4: "Berkshire",
-          postcode: "NXT STP")
-  end
-
-  let(:course) do
-    build(:course,
-          name: "Primary",
-          course_code: "X130",
-          provider: provider,
-          provider_code: provider.provider_code,
-          recruitment_cycle: current_recruitment_cycle)
-  end
-
-  let(:current_recruitment_cycle) { build :recruitment_cycle }
-
   let(:results_page) { PageObjects::Page::Results.new }
+  let(:base_parameters) {
+    { "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10 }
+  }
 
-  let(:subject) do
-    build(:subject,
-          :english,
-          scholarship: "2000",
-          bursary_amount: "4000",
-          early_career_payments: "1000")
-  end
-
-  let(:accrediting_provider) { build(:provider) }
-  let(:decorated_course) { course.decorate }
-  let(:courses) { [course] }
-
-  let(:courses_request) do
-    fields = {
-      courses: %i[provider_code course_code name description funding_type provider accrediting_provider subjects],
-      providers: %i[provider_name address1 address2 address3 address4 postcode],
-    }
-
-    params = { recruitment_cycle_year: Settings.current_cycle }
-
-    pagination = { page: page_index || 1, per_page: 10 }
-
-    include = %i[provider accrediting_provider financial_incentive subjects]
-
-    stub_api_v3_resource(
-      type: Course,
-      resources: courses,
-      params: params,
-      fields: fields,
-      include: include,
-      pagination: pagination,
-      links: {
-        last: api_v3_url(
-          type: Course,
-          params: params,
-          fields: fields,
-          include: include,
-          pagination: pagination,
-        ),
-      },
+  let(:courses_request) {
+    url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    stub_request(:get, url)
+      .with(query: base_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
     )
-  end
+  }
 
   let(:subject_request) do
     stub_api_v3_resource(
@@ -109,55 +43,31 @@ feature "Search results", type: :feature do
   end
 
   context "multiple courses" do
-    let(:course1) do
-      build(:course,
-            name: "First Course",
-            course_code: "X130",
-            provider: provider,
-            provider_code: provider.provider_code,
-            recruitment_cycle: current_recruitment_cycle,
-            accrediting_provider: provider,
-            description: "PGCE with QTS",
-            funding_type: "salary")
-    end
-
-    let(:course2) do
-      build(:course,
-            name: "Second Course",
-            course_code: "X255",
-            provider: provider2,
-            provider_code: provider.provider_code,
-            recruitment_cycle: current_recruitment_cycle,
-            description: "QTS",
-            subjects: [subject])
-    end
-    let(:courses) { [course1, course2] }
-
     it "Lists all courses" do
       results_page.courses.first.then do |first_course|
-        expect(first_course.name.text).to eq("#{courses.first.name} (#{courses.first.course_code})")
-        expect(first_course.provider_name.text).to eq(courses.first.provider.provider_name)
-        expect(first_course.description.text).to eq(courses.first.description)
-        expect(first_course.accrediting_provider.text).to eq(courses.first.accrediting_provider.provider_name)
+        expect(first_course.name.text).to eq("Mathematics (2VMB)")
+        expect(first_course.provider_name.text).to eq("South East Learning Alliance")
+        expect(first_course.description.text).to eq("QTS full time with salary")
+        expect(first_course).not_to have_accrediting_provider
         expect(first_course.funding_options.text).to eq("Salary")
-        expect(first_course.main_address.text).to eq("1 Long Rd, E1 ABC")
-        expect(first_course).to have_selector("[href='#{course_path(provider_code: course1.provider_code, course_code: course1.course_code)}']")
+        expect(first_course.main_address.text).to eq("South East Learning Alliance, Riddlesdown Collegiate, Purley, South Croydon, Surrey, CR8 1EX")
       end
 
       results_page.courses.second.then do |second_course|
-        expect(second_course.name.text).to eq("#{courses.second.name} (#{courses.second.course_code})")
-        expect(second_course.provider_name.text).to eq(courses.second.provider.provider_name)
-        expect(second_course.description.text).to eq(courses.second.description)
-        expect(second_course.funding_options.text).to eq("Scholarship, bursary or student finance if you’re eligible")
+        expect(second_course.name.text).to eq("English (26Q6)")
+        expect(second_course.provider_name.text).to eq("Delta Teaching School Alliance")
+        expect(second_course.description.text).to eq("PGCE with QTS full time with salary")
+        expect(second_course.funding_options.text).to eq("Salary")
         expect(second_course).not_to have_accrediting_provider
-        expect(second_course.main_address.text).to eq("Building 64, 32 Copton Lane, Bracknel, Berkshire, NXT STP")
-        expect(second_course).to have_selector("[href='#{course_path(provider_code: course2.provider_code, course_code: course2.course_code)}']")
+        expect(second_course.main_address.text).to eq("Education House, Spawd Bone Lane, Knottingley, West Yorkshire, WF11 0EP")
       end
     end
   end
 
   context "with a second page" do
-    let(:page_index) { 2 }
+    before do
+      base_parameters.merge(page_index: 2)
+    end
 
     it "requests the second page" do
       expect(courses_request).to have_been_requested

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -15,129 +15,198 @@ feature "Funding filter", type: :feature do
     )
   end
 
-  describe "funding page" do
-    before { filter_page.load }
-
-    it "has the correct title and heading" do
-      expect(page.title).to have_content("Find courses that pay a salary")
-      expect(page).to have_content("Find courses that pay a salary")
-    end
-
-    describe "back link" do
+  describe "selecting a filter" do
+    context "selecting all courses" do
       before do
-        stub_results_page_request
-      end
-
-      it "navigates back to the results page" do
-        filter_page.load(query: { test: "params" })
-        filter_page.back_link.click
-
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params:  {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
-            "test" => "params",
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          {
+            body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
           },
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
-    end
 
-    describe "selecting an option" do
-      before do
-        stub_results_page_request
-      end
+      it "list the courses" do
+        results_page.load
+        results_page.funding_filter.link.click
 
-      let(:qs_params) { "one=two" }
+        expect(filter_page.heading.text).to eq("Find courses that pay a salary")
 
-      it "allows the user to select all courses" do
         filter_page.all_courses.click
         filter_page.find_courses.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: { "funding" => all_course_param_value_from_c_sharp },
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.funding_filter.funding.text).to eq("Courses with and without salary")
+
+        expect(results_page.courses.count).to eq(2)
+      end
+    end
+
+    context "selecting salary only courses" do
+      before do
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[funding]=salary&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
 
-      it "allows the user to select salary courses" do
+      it "lists the courses" do
+        results_page.load
+        results_page.funding_filter.link.click
+
+        expect(filter_page.heading.text).to eq("Find courses that pay a salary")
+
         filter_page.salary_courses.click
         filter_page.find_courses.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: { "funding" => salary_course_param_value_from_c_sharp },
-        )
-      end
-    end
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.funding_filter.funding.text).to eq("Only courses with a salary")
 
-    describe "Pre populated value" do
-      context "with no salary_filter parameter" do
-        it "the all_courses button is selected by default" do
-          expect(filter_page.all_courses).to be_checked
-          expect(filter_page.salary_courses).not_to be_checked
-        end
-      end
-
-      context "with the salary filter set to salary courses only" do
-        before { filter_page.load(query: { "funding" => salary_course_param_value_from_c_sharp }) }
-
-        it "the salary_course button is selected" do
-          expect(filter_page.salary_courses).to be_checked
-          expect(filter_page.all_courses).not_to be_checked
-        end
-      end
-
-      context "with the salary filter set to all courses" do
-        before { filter_page.load(query: { "funding" => all_course_param_value_from_c_sharp }) }
-
-        it "the salary_course button is selected" do
-          expect(filter_page.salary_courses).not_to be_checked
-          expect(filter_page.all_courses).to be_checked
-        end
-      end
-    end
-
-    describe "QS parameters" do
-      before do
-        stub_results_page_request
-      end
-
-      it "passes querystring parameters to results" do
-        filter_page.load(query: { test: "value" })
-        filter_page.all_courses.click
-        filter_page.find_courses.click
-
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "funding" => all_course_param_value_from_c_sharp,
-            "test" => "value",
-          },
-        )
-      end
-
-      it "passes arrays correctly" do
-        url_with_array_params = "#{filter_page.url}?test=1,2"
-        PageObjects::Page::ResultFilters::Funding.set_url(url_with_array_params)
-
-        filter_page.load
-        filter_page.all_courses.click
-        filter_page.find_courses.click
-
-        expect(results_page).to be_displayed
-
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "funding" => all_course_param_value_from_c_sharp,
-            "test" => "1,2",
-          },
-        )
+        expect(results_page.courses.count).to eq(2)
       end
     end
   end
 end
+
+  # describe "funding page" do
+  #   before { filter_page.load }
+
+  #   it "has the correct title and heading" do
+  #     expect(page.title).to have_content("Find courses that pay a salary")
+  #     expect(page).to have_content("Find courses that pay a salary")
+  #   end
+
+  #   describe "back link" do
+  #     before do
+  #       stub_results_page_request
+  #     end
+
+  #     it "navigates back to the results page" do
+  #       filter_page.load(query: { test: "params" })
+  #       filter_page.back_link.click
+
+  #       expect_page_to_be_displayed_with_query(
+  #         page: results_page,
+  #         expected_query_params:  {
+  #           "fulltime" => "False",
+  #           "hasvacancies" => "True",
+  #           "parttime" => "False",
+  #           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+  #           "senCourses" => "False",
+  #           "test" => "params",
+  #         },
+  #       )
+  #     end
+  #   end
+
+  #   describe "selecting an option" do
+  #     before do
+  #       stub_results_page_request
+  #     end
+
+  #     let(:qs_params) { "one=two" }
+
+  #     it "allows the user to select all courses" do
+  #       filter_page.all_courses.click
+  #       filter_page.find_courses.click
+
+  #       expect_page_to_be_displayed_with_query(
+  #         page: results_page,
+  #         expected_query_params: { "funding" => all_course_param_value_from_c_sharp },
+  #       )
+  #     end
+
+  #     it "allows the user to select salary courses" do
+  #       filter_page.salary_courses.click
+  #       filter_page.find_courses.click
+
+  #       expect_page_to_be_displayed_with_query(
+  #         page: results_page,
+  #         expected_query_params: { "funding" => salary_course_param_value_from_c_sharp },
+  #       )
+  #     end
+  #   end
+
+  #   describe "Pre populated value" do
+  #     context "with no salary_filter parameter" do
+  #       it "the all_courses button is selected by default" do
+  #         expect(filter_page.all_courses).to be_checked
+  #         expect(filter_page.salary_courses).not_to be_checked
+  #       end
+  #     end
+
+  #     context "with the salary filter set to salary courses only" do
+  #       before { filter_page.load(query: { "funding" => salary_course_param_value_from_c_sharp }) }
+
+  #       it "the salary_course button is selected" do
+  #         expect(filter_page.salary_courses).to be_checked
+  #         expect(filter_page.all_courses).not_to be_checked
+  #       end
+  #     end
+
+  #     context "with the salary filter set to all courses" do
+  #       before { filter_page.load(query: { "funding" => all_course_param_value_from_c_sharp }) }
+
+  #       it "the salary_course button is selected" do
+  #         expect(filter_page.salary_courses).not_to be_checked
+  #         expect(filter_page.all_courses).to be_checked
+  #       end
+  #     end
+  #   end
+
+  #   describe "QS parameters" do
+  #     before do
+  #       stub_results_page_request
+  #     end
+
+  #     it "passes querystring parameters to results" do
+  #       filter_page.load(query: { test: "value" })
+  #       filter_page.all_courses.click
+  #       filter_page.find_courses.click
+
+  #       expect_page_to_be_displayed_with_query(
+  #         page: results_page,
+  #         expected_query_params: {
+  #           "funding" => all_course_param_value_from_c_sharp,
+  #           "test" => "value",
+  #         },
+  #       )
+  #     end
+
+  #     it "passes arrays correctly" do
+  #       url_with_array_params = "#{filter_page.url}?test=1,2"
+  #       PageObjects::Page::ResultFilters::Funding.set_url(url_with_array_params)
+
+  #       filter_page.load
+  #       filter_page.all_courses.click
+  #       filter_page.find_courses.click
+
+  #       expect(results_page).to be_displayed
+
+  #       expect_page_to_be_displayed_with_query(
+  #         page: results_page,
+  #         expected_query_params: {
+  #           "funding" => all_course_param_value_from_c_sharp,
+  #           "test" => "1,2",
+  #         },
+  #       )
+  #     end
+  #   end
+  # end
+# end

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -15,12 +15,35 @@ feature "Funding filter", type: :feature do
     )
   end
 
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10"
+  end
+
+  describe "viewing results without explicitly selecting a filter" do
+    before do
+      stub_request(
+        :get,
+        default_url,
+      ).to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
+    it "lists only courses with vacancies" do
+      results_page.load
+
+      expect(results_page.funding_filter.funding.text).to eq("Courses with and without salary")
+      expect(results_page.courses.count).to eq(2)
+    end
+  end
+
   describe "selecting a filter" do
     context "selecting all courses" do
       before do
         stub_request(
           :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+          default_url,
         ).to_return(
           {
             body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -51,7 +74,7 @@ feature "Funding filter", type: :feature do
       before do
         stub_request(
           :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+          default_url,
         ).to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -59,7 +82,7 @@ feature "Funding filter", type: :feature do
 
         stub_request(
           :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[funding]=salary&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[funding]=salary&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10",
         ).to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -6,6 +6,19 @@ feature "Funding filter", type: :feature do
 
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
 
   before do
     stub_api_v3_resource(
@@ -15,42 +28,105 @@ feature "Funding filter", type: :feature do
     )
   end
 
-  let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10"
+  describe "Funding filter page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Find courses that pay a salary")
+      expect(page).to have_content("Find courses that pay a salary")
+    end
+
+    describe "back link" do
+      before do
+        stub_request(:get, default_url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
+
+      it "navigates back to the results page" do
+        filter_page.load(query: { test: "params" })
+        filter_page.back_link.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
+        )
+      end
+    end
+
+    describe "Pre populated value" do
+      context "with no salary_filter parameter" do
+        it "the all_courses button is selected by default" do
+          expect(filter_page.all_courses).to be_checked
+          expect(filter_page.salary_courses).not_to be_checked
+        end
+      end
+
+      context "with the salary filter set to salary courses only" do
+        before { filter_page.load(query: { "funding" => salary_course_param_value_from_c_sharp }) }
+
+        it "the salary_course button is selected" do
+          expect(filter_page.salary_courses).to be_checked
+          expect(filter_page.all_courses).not_to be_checked
+        end
+      end
+
+      context "with the salary filter set to all courses" do
+        before { filter_page.load(query: { "funding" => all_course_param_value_from_c_sharp }) }
+
+        it "the salary_course button is selected" do
+          expect(filter_page.salary_courses).not_to be_checked
+          expect(filter_page.all_courses).to be_checked
+        end
+      end
+    end
   end
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(
-        :get,
-        default_url,
-      ).to_return(
-        body: File.new("spec/fixtures/api_responses/courses.json"),
-        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
 
-    it "lists only courses with vacancies" do
+    it "lists course with or without salary" do
       results_page.load
 
-      expect(results_page.funding_filter.funding.text).to eq("Courses with and without salary")
+      expect(results_page.funding_filter).to have_with_or_without_salary
       expect(results_page.courses.count).to eq(2)
     end
   end
 
-  describe "selecting a filter" do
+  describe "applying a filter" do
+    before do
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
     context "selecting all courses" do
       before do
-        stub_request(
-          :get,
-          default_url,
-        ).to_return(
-          {
-            body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+        stub_request(:get, default_url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-          },
-          body: File.new("spec/fixtures/api_responses/courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
 
@@ -64,7 +140,7 @@ feature "Funding filter", type: :feature do
         filter_page.find_courses.click
 
         expect(results_page.heading.text).to eq("Teacher training courses")
-        expect(results_page.funding_filter.funding.text).to eq("Courses with and without salary")
+        expect(results_page.funding_filter.with_or_without_salary.text).to eq("Courses with and without salary")
 
         expect(results_page.courses.count).to eq(2)
       end
@@ -72,20 +148,11 @@ feature "Funding filter", type: :feature do
 
     context "selecting salary only courses" do
       before do
-        stub_request(
-          :get,
-          default_url,
-        ).to_return(
-          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-        )
-
-        stub_request(
-          :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[funding]=salary&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10",
-        ).to_return(
-          body: File.new("spec/fixtures/api_responses/courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[funding]" => "salary"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
 
@@ -99,137 +166,35 @@ feature "Funding filter", type: :feature do
         filter_page.find_courses.click
 
         expect(results_page.heading.text).to eq("Teacher training courses")
-        expect(results_page.funding_filter.funding.text).to eq("Only courses with a salary")
+        expect(results_page.funding_filter.with_salary.text).to eq("Only courses with a salary")
 
         expect(results_page.courses.count).to eq(2)
       end
     end
   end
+
+  describe "submitting without applying a filter" do
+    before do
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+
+      stub_request(:get, default_url)
+        .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
+    it "lists only courses with and without salary" do
+      results_page.load
+
+      expect(results_page.funding_filter.with_or_without_salary.text).to eq("Courses with and without salary")
+      expect(results_page.courses.count).to eq(2)
+    end
+  end
 end
-
-  # describe "funding page" do
-  #   before { filter_page.load }
-
-  #   it "has the correct title and heading" do
-  #     expect(page.title).to have_content("Find courses that pay a salary")
-  #     expect(page).to have_content("Find courses that pay a salary")
-  #   end
-
-  #   describe "back link" do
-  #     before do
-  #       stub_results_page_request
-  #     end
-
-  #     it "navigates back to the results page" do
-  #       filter_page.load(query: { test: "params" })
-  #       filter_page.back_link.click
-
-  #       expect_page_to_be_displayed_with_query(
-  #         page: results_page,
-  #         expected_query_params:  {
-  #           "fulltime" => "False",
-  #           "hasvacancies" => "True",
-  #           "parttime" => "False",
-  #           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-  #           "senCourses" => "False",
-  #           "test" => "params",
-  #         },
-  #       )
-  #     end
-  #   end
-
-  #   describe "selecting an option" do
-  #     before do
-  #       stub_results_page_request
-  #     end
-
-  #     let(:qs_params) { "one=two" }
-
-  #     it "allows the user to select all courses" do
-  #       filter_page.all_courses.click
-  #       filter_page.find_courses.click
-
-  #       expect_page_to_be_displayed_with_query(
-  #         page: results_page,
-  #         expected_query_params: { "funding" => all_course_param_value_from_c_sharp },
-  #       )
-  #     end
-
-  #     it "allows the user to select salary courses" do
-  #       filter_page.salary_courses.click
-  #       filter_page.find_courses.click
-
-  #       expect_page_to_be_displayed_with_query(
-  #         page: results_page,
-  #         expected_query_params: { "funding" => salary_course_param_value_from_c_sharp },
-  #       )
-  #     end
-  #   end
-
-  #   describe "Pre populated value" do
-  #     context "with no salary_filter parameter" do
-  #       it "the all_courses button is selected by default" do
-  #         expect(filter_page.all_courses).to be_checked
-  #         expect(filter_page.salary_courses).not_to be_checked
-  #       end
-  #     end
-
-  #     context "with the salary filter set to salary courses only" do
-  #       before { filter_page.load(query: { "funding" => salary_course_param_value_from_c_sharp }) }
-
-  #       it "the salary_course button is selected" do
-  #         expect(filter_page.salary_courses).to be_checked
-  #         expect(filter_page.all_courses).not_to be_checked
-  #       end
-  #     end
-
-  #     context "with the salary filter set to all courses" do
-  #       before { filter_page.load(query: { "funding" => all_course_param_value_from_c_sharp }) }
-
-  #       it "the salary_course button is selected" do
-  #         expect(filter_page.salary_courses).not_to be_checked
-  #         expect(filter_page.all_courses).to be_checked
-  #       end
-  #     end
-  #   end
-
-  #   describe "QS parameters" do
-  #     before do
-  #       stub_results_page_request
-  #     end
-
-  #     it "passes querystring parameters to results" do
-  #       filter_page.load(query: { test: "value" })
-  #       filter_page.all_courses.click
-  #       filter_page.find_courses.click
-
-  #       expect_page_to_be_displayed_with_query(
-  #         page: results_page,
-  #         expected_query_params: {
-  #           "funding" => all_course_param_value_from_c_sharp,
-  #           "test" => "value",
-  #         },
-  #       )
-  #     end
-
-  #     it "passes arrays correctly" do
-  #       url_with_array_params = "#{filter_page.url}?test=1,2"
-  #       PageObjects::Page::ResultFilters::Funding.set_url(url_with_array_params)
-
-  #       filter_page.load
-  #       filter_page.all_courses.click
-  #       filter_page.find_courses.click
-
-  #       expect(results_page).to be_displayed
-
-  #       expect_page_to_be_displayed_with_query(
-  #         page: results_page,
-  #         expected_query_params: {
-  #           "funding" => all_course_param_value_from_c_sharp,
-  #           "test" => "1,2",
-  #         },
-  #       )
-  #     end
-  #   end
-  # end
-# end

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -6,8 +6,11 @@ feature "Funding filter", type: :feature do
 
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
   end
 
   let(:base_parameters) do
@@ -21,11 +24,7 @@ feature "Funding filter", type: :feature do
   end
 
   before do
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-    )
+    stub_request(:get, subjects_url)
   end
 
   describe "Funding filter page" do
@@ -38,7 +37,7 @@ feature "Funding filter", type: :feature do
 
     describe "back link" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -94,7 +93,7 @@ feature "Funding filter", type: :feature do
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -112,7 +111,7 @@ feature "Funding filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -122,7 +121,7 @@ feature "Funding filter", type: :feature do
 
     context "selecting all courses" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -148,7 +147,7 @@ feature "Funding filter", type: :feature do
 
     context "selecting salary only courses" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[funding]" => "salary"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -175,14 +174,14 @@ feature "Funding filter", type: :feature do
 
   describe "submitting without applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
 
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -5,8 +5,11 @@ feature "Location filter", type: :feature do
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
   end
 
   let(:base_parameters) do
@@ -22,13 +25,9 @@ feature "Location filter", type: :feature do
   before do
     stub_geocoder
 
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-        )
+    stub_request(:get, subjects_url)
 
-    stub_request(:get, default_url)
+    stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -5,10 +5,35 @@ feature "Location filter", type: :feature do
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+        "filter[vacancies]" => "true",
+        "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+        "include" => "provider",
+        "page[page]" => 1,
+        "page[per_page]" => 10,
+    }
+  end
 
   before do
     stub_geocoder
-    stub_results_page_request
+
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+        )
+
+    stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
   end
 
   describe "default text" do

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -5,15 +5,14 @@ feature "Provider filter", type: :feature do
   let(:location_filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
-  let(:providers) do
-    [
-      build(:provider, provider_name: "ACME SCITT 2", provider_code: "2"),
-      build(:provider, provider_name: "ACME SCITT 3", provider_code: "3"),
-    ]
-  end
-
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
+  end
+  let(:providers_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
   end
 
   let(:base_parameters) do
@@ -26,40 +25,26 @@ feature "Provider filter", type: :feature do
     }
   end
 
-  let(:provider_request) do
-    stub_api_v3_resource(
-      type: Provider,
-      resources: providers,
-      fields: { providers: %i[provider_code provider_name] },
-      params: { recruitment_cycle_year: 2020 },
-      search: search_term,
-    )
-  end
-
   let(:search_term) { "ACME" }
   let(:query_params) { { query: search_term } }
 
   before do
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-    )
+    stub_request(:get, subjects_url)
 
-    stub_request(:get, default_url)
+    stub_request(:get, courses_url)
       .with(query: base_parameters)
       .to_return(
         body: File.new("spec/fixtures/api_responses/courses.json"),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
     )
-
-    provider_request
-
-    provider_filter_page.load(query: query_params)
   end
 
   context "with an empty search" do
     let(:query_params) { "   " }
+
+    before do
+      provider_filter_page.load(query: query_params)
+    end
 
     it "Displays an error if provider search is selected but empty" do
       expect(location_filter_page).to have_error
@@ -71,83 +56,107 @@ feature "Provider filter", type: :feature do
   end
 
   context "with a query" do
-    it "queries the API" do
-      expect(provider_filter_page.provider_suggestions.first.hyperlink.text).to eq("#{providers.first.provider_name} (#{providers.first.provider_code})")
-      expect(provider_filter_page.provider_suggestions.second.hyperlink.text).to eq("#{providers.second.provider_name} (#{providers.second.provider_code})")
-    end
-
-    it "links to the results page" do
-      provider_filter_page.provider_suggestions.first.hyperlink.click
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "query" => "ACME SCITT 2",
-        },
-      )
-    end
-
-    context "with existing params" do
-      let(:query_params) { { other_param: "my other param", query: "ACME" } }
-
-      it "preserves previous parameters" do
-        provider_filter_page.provider_suggestions.first.hyperlink.click
-        #We must do this because site_prism's URL system is broken
-        expect(results_page.url).to eq(current_path)
-        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          "other_param" => "my other param",
-          "query" => "ACME SCITT 2",
+    context "with many providers" do
+      before do
+        stub_request(:get, providers_url)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/providers.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
+
+        provider_filter_page.load(query: query_params)
+      end
+
+      it "queries the API" do
+        expect(provider_filter_page.provider_suggestions.first.hyperlink.text).to eq("ACME SCITT 0 (A0)")
+        expect(provider_filter_page.provider_suggestions.second.hyperlink.text).to eq("ACME SCITT 1 (A1)")
+      end
+
+      it "links to the results page" do
+        provider_filter_page.provider_suggestions.first.hyperlink.click
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "query" => "ACME SCITT 0",
+          },
+        )
+      end
+
+      context "with existing params" do
+        let(:query_params) { { other_param: "my other param", query: "ACME" } }
+
+        it "preserves previous parameters" do
+          provider_filter_page.provider_suggestions.first.hyperlink.click
+          #We must do this because site_prism's URL system is broken
+          expect(results_page.url).to eq(current_path)
+          expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+            "other_param" => "my other param",
+            "query" => "ACME SCITT 0",
+          )
+        end
       end
     end
 
     context "with only one provider" do
-      let(:providers) do
-        [
-          build(:provider, provider_name: "ACME SCITT 4", provider_code: "4"),
-        ]
+      before do
+        stub_request(:get, providers_url)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/one_provider.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+
+        provider_filter_page.load(query: query_params)
       end
 
       it "is automatically selected" do
         expect(results_page.url).to eq(current_path)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          "query" => "ACME SCITT 4",
+          "query" => "ACME SCITT 0",
         )
       end
     end
 
     context "with no providers" do
-      let(:providers) do
-        []
+      before do
+        stub_request(:get, providers_url)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/empty_providers.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+
+        provider_filter_page.load(query: query_params)
       end
 
       it "redirects to location page with an error" do
         expect(current_path).to eq(location_filter_page.url)
-        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          "query" => "ACME",
-        )
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq("query" => "ACME")
         expect(location_filter_page.error_text.text).to eq("Training provider")
         expect(location_filter_page.provider_error.text).to eq("Error: Please enter the name of a training provider")
       end
     end
   end
 
-  it "has a form with which to search again" do
-    stub_api_v3_resource(
-      type: Provider,
-      resources: providers,
-      fields: { providers: %i[provider_code provider_name] },
-      params: { recruitment_cycle_year: 2020 },
-      search: "ACME SCITT",
-    )
+  context "Searching" do
+    let(:search_term) { "ACME SCITT" }
+    before do
+      stub_request(:get, providers_url)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/providers.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
 
-    provider_filter_page.search.expand.click
-    provider_filter_page.search.input.fill_in(with: "ACME SCITT")
-    provider_filter_page.search.submit.click
+      provider_filter_page.load(query: query_params)
+    end
+    it "has a form with which to search again" do
+      provider_filter_page.search.expand.click
+      provider_filter_page.search.input.fill_in(with: "ACME SCITT")
+      provider_filter_page.search.submit.click
 
-    expect(current_path).to eq(provider_filter_page.url)
-    expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-      "query" => "ACME SCITT",
-      "utf8" => "✓",
-    )
+      expect(current_path).to eq(provider_filter_page.url)
+      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+        "query" => "ACME SCITT",
+        "utf8" => "✓",
+      )
+    end
   end
 end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -12,6 +12,20 @@ feature "Provider filter", type: :feature do
     ]
   end
 
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
+
   let(:provider_request) do
     stub_api_v3_resource(
       type: Provider,
@@ -26,7 +40,18 @@ feature "Provider filter", type: :feature do
   let(:query_params) { { query: search_term } }
 
   before do
-    stub_results_page_request
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+
+    stub_request(:get, default_url)
+      .with(query: base_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
 
     provider_request
 

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -3,8 +3,11 @@ require "rails_helper"
 feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
   end
 
   let(:base_parameters) do
@@ -18,11 +21,7 @@ feature "Qualifications filter", type: :feature do
   end
 
   before do
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-    )
+    stub_request(:get, subjects_url)
   end
 
   describe "Qualification filter page" do
@@ -35,7 +34,7 @@ feature "Qualifications filter", type: :feature do
 
     describe "back link" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -90,7 +89,7 @@ feature "Qualifications filter", type: :feature do
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -108,7 +107,7 @@ feature "Qualifications filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -118,7 +117,7 @@ feature "Qualifications filter", type: :feature do
 
     context "deselecting courses with 'qts only' qualification" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[qualifications]" => "PgdePgceWithQts,Other"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -145,7 +144,7 @@ feature "Qualifications filter", type: :feature do
 
     context "deselecting courses that with 'pgde with qts' qualification" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,Other"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -172,7 +171,7 @@ feature "Qualifications filter", type: :feature do
 
     context "deselecting courses with 'further education' qualification" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -216,14 +215,14 @@ feature "Qualifications filter", type: :feature do
 
   describe "submitting without applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
 
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -3,6 +3,18 @@ require "rails_helper"
 feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
+  let(:url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+        "filter[vacancies]" => "true",
+        "include" => "provider",
+        "page[page]" => 1,
+        "page[per_page]" => 10,
+    }
+  end
 
   before do
     stub_api_v3_resource(
@@ -12,114 +24,265 @@ feature "Qualifications filter", type: :feature do
     )
   end
 
-  describe "qualification page" do
-    before { filter_page.load }
-
-    it "has the correct title and heading" do
-      expect(page.title).to have_content("Filter by qualification")
-      expect(page).to have_content("What you will get")
+  describe "viewing results without explicitly selecting a filter" do
+    before do
+      stub_request(:get, url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
     end
 
-    describe "back link" do
+    it "lists only courses with all qualifications" do
+      results_page.load
+
+      expect(results_page.qualifications_filter).to have_qualifications
+      expect(results_page.courses.count).to eq(2)
+    end
+  end
+
+  describe "applying a filter" do
+    before do
+      stub_request(:get, url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
+    end
+
+    context "submitting without applying a filter" do
       before do
-        stub_results_page_request
+        stub_request(:get, url)
+            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
+            .to_return(
+              body: File.new("spec/fixtures/api_responses/courses.json"),
+              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
       end
 
-      it "navigates back to the results page" do
-        filter_page.load(query: { test: "params" })
-        filter_page.back_link.click
+      it "list the courses" do
+        results_page.load
+        results_page.qualifications_filter.link.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params:  {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
-            "test" => "params",
-          },
-        )
+        expect(filter_page.heading.text).to eq("What you will get")
+        filter_page.find_courses.click
+
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.qualifications_filter).to have_qualifications
+
+        expect(results_page.courses.count).to eq(2)
       end
     end
 
-    describe "de-selecting an option" do
+    context "deselecting qts only" do
       before do
-        stub_results_page_request
+        stub_request(:get, url)
+            .with(query: base_parameters.merge("filter[qualifications]" => "PgdePgceWithQts,Other"))
+            .to_return(
+              body: File.new("spec/fixtures/api_responses/courses.json"),
+              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
       end
 
-      it "it removes the option from the parameters" do
+      it "list the courses" do
+        results_page.load
+        results_page.qualifications_filter.link.click
+
+        expect(filter_page.heading.text).to eq("What you will get")
+
         filter_page.qts_only.click
         filter_page.find_courses.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "qualifications" => "PgdePgceWithQts,Other",
-          },
-        )
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.qualifications_filter).to have_pgde_pgce_with_qts
+        expect(results_page.qualifications_filter).to have_other_qualifications
+
+        expect(results_page.courses.count).to eq(2)
       end
     end
 
-    describe "pre-populating values" do
-      context "with no qualifications parameters" do
-        it "checks all boxes" do
-          expect(filter_page.qts_only).to be_checked
-          expect(filter_page.pgde_pgce_with_qts).to be_checked
-          expect(filter_page.other).to be_checked
-        end
-      end
-    end
-
-    describe "validation" do
-      context "when no qualification is selected" do
-        it "shows an error message" do
-          filter_page.qts_only.click
-          filter_page.pgde_pgce_with_qts.click
-          filter_page.other.click
-          filter_page.find_courses.click
-
-          expect(filter_page).to have_error
-          expect(filter_page.qts_only).not_to be_checked
-          expect(filter_page.pgde_pgce_with_qts).not_to be_checked
-          expect(filter_page.other).not_to be_checked
-        end
-      end
-    end
-
-    describe "QS parameters" do
+    context "deselecting pgde with qts" do
       before do
-        stub_results_page_request
+        stub_request(:get, url)
+            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,Other"))
+            .to_return(
+              body: File.new("spec/fixtures/api_responses/courses.json"),
+              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
       end
 
-      it "passes querystring parameters to results" do
-        filter_page.load(query: { test: "value" })
+      it "list the courses" do
+        results_page.load
+        results_page.qualifications_filter.link.click
+
+        expect(filter_page.heading.text).to eq("What you will get")
+
+        filter_page.pgde_pgce_with_qts.click
         filter_page.find_courses.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "test" => "value",
-          },
-        )
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.qualifications_filter).to have_qts_only
+        expect(results_page.qualifications_filter).to have_other_qualifications
+
+        expect(results_page.courses.count).to eq(2)
+      end
+    end
+
+    context "deselecting further education" do
+      before do
+        stub_request(:get, url)
+            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts"))
+            .to_return(
+              body: File.new("spec/fixtures/api_responses/courses.json"),
+              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
       end
 
-      it "passes arrays correctly" do
-        url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-        PageObjects::Page::ResultFilters::Qualification.set_url(url_with_array_params)
+      it "list the courses" do
+        results_page.load
+        results_page.qualifications_filter.link.click
 
-        filter_page.load
+        expect(filter_page.heading.text).to eq("What you will get")
+
+        filter_page.other.click
         filter_page.find_courses.click
 
-        expect_page_to_be_displayed_with_query(
-          page: results_page,
-          expected_query_params: {
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "test" => "1,2",
-          },
-        )
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.qualifications_filter).to have_pgde_pgce_with_qts
+        expect(results_page.qualifications_filter).to have_qts_only
+
+        expect(results_page.courses.count).to eq(2)
+      end
+    end
+
+    context "deselecting all options" do
+      it "displays an error" do
+        results_page.load
+        results_page.qualifications_filter.link.click
+
+        expect(filter_page.heading.text).to eq("What you will get")
+
+        filter_page.qts_only.click
+        filter_page.pgde_pgce_with_qts.click
+        filter_page.other.click
+        filter_page.find_courses.click
+
+        expect(filter_page).to have_error
       end
     end
   end
 end
+
+# describe "qualification page" do
+#   before { filter_page.load }
+#
+#   it "has the correct title and heading" do
+#     expect(page.title).to have_content("Filter by qualification")
+#     expect(page).to have_content("What you will get")
+#   end
+#
+#   describe "back link" do
+#     before do
+#       stub_results_page_request
+#     end
+#
+#     it "navigates back to the results page" do
+#       filter_page.load(query: { test: "params" })
+#       filter_page.back_link.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params:  {
+#           "fulltime" => "False",
+#           "hasvacancies" => "True",
+#           "parttime" => "False",
+#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+#           "senCourses" => "False",
+#           "test" => "params",
+#         },
+#       )
+#     end
+#   end
+#
+#   describe "de-selecting an option" do
+#     before do
+#       stub_results_page_request
+#     end
+#
+#     it "it removes the option from the parameters" do
+#       filter_page.qts_only.click
+#       filter_page.find_courses.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "qualifications" => "PgdePgceWithQts,Other",
+#         },
+#       )
+#     end
+#   end
+#
+#   describe "pre-populating values" do
+#     context "with no qualifications parameters" do
+#       it "checks all boxes" do
+#         expect(filter_page.qts_only).to be_checked
+#         expect(filter_page.pgde_pgce_with_qts).to be_checked
+#         expect(filter_page.other).to be_checked
+#       end
+#     end
+#   end
+#
+#   describe "validation" do
+#     context "when no qualification is selected" do
+#       it "shows an error message" do
+#         filter_page.qts_only.click
+#         filter_page.pgde_pgce_with_qts.click
+#         filter_page.other.click
+#         filter_page.find_courses.click
+#
+#         expect(filter_page).to have_error
+#         expect(filter_page.qts_only).not_to be_checked
+#         expect(filter_page.pgde_pgce_with_qts).not_to be_checked
+#         expect(filter_page.other).not_to be_checked
+#       end
+#     end
+#   end
+#
+#   describe "QS parameters" do
+#     before do
+#       stub_results_page_request
+#     end
+#
+#     it "passes querystring parameters to results" do
+#       filter_page.load(query: { test: "value" })
+#       filter_page.find_courses.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+#           "test" => "value",
+#         },
+#       )
+#     end
+#
+#     it "passes arrays correctly" do
+#       url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+#       PageObjects::Page::ResultFilters::Qualification.set_url(url_with_array_params)
+#
+#       filter_page.load
+#       filter_page.find_courses.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+#           "test" => "1,2",
+#         },
+#       )
+#     end
+#   end
+# end
+# end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -3,16 +3,17 @@ require "rails_helper"
 feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:url) do
+  let(:default_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
   end
 
   let(:base_parameters) do
     {
-        "filter[vacancies]" => "true",
-        "include" => "provider",
-        "page[page]" => 1,
-        "page[per_page]" => 10,
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
     }
   end
 
@@ -24,14 +25,77 @@ feature "Qualifications filter", type: :feature do
     )
   end
 
-  describe "viewing results without explicitly selecting a filter" do
-    before do
-      stub_request(:get, url)
+  describe "Qualification filter page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Filter by qualification")
+      expect(page).to have_content("What you will get")
+    end
+
+    describe "back link" do
+      before do
+        stub_request(:get, default_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-          )
+        )
+      end
+
+      it "navigates back to the results page" do
+        filter_page.load(query: { test: "params" })
+        filter_page.back_link.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
+        )
+      end
+    end
+
+    describe "pre-populating values" do
+      context "with no qualifications parameters" do
+        it "checks all boxes" do
+          expect(filter_page.qts_only).to be_checked
+          expect(filter_page.pgde_pgce_with_qts).to be_checked
+          expect(filter_page.other).to be_checked
+        end
+      end
+    end
+
+    describe "validation" do
+      context "when no qualification is selected" do
+        it "shows an error message" do
+          filter_page.qts_only.click
+          filter_page.pgde_pgce_with_qts.click
+          filter_page.other.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_error
+          expect(filter_page.qts_only).not_to be_checked
+          expect(filter_page.pgde_pgce_with_qts).not_to be_checked
+          expect(filter_page.other).not_to be_checked
+        end
+      end
+    end
+  end
+
+  describe "viewing results without explicitly selecting a filter" do
+    before do
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
     end
 
     it "lists only courses with all qualifications" do
@@ -44,46 +108,22 @@ feature "Qualifications filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, url)
-          .with(query: base_parameters)
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
+    context "deselecting courses with 'qts only' qualification" do
+      before do
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[qualifications]" => "PgdePgceWithQts,Other"))
           .to_return(
-            body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+            body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-          )
-    end
-
-    context "submitting without applying a filter" do
-      before do
-        stub_request(:get, url)
-            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
-            .to_return(
-              body: File.new("spec/fixtures/api_responses/courses.json"),
-              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-            )
-      end
-
-      it "list the courses" do
-        results_page.load
-        results_page.qualifications_filter.link.click
-
-        expect(filter_page.heading.text).to eq("What you will get")
-        filter_page.find_courses.click
-
-        expect(results_page.heading.text).to eq("Teacher training courses")
-        expect(results_page.qualifications_filter).to have_qualifications
-
-        expect(results_page.courses.count).to eq(2)
-      end
-    end
-
-    context "deselecting qts only" do
-      before do
-        stub_request(:get, url)
-            .with(query: base_parameters.merge("filter[qualifications]" => "PgdePgceWithQts,Other"))
-            .to_return(
-              body: File.new("spec/fixtures/api_responses/courses.json"),
-              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-            )
+        )
       end
 
       it "list the courses" do
@@ -103,14 +143,14 @@ feature "Qualifications filter", type: :feature do
       end
     end
 
-    context "deselecting pgde with qts" do
+    context "deselecting courses that with 'pgde with qts' qualification" do
       before do
-        stub_request(:get, url)
-            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,Other"))
-            .to_return(
-              body: File.new("spec/fixtures/api_responses/courses.json"),
-              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-            )
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,Other"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
       end
 
       it "list the courses" do
@@ -130,14 +170,14 @@ feature "Qualifications filter", type: :feature do
       end
     end
 
-    context "deselecting further education" do
+    context "deselecting courses with 'further education' qualification" do
       before do
-        stub_request(:get, url)
-            .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts"))
-            .to_return(
-              body: File.new("spec/fixtures/api_responses/courses.json"),
-              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-            )
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
       end
 
       it "list the courses" do
@@ -173,116 +213,35 @@ feature "Qualifications filter", type: :feature do
       end
     end
   end
-end
 
-# describe "qualification page" do
-#   before { filter_page.load }
-#
-#   it "has the correct title and heading" do
-#     expect(page.title).to have_content("Filter by qualification")
-#     expect(page).to have_content("What you will get")
-#   end
-#
-#   describe "back link" do
-#     before do
-#       stub_results_page_request
-#     end
-#
-#     it "navigates back to the results page" do
-#       filter_page.load(query: { test: "params" })
-#       filter_page.back_link.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params:  {
-#           "fulltime" => "False",
-#           "hasvacancies" => "True",
-#           "parttime" => "False",
-#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-#           "senCourses" => "False",
-#           "test" => "params",
-#         },
-#       )
-#     end
-#   end
-#
-#   describe "de-selecting an option" do
-#     before do
-#       stub_results_page_request
-#     end
-#
-#     it "it removes the option from the parameters" do
-#       filter_page.qts_only.click
-#       filter_page.find_courses.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "qualifications" => "PgdePgceWithQts,Other",
-#         },
-#       )
-#     end
-#   end
-#
-#   describe "pre-populating values" do
-#     context "with no qualifications parameters" do
-#       it "checks all boxes" do
-#         expect(filter_page.qts_only).to be_checked
-#         expect(filter_page.pgde_pgce_with_qts).to be_checked
-#         expect(filter_page.other).to be_checked
-#       end
-#     end
-#   end
-#
-#   describe "validation" do
-#     context "when no qualification is selected" do
-#       it "shows an error message" do
-#         filter_page.qts_only.click
-#         filter_page.pgde_pgce_with_qts.click
-#         filter_page.other.click
-#         filter_page.find_courses.click
-#
-#         expect(filter_page).to have_error
-#         expect(filter_page.qts_only).not_to be_checked
-#         expect(filter_page.pgde_pgce_with_qts).not_to be_checked
-#         expect(filter_page.other).not_to be_checked
-#       end
-#     end
-#   end
-#
-#   describe "QS parameters" do
-#     before do
-#       stub_results_page_request
-#     end
-#
-#     it "passes querystring parameters to results" do
-#       filter_page.load(query: { test: "value" })
-#       filter_page.find_courses.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-#           "test" => "value",
-#         },
-#       )
-#     end
-#
-#     it "passes arrays correctly" do
-#       url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-#       PageObjects::Page::ResultFilters::Qualification.set_url(url_with_array_params)
-#
-#       filter_page.load
-#       filter_page.find_courses.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-#           "test" => "1,2",
-#         },
-#       )
-#     end
-#   end
-# end
-# end
+  describe "submitting without applying a filter" do
+    before do
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+
+      stub_request(:get, default_url)
+        .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
+    it "list the courses" do
+      results_page.load
+      results_page.qualifications_filter.link.click
+
+      expect(filter_page.heading.text).to eq("What you will get")
+      filter_page.find_courses.click
+
+      expect(results_page.heading.text).to eq("Teacher training courses")
+      expect(results_page.qualifications_filter).to have_qualifications
+
+      expect(results_page.courses.count).to eq(2)
+    end
+  end
+end

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -16,6 +16,14 @@ feature "Study type filter", type: :feature do
     }
   end
 
+  before do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+        )
+  end
+
   describe "viewing results without explicitly selecting a filter" do
     before do
       stub_request(:get, url)
@@ -49,7 +57,7 @@ feature "Study type filter", type: :feature do
     context "deselecting full time" do
       before do
         stub_request(:get, url)
-          .with( query: base_parameters.merge("filter[study_type]" => "part_time"))
+          .with(query: base_parameters.merge("filter[study_type]" => "part_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -3,135 +3,271 @@ require "rails_helper"
 feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
-
-  before do
-    stub_results_page_request
+  let(:url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
   end
 
-  describe "back link" do
-    it "navigates back to the results page" do
-      filter_page.load(query: { test: "params" })
-      filter_page.back_link.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params:  {
-          "fulltime" => "False",
-          "hasvacancies" => "True",
-          "parttime" => "False",
-          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-          "senCourses" => "False",
-          "test" => "params",
-        },
-      )
-    end
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
   end
 
-
-  describe "deselecting an option" do
-    before { filter_page.load }
-
-    it "default full time and part time to true" do
-      expect(filter_page.full_time.checked?).to be true
-      expect(filter_page.part_time.checked?).to be true
-    end
-
-    it "Allows the user to deselect full time" do
-      filter_page.full_time.click
-      filter_page.find_courses.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "False",
-          "parttime" => "True",
-        },
+  describe "viewing results without explicitly selecting a filter" do
+    before do
+      stub_request(:get, url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
 
-    it "Allows the user to deselect part time" do
-      filter_page.part_time.click
-      filter_page.find_courses.click
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "True",
-          "parttime" => "False",
-        },
-      )
-    end
+    it "lists only courses with both study types" do
+      results_page.load
 
-    it "Allows the user to find courses" do
-      filter_page.find_courses.click
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "True",
-          "parttime" => "True",
-        },
-      )
+      expect(results_page.study_type_filter).to have_parttime
+      expect(results_page.study_type_filter).to have_fulltime
+
+      expect(results_page.courses.count).to eq(2)
     end
   end
 
-  describe "Navigating to the page with currently selected filters" do
-    it "Allows the full time param to be pre-selected" do
-      filter_page.load(query: { fulltime: "True" })
-      expect(filter_page.full_time.checked?).to eq(true)
-    end
-
-    it "Allows the part time param to be pre-selected" do
-      filter_page.load(query: { parttime: "True" })
-      expect(filter_page.part_time.checked?).to eq(true)
-    end
-  end
-
-  describe "Validation" do
-    it "Displays an error if neither option is selected" do
-      filter_page.load
-
-      filter_page.part_time.click
-      filter_page.full_time.click
-
-      filter_page.find_courses.click
-
-      expect(filter_page).to have_error
-    end
-  end
-
-  describe "QS parameters" do
-    it "passes querystring parameters to results" do
-      filter_page.load(query: { test: "value", parttime: "True" })
-
-      filter_page.find_courses.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "False",
-          "parttime" => "True",
-          "test" => "value",
-        },
+  describe "applying a filter" do
+    before do
+      stub_request(:get, url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
 
-    it "passes arrays correctly" do
-      url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-      PageObjects::Page::ResultFilters::StudyType.set_url(url_with_array_params)
+    context "deselecting full time" do
+      before do
+        stub_request(:get, url)
+          .with( query: base_parameters.merge("filter[study_type]" => "part_time"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
 
-      filter_page.load
-      filter_page.part_time.click
-      filter_page.find_courses.click
+      it "list the courses" do
+        results_page.load
+        results_page.study_type_filter.link.click
 
-      expect(results_page).to be_displayed
+        expect(filter_page.heading.text).to eq("Study type")
+        filter_page.full_time.click
+        filter_page.find_courses.click
 
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "fulltime" => "True",
-          "parttime" => "False",
-          "test" => "1,2",
-        },
-      )
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.study_type_filter).to have_parttime
+
+        expect(results_page.courses.count).to eq(2)
+      end
+    end
+
+    context "deselecting part time" do
+      before do
+        stub_request(:get, url)
+          .with(query: base_parameters.merge("filter[study_type]" => "full_time"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
+
+      it "list the courses" do
+        results_page.load
+        results_page.study_type_filter.link.click
+
+        expect(filter_page.heading.text).to eq("Study type")
+        filter_page.part_time.click
+        filter_page.find_courses.click
+
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.study_type_filter).to have_fulltime
+
+        expect(results_page.courses.count).to eq(2)
+      end
+    end
+
+    context "deselecting full time and part time" do
+      it "displays an error" do
+        results_page.load
+        results_page.study_type_filter.link.click
+
+        expect(filter_page.heading.text).to eq("Study type")
+        filter_page.part_time.click
+        filter_page.full_time.click
+        filter_page.find_courses.click
+
+        expect(filter_page).to have_error
+      end
+    end
+
+    context "submitting without deselection" do
+      before do
+        stub_request(:get, url)
+          .with(query: base_parameters.merge("filter[study_type]" => "full_time,part_time"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
+
+      it "list the courses" do
+        results_page.load
+        results_page.study_type_filter.link.click
+
+        expect(filter_page.heading.text).to eq("Study type")
+
+        filter_page.find_courses.click
+
+        expect(filter_page.heading.text).to eq("Teacher training courses")
+
+        expect(results_page.study_type_filter).to have_fulltime
+
+        expect(results_page.study_type_filter).to have_parttime
+
+        expect(results_page.courses.count).to eq(2)
+      end
     end
   end
 end
+
+#   before do
+#     stub_results_page_request
+#   end
+#
+#   describe "back link" do
+#     it "navigates back to the results page" do
+#       filter_page.load(query: { test: "params" })
+#       filter_page.back_link.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params:  {
+#           "fulltime" => "False",
+#           "hasvacancies" => "True",
+#           "parttime" => "False",
+#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+#           "senCourses" => "False",
+#           "test" => "params",
+#         },
+#       )
+#     end
+#   end
+#
+#
+#   describe "deselecting an option" do
+#     before { filter_page.load }
+#
+#     it "default full time and part time to true" do
+#       expect(filter_page.full_time.checked?).to be true
+#       expect(filter_page.part_time.checked?).to be true
+#     end
+#
+#     it "Allows the user to deselect full time" do
+#       filter_page.full_time.click
+#       filter_page.find_courses.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "fulltime" => "False",
+#           "parttime" => "True",
+#         },
+#       )
+#     end
+#
+#     it "Allows the user to deselect part time" do
+#       filter_page.part_time.click
+#       filter_page.find_courses.click
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "fulltime" => "True",
+#           "parttime" => "False",
+#         },
+#       )
+#     end
+#
+#     it "Allows the user to find courses" do
+#       filter_page.find_courses.click
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "fulltime" => "True",
+#           "parttime" => "True",
+#         },
+#       )
+#     end
+#   end
+#
+#   describe "Navigating to the page with currently selected filters" do
+#     it "Allows the full time param to be pre-selected" do
+#       filter_page.load(query: { fulltime: "True" })
+#       expect(filter_page.full_time.checked?).to eq(true)
+#     end
+#
+#     it "Allows the part time param to be pre-selected" do
+#       filter_page.load(query: { parttime: "True" })
+#       expect(filter_page.part_time.checked?).to eq(true)
+#     end
+#   end
+#
+#   describe "Validation" do
+#     it "Displays an error if neither option is selected" do
+#       filter_page.load
+#
+#       filter_page.part_time.click
+#       filter_page.full_time.click
+#
+#       filter_page.find_courses.click
+#
+#       expect(filter_page).to have_error
+#     end
+#   end
+#
+#   describe "QS parameters" do
+#     it "passes querystring parameters to results" do
+#       filter_page.load(query: { test: "value", parttime: "True" })
+#
+#       filter_page.find_courses.click
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "fulltime" => "False",
+#           "parttime" => "True",
+#           "test" => "value",
+#         },
+#       )
+#     end
+#
+#     it "passes arrays correctly" do
+#       url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+#       PageObjects::Page::ResultFilters::StudyType.set_url(url_with_array_params)
+#
+#       filter_page.load
+#       filter_page.part_time.click
+#       filter_page.find_courses.click
+#
+#       expect(results_page).to be_displayed
+#
+#       expect_page_to_be_displayed_with_query(
+#         page: results_page,
+#         expected_query_params: {
+#           "fulltime" => "True",
+#           "parttime" => "False",
+#           "test" => "1,2",
+#         },
+#       )
+#     end
+#   end
+# end

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -3,8 +3,11 @@ require "rails_helper"
 feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
   end
 
   let(:base_parameters) do
@@ -18,11 +21,7 @@ feature "Study type filter", type: :feature do
   end
 
   before do
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-    )
+    stub_request(:get, subjects_url)
   end
 
   describe "Study type filter page" do
@@ -35,7 +34,7 @@ feature "Study type filter", type: :feature do
 
     describe "back link" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -89,7 +88,7 @@ feature "Study type filter", type: :feature do
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -109,7 +108,7 @@ feature "Study type filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -119,7 +118,7 @@ feature "Study type filter", type: :feature do
 
     context "deselecting full time" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[study_type]" => "part_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -144,7 +143,7 @@ feature "Study type filter", type: :feature do
 
     context "deselecting part time" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[study_type]" => "full_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -183,7 +182,7 @@ feature "Study type filter", type: :feature do
 
     context "submitting without deselection" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[study_type]" => "full_time,part_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -3,13 +3,14 @@ require "rails_helper"
 feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:url) do
+  let(:default_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
   end
 
   let(:base_parameters) do
     {
       "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
       "include" => "provider",
       "page[page]" => 1,
       "page[per_page]" => 10,
@@ -21,12 +22,74 @@ feature "Study type filter", type: :feature do
       type: SubjectArea,
       resources: nil,
       include: [:subjects],
+    )
+  end
+
+  describe "Study type filter page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Filter by study type")
+      expect(page).to have_content("Study type")
+    end
+
+    describe "back link" do
+      before do
+        stub_request(:get, default_url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
+      end
+
+      it "navigates back to the results page" do
+        filter_page.load(query: { test: "params" })
+        filter_page.back_link.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
+        )
+      end
+    end
+
+    describe "Navigating to the page with currently selected filters" do
+      it "Allows the full time param to be pre-selected" do
+        filter_page.load(query: { fulltime: "True" })
+        expect(filter_page.full_time.checked?).to eq(true)
+      end
+
+      it "Allows the part time param to be pre-selected" do
+        filter_page.load(query: { parttime: "True" })
+        expect(filter_page.part_time.checked?).to eq(true)
+      end
+    end
+
+    describe "Validation" do
+      it "Displays an error if neither option is selected" do
+        filter_page.load
+
+        filter_page.part_time.click
+        filter_page.full_time.click
+
+        filter_page.find_courses.click
+
+        expect(filter_page).to have_error
+      end
+    end
   end
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(:get, url)
+      stub_request(:get, default_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -46,7 +109,7 @@ feature "Study type filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, url)
+      stub_request(:get, default_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -56,7 +119,7 @@ feature "Study type filter", type: :feature do
 
     context "deselecting full time" do
       before do
-        stub_request(:get, url)
+        stub_request(:get, default_url)
           .with(query: base_parameters.merge("filter[study_type]" => "part_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -81,7 +144,7 @@ feature "Study type filter", type: :feature do
 
     context "deselecting part time" do
       before do
-        stub_request(:get, url)
+        stub_request(:get, default_url)
           .with(query: base_parameters.merge("filter[study_type]" => "full_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -120,7 +183,7 @@ feature "Study type filter", type: :feature do
 
     context "submitting without deselection" do
       before do
-        stub_request(:get, url)
+        stub_request(:get, default_url)
           .with(query: base_parameters.merge("filter[study_type]" => "full_time,part_time"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -147,135 +210,3 @@ feature "Study type filter", type: :feature do
     end
   end
 end
-
-#   before do
-#     stub_results_page_request
-#   end
-#
-#   describe "back link" do
-#     it "navigates back to the results page" do
-#       filter_page.load(query: { test: "params" })
-#       filter_page.back_link.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params:  {
-#           "fulltime" => "False",
-#           "hasvacancies" => "True",
-#           "parttime" => "False",
-#           "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-#           "senCourses" => "False",
-#           "test" => "params",
-#         },
-#       )
-#     end
-#   end
-#
-#
-#   describe "deselecting an option" do
-#     before { filter_page.load }
-#
-#     it "default full time and part time to true" do
-#       expect(filter_page.full_time.checked?).to be true
-#       expect(filter_page.part_time.checked?).to be true
-#     end
-#
-#     it "Allows the user to deselect full time" do
-#       filter_page.full_time.click
-#       filter_page.find_courses.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "fulltime" => "False",
-#           "parttime" => "True",
-#         },
-#       )
-#     end
-#
-#     it "Allows the user to deselect part time" do
-#       filter_page.part_time.click
-#       filter_page.find_courses.click
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "fulltime" => "True",
-#           "parttime" => "False",
-#         },
-#       )
-#     end
-#
-#     it "Allows the user to find courses" do
-#       filter_page.find_courses.click
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "fulltime" => "True",
-#           "parttime" => "True",
-#         },
-#       )
-#     end
-#   end
-#
-#   describe "Navigating to the page with currently selected filters" do
-#     it "Allows the full time param to be pre-selected" do
-#       filter_page.load(query: { fulltime: "True" })
-#       expect(filter_page.full_time.checked?).to eq(true)
-#     end
-#
-#     it "Allows the part time param to be pre-selected" do
-#       filter_page.load(query: { parttime: "True" })
-#       expect(filter_page.part_time.checked?).to eq(true)
-#     end
-#   end
-#
-#   describe "Validation" do
-#     it "Displays an error if neither option is selected" do
-#       filter_page.load
-#
-#       filter_page.part_time.click
-#       filter_page.full_time.click
-#
-#       filter_page.find_courses.click
-#
-#       expect(filter_page).to have_error
-#     end
-#   end
-#
-#   describe "QS parameters" do
-#     it "passes querystring parameters to results" do
-#       filter_page.load(query: { test: "value", parttime: "True" })
-#
-#       filter_page.find_courses.click
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "fulltime" => "False",
-#           "parttime" => "True",
-#           "test" => "value",
-#         },
-#       )
-#     end
-#
-#     it "passes arrays correctly" do
-#       url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-#       PageObjects::Page::ResultFilters::StudyType.set_url(url_with_array_params)
-#
-#       filter_page.load
-#       filter_page.part_time.click
-#       filter_page.find_courses.click
-#
-#       expect(results_page).to be_displayed
-#
-#       expect_page_to_be_displayed_with_query(
-#         page: results_page,
-#         expected_query_params: {
-#           "fulltime" => "True",
-#           "parttime" => "False",
-#           "test" => "1,2",
-#         },
-#       )
-#     end
-#   end
-# end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -10,13 +10,32 @@ feature "Subject filter", type: :feature do
         build(:subject, :primary, id: 1, bursary_amount: "1000"),
         build(:subject, :biology, id: 10, scholarship: "2000", subject_knowledge_enhancement_course_available: true),
         build(:subject, :russian, id: 38, bursary_amount: "3000", scholarship: "4000", early_career_payments: "1000"),
-        ]),
+      ]),
       build(:subject_area, :secondary, subjects: [build(:subject, :english, id: 12, subject_knowledge_enhancement_course_available: true)]),
     ]
   end
 
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
+
   before do
-    stub_results_page_request
+    stub_request(:get, default_url)
+      .with(query: base_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
 
     stub_api_v3_resource(
       type: SubjectArea,

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -3,8 +3,11 @@ require "rails_helper"
 feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:default_url) do
+  let(:courses_url) do
     "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
   end
 
   let(:base_parameters) do
@@ -18,11 +21,7 @@ feature "Vacancy filter", type: :feature do
   end
 
   before do
-    stub_api_v3_resource(
-      type: SubjectArea,
-      resources: nil,
-      include: [:subjects],
-    )
+    stub_request(:get, subjects_url)
   end
 
   describe "Vacancy filter page" do
@@ -35,7 +34,7 @@ feature "Vacancy filter", type: :feature do
 
     describe "back link" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -76,7 +75,7 @@ feature "Vacancy filter", type: :feature do
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -94,7 +93,7 @@ feature "Vacancy filter", type: :feature do
 
   describe "applying a filter" do
     before do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -104,7 +103,7 @@ feature "Vacancy filter", type: :feature do
 
     context "selecting courses with or without vacancies" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[vacancies]" => "false"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
@@ -129,7 +128,7 @@ feature "Vacancy filter", type: :feature do
 
     context "selecting courses with vacancies" do
       before do
-        stub_request(:get, default_url)
+        stub_request(:get, courses_url)
           .with(query: base_parameters.merge("filter[vacancies]" => "true"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -4,17 +4,83 @@ feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10"
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
+
+  before do
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+  end
+
+  describe "Vacancy filter page" do
+    before { filter_page.load }
+
+    it "has the correct title and heading" do
+      expect(page.title).to have_content("Find courses by vacancies")
+      expect(page).to have_content("Find courses by vacancies")
+    end
+
+    describe "back link" do
+      before do
+        stub_request(:get, default_url)
+          .with(query: base_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
+
+      it "navigates back to the results page" do
+        filter_page.load(query: { test: "params" })
+        filter_page.back_link.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            "fulltime" => "False",
+            "hasvacancies" => "True",
+            "parttime" => "False",
+            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+            "senCourses" => "False",
+            "test" => "params",
+          },
+        )
+      end
+    end
+
+    describe "Navigating to the page with currently selected filters" do
+      it "Preselects with vacancies" do
+        filter_page.load(query: { hasvacancies: "True" })
+        expect(filter_page.with_vacancies.checked?).to eq(true)
+      end
+
+      it "Preselects with and without vacancies" do
+        filter_page.load(query: { hasvacancies: "False" })
+        expect(filter_page.with_and_without_vacancies.checked?).to eq(true)
+      end
+    end
   end
 
   describe "viewing results without explicitly selecting a filter" do
     before do
-      stub_request(
-        :get,
-        default_url,
-      ).to_return(
-        body: File.new("spec/fixtures/api_responses/courses.json"),
-        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
 
@@ -26,23 +92,23 @@ feature "Vacancy filter", type: :feature do
     end
   end
 
-  describe "selecting a filter" do
-    context "selecting with or without vacancies" do
-      before do
-        stub_request(
-          :get,
-          default_url,
-        ).to_return(
+  describe "applying a filter" do
+    before do
+      stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
           body: File.new("spec/fixtures/api_responses/empty_courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-        )
+      )
+    end
 
-        stub_request(
-          :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=false&page%5Bpage%5D=1&page%5Bper_page%5D=10",
-        ).to_return(
-          body: File.new("spec/fixtures/api_responses/courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    context "selecting courses with or without vacancies" do
+      before do
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[vacancies]" => "false"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
 
@@ -51,32 +117,23 @@ feature "Vacancy filter", type: :feature do
         results_page.vacancies_filter.link.click
 
         expect(filter_page.heading.text).to eq("Find courses by vacancies")
+
         filter_page.with_and_without_vacancies.click
         filter_page.find_courses.click
 
         expect(results_page.heading.text).to eq("Teacher training courses")
         expect(results_page.vacancies_filter.vacancies.text).to eq("Courses with and without vacancies")
-
         expect(results_page.courses.count).to eq(2)
       end
     end
 
-    context "selecting only courses with vacancies" do
+    context "selecting courses with vacancies" do
       before do
-        stub_request(
-          :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
-        ).to_return(
-          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-        )
-
-        stub_request(
-          :get,
-          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10",
-        ).to_return(
-          body: File.new("spec/fixtures/api_responses/courses.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        stub_request(:get, default_url)
+          .with(query: base_parameters.merge("filter[vacancies]" => "true"))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
       end
 
@@ -97,108 +154,3 @@ feature "Vacancy filter", type: :feature do
     end
   end
 end
-
-  # before do
-  #   stub_results_page_request
-  # end
-
-  # describe "Navigating to the page with no selected filters" do
-  #   it "Defaults to with vacancies" do
-  #     filter_page.load
-  #     expect(filter_page.with_vacancies.checked?).to eq(true)
-  #   end
-  # end
-
-  # describe "back link" do
-  #   it "navigates back to the results page" do
-  #     filter_page.load(query: { test: "params" })
-  #     filter_page.back_link.click
-
-  #     expect_page_to_be_displayed_with_query(
-  #       page: results_page,
-  #       expected_query_params:  {
-  #         "fulltime" => "False",
-  #         "hasvacancies" => "True",
-  #         "parttime" => "False",
-  #         "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-  #         "senCourses" => "False",
-  #         "test" => "params",
-  #       },
-  #     )
-  #   end
-  # end
-
-  # describe "Selecting an option" do
-  #   before { filter_page.load }
-
-  #   it "Allows the user to select with vacancies" do
-  #     filter_page.with_vacancies.click
-  #     filter_page.find_courses.click
-
-  #     expect_page_to_be_displayed_with_query(
-  #       page: results_page,
-  #       expected_query_params: {
-  #         "hasvacancies" => "True",
-  #       },
-  #     )
-  #   end
-
-  #   it "Allows the user to select with and without vacancies" do
-  #     filter_page.with_and_without_vacancies.click
-  #     filter_page.find_courses.click
-  #     expect_page_to_be_displayed_with_query(
-  #       page: results_page,
-  #       expected_query_params: {
-  #         "hasvacancies" => "False",
-  #       },
-  #     )
-  #   end
-  # end
-
-  # describe "Navigating to the page with currently selected filters" do
-  #   it "Preselects with vacancies" do
-  #     filter_page.load(query: { hasvacancies: "True" })
-  #     expect(filter_page.with_vacancies.checked?).to eq(true)
-  #   end
-
-  #   it "Preselects with and without vacancies" do
-  #     filter_page.load(query: { hasvacancies: "False" })
-  #     expect(filter_page.with_and_without_vacancies.checked?).to eq(true)
-  #   end
-  # end
-
-  # describe "QS parameters" do
-  #   it "passes querystring parameters to results" do
-  #     filter_page.load(query: { test: "value" })
-  #     filter_page.with_vacancies.click
-  #     filter_page.find_courses.click
-
-  #     expect_page_to_be_displayed_with_query(
-  #       page: results_page,
-  #       expected_query_params: {
-  #         "hasvacancies" => "True",
-  #         "test" => "value",
-  #       },
-  #     )
-  #   end
-
-  #   it "passes arrays correctly" do
-  #     url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-  #     PageObjects::Page::ResultFilters::Vacancy.set_url(url_with_array_params)
-
-  #     filter_page.load
-  #     filter_page.with_vacancies.click
-  #     filter_page.find_courses.click
-
-  #     expect(results_page).to be_displayed
-
-  #     expect_page_to_be_displayed_with_query(
-  #       page: results_page,
-  #       expected_query_params: {
-  #         "hasvacancies" => "True",
-  #         "test" => "1,2",
-  #       },
-  #     )
-  #   end
-  # end
-# end

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -3,108 +3,202 @@ require "rails_helper"
 feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
-
-  before do
-    stub_results_page_request
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10"
   end
 
-  describe "Navigating to the page with no selected filters" do
-    it "Defaults to with vacancies" do
-      filter_page.load
-      expect(filter_page.with_vacancies.checked?).to eq(true)
-    end
-  end
-
-  describe "back link" do
-    it "navigates back to the results page" do
-      filter_page.load(query: { test: "params" })
-      filter_page.back_link.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params:  {
-          "fulltime" => "False",
-          "hasvacancies" => "True",
-          "parttime" => "False",
-          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-          "senCourses" => "False",
-          "test" => "params",
-        },
-      )
-    end
-  end
-
-  describe "Selecting an option" do
-    before { filter_page.load }
-
-    it "Allows the user to select with vacancies" do
-      filter_page.with_vacancies.click
-      filter_page.find_courses.click
-
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "hasvacancies" => "True",
-        },
+  describe "viewing results without explicitly selecting a filter" do
+    before do
+      stub_request(
+        :get,
+        default_url,
+      ).to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
 
-    it "Allows the user to select with and without vacancies" do
-      filter_page.with_and_without_vacancies.click
-      filter_page.find_courses.click
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "hasvacancies" => "False",
-        },
-      )
+    it "lists only courses with vacancies" do
+      results_page.load
+
+      expect(results_page.vacancies_filter.vacancies.text).to eq("Only courses with vacancies")
+      expect(results_page.courses.count).to eq(2)
     end
   end
 
-  describe "Navigating to the page with currently selected filters" do
-    it "Preselects with vacancies" do
-      filter_page.load(query: { hasvacancies: "True" })
-      expect(filter_page.with_vacancies.checked?).to eq(true)
+  describe "selecting a filter" do
+    context "selecting with or without vacancies" do
+      before do
+        stub_request(
+          :get,
+          default_url,
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=false&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
+
+      it "list the courses" do
+        results_page.load
+        results_page.vacancies_filter.link.click
+
+        expect(filter_page.heading.text).to eq("Find courses by vacancies")
+        filter_page.with_and_without_vacancies.click
+        filter_page.find_courses.click
+
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.vacancies_filter.vacancies.text).to eq("Courses with and without vacancies")
+
+        expect(results_page.courses.count).to eq(2)
+      end
     end
 
-    it "Preselects with and without vacancies" do
-      filter_page.load(query: { hasvacancies: "False" })
-      expect(filter_page.with_and_without_vacancies.checked?).to eq(true)
-    end
-  end
+    context "selecting only courses with vacancies" do
+      before do
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/empty_courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
 
-  describe "QS parameters" do
-    it "passes querystring parameters to results" do
-      filter_page.load(query: { test: "value" })
-      filter_page.with_vacancies.click
-      filter_page.find_courses.click
+        stub_request(
+          :get,
+          "http://localhost:3001/api/v3/recruitment_cycles/2020/courses?include=provider&filter[vacancies]=true&page%5Bpage%5D=1&page%5Bper_page%5D=10",
+        ).to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
+      end
 
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "hasvacancies" => "True",
-          "test" => "value",
-        },
-      )
-    end
+      it "lists the courses" do
+        results_page.load
+        results_page.vacancies_filter.link.click
 
-    it "passes arrays correctly" do
-      url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
-      PageObjects::Page::ResultFilters::Vacancy.set_url(url_with_array_params)
+        expect(filter_page.heading.text).to eq("Find courses by vacancies")
 
-      filter_page.load
-      filter_page.with_vacancies.click
-      filter_page.find_courses.click
+        filter_page.with_vacancies.click
+        filter_page.find_courses.click
 
-      expect(results_page).to be_displayed
+        expect(results_page.heading.text).to eq("Teacher training courses")
+        expect(results_page.vacancies_filter.vacancies.text).to eq("Only courses with vacancies")
 
-      expect_page_to_be_displayed_with_query(
-        page: results_page,
-        expected_query_params: {
-          "hasvacancies" => "True",
-          "test" => "1,2",
-        },
-      )
+        expect(results_page.courses.count).to eq(2)
+      end
     end
   end
 end
+
+  # before do
+  #   stub_results_page_request
+  # end
+
+  # describe "Navigating to the page with no selected filters" do
+  #   it "Defaults to with vacancies" do
+  #     filter_page.load
+  #     expect(filter_page.with_vacancies.checked?).to eq(true)
+  #   end
+  # end
+
+  # describe "back link" do
+  #   it "navigates back to the results page" do
+  #     filter_page.load(query: { test: "params" })
+  #     filter_page.back_link.click
+
+  #     expect_page_to_be_displayed_with_query(
+  #       page: results_page,
+  #       expected_query_params:  {
+  #         "fulltime" => "False",
+  #         "hasvacancies" => "True",
+  #         "parttime" => "False",
+  #         "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+  #         "senCourses" => "False",
+  #         "test" => "params",
+  #       },
+  #     )
+  #   end
+  # end
+
+  # describe "Selecting an option" do
+  #   before { filter_page.load }
+
+  #   it "Allows the user to select with vacancies" do
+  #     filter_page.with_vacancies.click
+  #     filter_page.find_courses.click
+
+  #     expect_page_to_be_displayed_with_query(
+  #       page: results_page,
+  #       expected_query_params: {
+  #         "hasvacancies" => "True",
+  #       },
+  #     )
+  #   end
+
+  #   it "Allows the user to select with and without vacancies" do
+  #     filter_page.with_and_without_vacancies.click
+  #     filter_page.find_courses.click
+  #     expect_page_to_be_displayed_with_query(
+  #       page: results_page,
+  #       expected_query_params: {
+  #         "hasvacancies" => "False",
+  #       },
+  #     )
+  #   end
+  # end
+
+  # describe "Navigating to the page with currently selected filters" do
+  #   it "Preselects with vacancies" do
+  #     filter_page.load(query: { hasvacancies: "True" })
+  #     expect(filter_page.with_vacancies.checked?).to eq(true)
+  #   end
+
+  #   it "Preselects with and without vacancies" do
+  #     filter_page.load(query: { hasvacancies: "False" })
+  #     expect(filter_page.with_and_without_vacancies.checked?).to eq(true)
+  #   end
+  # end
+
+  # describe "QS parameters" do
+  #   it "passes querystring parameters to results" do
+  #     filter_page.load(query: { test: "value" })
+  #     filter_page.with_vacancies.click
+  #     filter_page.find_courses.click
+
+  #     expect_page_to_be_displayed_with_query(
+  #       page: results_page,
+  #       expected_query_params: {
+  #         "hasvacancies" => "True",
+  #         "test" => "value",
+  #       },
+  #     )
+  #   end
+
+  #   it "passes arrays correctly" do
+  #     url_with_array_params = "#{filter_page.url}?test[]=1&test[]=2"
+  #     PageObjects::Page::ResultFilters::Vacancy.set_url(url_with_array_params)
+
+  #     filter_page.load
+  #     filter_page.with_vacancies.click
+  #     filter_page.find_courses.click
+
+  #     expect(results_page).to be_displayed
+
+  #     expect_page_to_be_displayed_with_query(
+  #       page: results_page,
+  #       expected_query_params: {
+  #         "hasvacancies" => "True",
+  #         "test" => "1,2",
+  #       },
+  #     )
+  #   end
+  # end
+# end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -29,6 +29,10 @@ feature "results", type: :feature do
     }
   end
 
+  let(:courses) {
+    File.new("spec/fixtures/api_responses/courses.json")
+  }
+
   before do
     stub_api_v3_resource(
       type: SubjectArea,
@@ -39,13 +43,31 @@ feature "results", type: :feature do
     stub_request(:get, default_url)
       .with(query: base_parameters)
       .to_return(
-        body: File.new("spec/fixtures/api_responses/courses.json"),
+        body: courses,
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
     )
 
     allow(Settings).to receive_message_chain(:google, :maps_api_key).and_return("alohomora")
     allow(Settings).to receive_message_chain(:google, :maps_api_url).and_return("https://maps.googleapis.com/maps/api/staticmap")
     visit results_path(params)
+  end
+
+  describe "course count" do
+    context "when API returns two courses" do
+      it "displays the correct course count" do
+        expect(results_page.course_count).to have_content("2 courses found")
+      end
+    end
+
+    context "when API return no courses" do
+      let(:courses) {
+        File.new("spec/fixtures/api_responses/empty_courses.json")
+      }
+
+      it "displays the correct course count" do
+        expect(results_page.course_count).to have_content("0 courses found")
+      end
+    end
   end
 
   describe "filters defaults without query string" do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -11,18 +11,36 @@ feature "results", type: :feature do
         build(:subject, :english, id: 21),
         build(:subject, :mathematics, id: 25),
         build(:subject, :french, id: 34),
-        ]),
+      ]),
       build(:subject_area, :secondary),
     ]
   end
+  let(:default_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:base_parameters) do
+    {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
+  end
 
   before do
-    stub_results_page_request
-
     stub_api_v3_resource(
       type: SubjectArea,
       resources: subject_areas,
       include: [:subjects],
+    )
+
+    stub_request(:get, default_url)
+      .with(query: base_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
     )
 
     allow(Settings).to receive_message_chain(:google, :maps_api_key).and_return("alohomora")
@@ -77,191 +95,97 @@ feature "results", type: :feature do
     end
   end
 
-  describe "filters with query string" do
-    describe "study type filter" do
-      context "for full time only" do
-        let(:params) { { fulltime: "True", parttime: "False" } }
+  describe "subjects filter" do
+    context "no subjects selected" do
+      let(:params) { { subjects: {} } }
 
-        it "has study type filter for full time only " do
-          expect(results_page.study_type_filter.subheading).to have_content("Study type:")
-          expect(results_page.study_type_filter.fulltime).to have_content("Full time (12 months)")
-          expect(results_page.study_type_filter).not_to have_parttime
-          expect(results_page.study_type_filter.link).to have_content("Change study type")
-        end
-      end
-
-      context "for part time only" do
-        let(:params) { { fulltime: "False", parttime: "True" } }
-
-        it "has study type filter for part time only" do
-          expect(results_page.study_type_filter.subheading).to have_content("Study type:")
-          expect(results_page.study_type_filter).not_to have_fulltime
-          expect(results_page.study_type_filter.parttime).to have_content("Part time (18 - 24 months)")
-          expect(results_page.study_type_filter.link).to have_content("Change study type")
-        end
+      it "defaults to all subjects without 'Only SEND courses'" do
+        expect(results_page.subjects_filter).not_to have_send_courses
+        expect(results_page.subjects_filter).to have_content("Biology")
+        expect(results_page.subjects_filter).to have_content("English")
+        expect(results_page.subjects_filter).to have_content("French")
+        expect(results_page.subjects_filter).to have_content("Mathematics")
+        expect("Biology").to appear_before("English")
+        expect("English").to appear_before("French")
+        expect("French").to appear_before("Mathematics")
+        expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
       end
     end
 
-    describe "vacancies filter" do
-      context "only courses with vacancies" do
-        let(:params) { { hasvacancies: "True" } }
+    context "up to 4 subjects selected" do
+      let(:params) { { subjects: "31,1" } }
 
-        it "has vacancies filter" do
-          expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
-          expect(results_page.vacancies_filter.vacancies).to have_content("Only courses with vacancies")
-          expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
-        end
-      end
-
-      context "courses with and without vacancies" do
-        let(:params) { { hasvacancies: "False" } }
-
-        it "has vacancies filter" do
-          expect(results_page.vacancies_filter.subheading).to have_content("Vacancies:")
-          expect(results_page.vacancies_filter.vacancies).to have_content("Courses with and without vacancies")
-          expect(results_page.vacancies_filter.link).to have_content("Change vacancies")
-        end
-      end
-
-      describe "salary filter" do
-        context "only courses with salaries" do
-          let(:params) { { funding: "8" } }
-
-          it "has salaries filter" do
-            expect(results_page.funding_filter.funding).to have_content("Only courses with a salary")
-          end
-        end
-
-        context "courses with and without salaries" do
-          let(:params) { { funding: "15" } }
-
-          it "has salaries filter" do
-            expect(results_page.funding_filter.funding).to have_content("Courses with and without salary")
-          end
-        end
-
-        context "without any parameters" do
-          it "defaults to courses with and without salaries" do
-            expect(results_page.funding_filter.funding).to have_content("Courses with and without salary")
-          end
-        end
+      it "displays all selected subjects in alphabetical order" do
+        expect(results_page.subjects_filter).not_to have_send_courses
+        expect(results_page.subjects_filter).to have_content("Biology")
+        expect(results_page.subjects_filter).to have_content("Primary")
+        expect("Biology").to appear_before("Primary")
       end
     end
 
-    describe "qualifications filter" do
-      context "all selected" do
-        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts,Other" } }
+    context "more than 4 subjects selected" do
+      let(:params) { { subjects: "31,1,12,24,13" } }
 
-        it "displays text 'All qualifications'" do
-          expect(results_page.qualifications_filter.qualifications.first).to have_content("All qualifications")
-        end
+      it "displays first 4 subjects and number of extra courses selected" do
+        expect(results_page.subjects_filter).to have_content("Biology")
+        expect(results_page.subjects_filter).to have_content("English")
+        expect(results_page.subjects_filter).to have_content("French")
+        expect(results_page.subjects_filter).to have_content("Mathematics")
+        expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
       end
 
-      context "two selected" do
-        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+      context "'Only SEND courses' selected" do
+        let(:params) { { subjects: "31,1,12,24,13", senCourses: "true" } }
 
-        it "displays text for each qualification" do
-          expect(results_page.qualifications_filter.qualifications.first).to have_content("QTS only")
-          expect(results_page.qualifications_filter.qualifications.last).to have_content("PGCE (or PGDE) with QTS")
-          expect(results_page.qualifications_filter.qualifications.count).to eq(2)
-        end
-      end
-    end
-
-    describe "subjects filter" do
-      context "no subjects selected" do
-        let(:params) { { subjects: {} } }
-
-        it "defaults to all subjects without 'Only SEND courses'" do
-          expect(results_page.subjects_filter).not_to have_send_courses
-          expect(results_page.subjects_filter).to have_content("Biology")
-          expect(results_page.subjects_filter).to have_content("English")
-          expect(results_page.subjects_filter).to have_content("French")
-          expect(results_page.subjects_filter).to have_content("Mathematics")
-          expect("Biology").to appear_before("English")
-          expect("English").to appear_before("French")
-          expect("French").to appear_before("Mathematics")
-          expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
-        end
-      end
-
-      context "up to 4 subjects selected" do
-        let(:params) { { subjects: "31,1" } }
-
-        it "displays all selected subjects in alphabetical order" do
-          expect(results_page.subjects_filter).not_to have_send_courses
-          expect(results_page.subjects_filter).to have_content("Biology")
-          expect(results_page.subjects_filter).to have_content("Primary")
-          expect("Biology").to appear_before("Primary")
-        end
-      end
-
-      context "more than 4 subjects selected" do
-        let(:params) { { subjects: "31,1,12,24,13" } }
-
-        it "displays first 4 subjects and number of extra courses selected" do
+        it "displays 'Only SEND courses' at the top of the list and doesn't count towards 4 items rule" do
+          expect(results_page.subjects_filter.send_courses).to have_content("Only SEND courses")
           expect(results_page.subjects_filter).to have_content("Biology")
           expect(results_page.subjects_filter).to have_content("English")
           expect(results_page.subjects_filter).to have_content("French")
           expect(results_page.subjects_filter).to have_content("Mathematics")
           expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
-        end
-
-        context "'Only SEND courses' selected" do
-          let(:params) { { subjects: "31,1,12,24,13", senCourses: "true" } }
-
-          it "displays 'Only SEND courses' at the top of the list and doesn't count towards 4 items rule" do
-            expect(results_page.subjects_filter.send_courses).to have_content("Only SEND courses")
-            expect(results_page.subjects_filter).to have_content("Biology")
-            expect(results_page.subjects_filter).to have_content("English")
-            expect(results_page.subjects_filter).to have_content("French")
-            expect(results_page.subjects_filter).to have_content("Mathematics")
-            expect(results_page.subjects_filter.extra_subjects).to have_content("and 1 more...")
-            expect("Only SEND courses").to appear_before("Biology")
-          end
+          expect("Only SEND courses").to appear_before("Biology")
         end
       end
     end
+  end
 
-    describe "location filter" do
-      context "location selected within 10 miles" do
-        let(:params) do
-          {
-            loc: "Hogwarts, Reading, UK",
-            rad: "10",
-            lng: "-27.1504002",
-            lat: "-109.3042697",
-            l: "1",
-          }
-        end
+  describe "provider filter" do
+    context "provider selected" do
+      let(:params) { { query: "Junior Middle Lower Upper Second Fifth High", l: "3" } }
 
-        it "displays the location filter" do
-          expected_url = "https://maps.googleapis.com/maps/api/staticmap?key=alohomora&center=-109.3042697,-27.1504002&zoom=11&size=300x200&scale=2&markers=-109.3042697,-27.1504002"
-          expect(results_page).to_not have_provider_filter
-          expect(results_page.location_filter.name).to have_content("Hogwarts, Reading, UK")
-          expect(results_page.location_filter.distance).to have_content("Within 10 miles of the pin")
-          expect(results_page.location_filter.map["src"]).to have_content(expected_url)
-          results_page.location_filter.link.click
-          location_filter_uri = URI(current_url)
-          expect(location_filter_uri.path).to eq("/results/filter/location")
-          expect(location_filter_uri.query).to eq("l=1&lat=-109.3042697&lng=-27.1504002&loc=Hogwarts,+Reading,+UK&rad=10&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
-        end
+      it "displays the provider filter" do
+        expect(results_page.provider_title).to have_content("Junior Middle Lower Upper Second Fifth High")
+        expect(results_page).to_not have_location_filter
+        expect(results_page.provider_filter.name).to have_content("Junior Middle Lower Upper Second Fifth High")
+        results_page.provider_filter.link.click
+        provider_filter_uri = URI(current_url)
+        expect(provider_filter_uri.path).to eq("/results/filter/location")
+        expect(provider_filter_uri.query).to eq("l=3&query=Junior+Middle+Lower+Upper+Second+Fifth+High&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
       end
     end
+  end
 
-    describe "provider filter" do
-      context "provider selected" do
-        let(:params) { { query: "Junior Middle Lower Upper Second Fifth High", l: "3" } }
+  describe "location filter" do
+    context "location selected within 10 miles" do
+      let(:params) do
+        {
+          loc: "Hogwarts, Reading, UK",
+          rad: "10",
+          lng: "-27.1504002",
+          lat: "-109.3042697",
+        }
+      end
 
-        it "displays the provider filter" do
-          expect(results_page.provider_title).to have_content("Junior Middle Lower Upper Second Fifth High")
-          expect(results_page).to_not have_location_filter
-          expect(results_page.provider_filter.name).to have_content("Junior Middle Lower Upper Second Fifth High")
-          results_page.provider_filter.link.click
-          provider_filter_uri = URI(current_url)
-          expect(provider_filter_uri.path).to eq("/results/filter/location")
-          expect(provider_filter_uri.query).to eq("l=3&query=Junior+Middle+Lower+Upper+Second+Fifth+High&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
-        end
+      it "displays the location filter" do
+        expected_url = "https://maps.googleapis.com/maps/api/staticmap?key=alohomora&center=-109.3042697,-27.1504002&zoom=11&size=300x200&scale=2&markers=-109.3042697,-27.1504002"
+        expect(results_page.location_filter.name).to have_content("Hogwarts, Reading, UK")
+        expect(results_page.location_filter.distance).to have_content("Within 10 miles of the pin")
+        expect(results_page.location_filter.map["src"]).to have_content(expected_url)
+        results_page.location_filter.link.click
+        location_filter_uri = URI(current_url)
+        expect(location_filter_uri.path).to eq("/results/filter/location")
+        expect(location_filter_uri.query).to eq("lat=-109.3042697&lng=-27.1504002&loc=Hogwarts,+Reading,+UK&rad=10&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
       end
     end
   end

--- a/spec/fixtures/api_responses/courses.json
+++ b/spec/fixtures/api_responses/courses.json
@@ -1,0 +1,1065 @@
+{
+  "data": [
+    {
+      "id": "12928386",
+      "type": "courses",
+      "attributes": {
+        "findable?": true,
+        "open_for_applications?": true,
+        "has_vacancies?": true,
+        "course_code": "2VMB",
+        "name": "Mathematics",
+        "study_mode": "full_time",
+        "qualification": "qts",
+        "description": "QTS full time with salary",
+        "content_status": "published",
+        "ucas_status": "running",
+        "funding_type": "salary",
+        "level": "secondary",
+        "is_send?": false,
+        "english": "must_have_qualification_at_application_time",
+        "maths": "must_have_qualification_at_application_time",
+        "science": null,
+        "gcse_subjects_required": [
+          "maths",
+          "english"
+        ],
+        "age_range_in_years": "11_to_18",
+        "accrediting_provider": {
+          "id": 13985,
+          "address4": "London",
+          "provider_name": "e-Qualitas",
+          "scheme_member": "is_a_UCAS_ITT_member",
+          "contact_name": "Programme Director",
+          "year_code": "2019",
+          "provider_code": "E69",
+          "provider_type": "scitt",
+          "postcode": "D3N 3FJ",
+          "website": "http://cat.me",
+          "address1": "4th Floor, 8 Frank's Avenue",
+          "address2": "",
+          "address3": "London",
+          "email": "info@qualitas.co.uk",
+          "telephone": "0456 055 8566",
+          "region_code": "south_east",
+          "created_at": "2019-07-19T08:28:58.099Z",
+          "updated_at": "2019-12-12T15:23:05.891Z",
+          "accrediting_provider": "accredited_body",
+          "changed_at": "2020-01-16T15:15:20.240Z",
+          "recruitment_cycle_id": 2,
+          "discarded_at": null,
+          "train_with_us": "We are a large SCITT, working with schools of all kinds (primary, secondary, special, independent) in the London area and across southern England. We have rolling recruitment, meaning that trainees can start in September or later in the academic year. \r\n\r\nOur course suits those who are independent, self-motivated learners. An individual training plan guides each trainee; we have an extensive on-line library, and training days in central London complement the in-school training. Trainees are assessed every five weeks, which ensures that they know what they have done well, and what to focus on next. Each trainee has a visiting tutor who is a secondary subject, or primary, specialist. Tutors visit their trainees for a full day each half term. These visits include two lesson observations of the trainee, feedback on strengths and development points, and a check on progress overall.\r\n\r\nOur aim is that all our trainees become excellent teachers. Everything we do is focused on this. In each of the last three years, two-thirds of our trainees have been graded 'excellent' in the final assessment for QTS. Over 90% have been appointed to a teaching post in the school in which they trained or did a placement (a few take teaching posts in other schools).  \r\n",
+          "train_with_disability": "Our course is designed to be flexible and responsive to individual needs. As a group of full-time trainees starts each term, trainees who aren't able to train on a full-time basis, or who become ill and need time off during the course, don't miss out on any training as they join in with the next group of trainees. Adapted tasks are available for students whose dyslexia makes it hard to write full essays for their assignments. Training day venues have wheelchair access, and cater for all dietary requirements. We ask trainees to let us know of any disability or other need, so that we and the partner schools can make appropriate arrangements.\r\n\r\nTrainees who wish to gain a PGCE as well as QTS can add the academic award through our higher education partner. As we do not have a compulsory integral PGCE we have great flexibility in meeting our trainees' individual training needs eg we can adapt  coursework tasks for those who need individual arrangements, we don't have fixed coursework deadlines during the training, and our trainees can start the course when it suits them  and their school during the academic year.\r\n",
+          "accrediting_provider_enrichments": [],
+          "latitude": 51.5116168,
+          "longitude": -0.0776898
+        },
+        "accrediting_provider_code": "E69",
+        "start_date": "September 2020",
+        "applications_open_from": "2019-10-08",
+        "last_published_at": "2019-09-29T21:02:41Z",
+        "about_accrediting_body": "e-Qualitas offers a route into teacher training, through the South East Learning Alliance, where your study is completed through the distance-learning resources on the eQ virtual learning environment (VLE). Training sessions are provided by experienced school staff, and you are invited to attend training days led by eQ at a central London location. You will also benefit from a subject-specialist visiting Tutor from e-Qualitas, who will support you through your training. You will follow a course that leads to QTS. The course content is organised into six modules, the first three of which may be worked on concurrently.",
+        "provider_code": "1J1",
+        "recruitment_cycle_year": "2020",
+        "about_course": "The School Direct package offered by the South East Learning Alliance is one that allows prospective teachers to gain an opportunity to train in a dynamic educational setting located across ten highly different, but successful schools. The Alliance comprises of four comprehensive secondary schools and six primary schools, all of whom are working in partnership to help produce high quality and well-trained teachers of the future. The South East Learning Alliance is very proud of the bespoke and personal training opportunities we offer our students, which we believe is paramount to successfully completing your teacher-training. \r\n\r\n* Applicants who opt to train through the Salaried School Direct route, will have a timetable of classes from the outset of their training year, which is complimented by the online tutorials and distance-learning modules e-Qualitas delivers\r\n\r\n* In addition to a subject-specific Mentor within your host-school; the partner University also offers a learning-Mentor to support you in the completion of the three written assignments you will undertake across the year, which focusses on the theoretical approaches to pedagogy and effective classroom practice \r\n\r\n* You will train across two diverse placement schools, ensuring you have the confidence to teach in any educational setting\r\n\r\n* In addition to the written assignments; trainees will also be assessed on their classroom practice; their ability to meet the National Teaching Standards; their interactions with students and ability to plan and deliver high quality lessons",
+        "course_length": "OneYear",
+        "fee_details": null,
+        "fee_international": null,
+        "fee_uk_eu": null,
+        "financial_support": null,
+        "how_school_placements_work": "With our School Direct programme, you get practical, hands-on experience in two contrasting placement schools. The majority of your training will take place in your host school, where you will be fully supported by a subject specific Mentor and become a fully established member of the staffing body. This is in addition to benefiting from the wealth of expertise and experience our partner Universities offer our students, which fully compliments the training received in school. \r\n\r\nYou will also benefit from training in an alternative placement school for at least 5 weeks; where the South East Learning Alliance takes great time and care placing the trainees; ensuring the alternative setting fully supports the individual needs of each student, whilst still offering a diverse experience. All of our trainees will have an opportunity to teach across the age range. \r\n\r\nThe hands-on practice gained by completing a School Direct programme is complimented with the theoretical and academic rigour of our affiliated Universities. We offer full-time School Direct courses, which run from September – July and each course results in QTS (e-Qualitas). ",
+        "interview_process": "At interview applicants will be given the opportunity to visit one of our Alliance schools. This provides an excellent opportunity to meet a variety of colleagues; tour the facilities and to gain a greater understanding of the opportunities on offer as a result of choosing to train with the South East Learning Alliance. It also affords an opportunity for applicants to better understand the ethos and culture of the school you may be working in partnership with.\r\n\r\nYou will be expected to prepare for a formal interview panel; plan and deliver a 30-50 minute lesson; complete a subject-knowledge task and undertake a written communication task. The interview panel will consist of a subject-specialist from the host school; a representative from the South East Learning Alliance and often a University representative.  \r\n\r\nWhilst the interview process is both rigorous and robust - we have experienced great success with this practice; ensuring the right candidates progress onto the right courses - leading to excellent rates of retention.",
+        "other_requirements": "* Provide the details of two referees. If candidates have studied within the last 5 years; an academic reference must be provided. The other reference should be a school or employer's reference. \r\n\r\n* If you do not currently hold a GCSE grade C or above in Mathematics and English Language, please note that we accept the equivalency tests in both Mathematics and English offered by Equivalency Testing. Please contact them directly via their website [http://www.equivalencytesting.com]",
+        "personal_qualities": "* A sense of humour \r\n* Genuine concern for others \u0026 a clear moral purpose\r\n* Resilient and determined \r\n* Integrity, trusted, honest and open \r\n* Approachable \r\n* Intellectual versatility \r\n* Ability to show initiative\r\n* Adaptable \u0026 a team-player \r\n* A willingness to participate in extra-curricular activities and evening events such as concerts, awards evening, extra-curricular clubs \r\n* A positive attitude  \r\n",
+        "required_qualifications": "* Hold an undergraduate degree conferred by a UK higher education institution or an equivalent qualification (2:2 degree classification or better). Applicants should have a single subject degree in mathematics or a joint degree in which mathematics formed a substantial part. Students with a degree in other disciplines with a strong mathematical content, such as engineering and management science, are also welcome to apply. \r\n\r\n* Have achieved at least a grade C in both Mathematics and English Language GCSEs (or approved equivalents). \r\n\r\n* Applicants are expected to have significant work experience in an educational setting, prior to submitting an application. ",
+        "salary_details": "Salary negotiable. \r\nThe salary will be awarded using the Unqualified Teachers Pay Scale; the details of which can be found here: [https://getintoteaching.education.gov.uk/funding-and-salary/teacher-salaries]\r\nThe final salary decision will be based upon experience, location of the host-school, qualifications and subject-specialism. "
+      },
+      "relationships": {
+        "provider": {
+          "data": {
+            "type": "providers",
+            "id": "14361"
+          }
+        },
+        "accrediting_provider": {
+          "meta": {
+            "included": false
+          }
+        },
+        "site_statuses": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "subjects": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "meta": {
+        "edit_options": {
+          "entry_requirements": [
+            "must_have_qualification_at_application_time",
+            "expect_to_achieve_before_training_begins",
+            "equivalence_test"
+          ],
+          "qualifications": [
+            "qts",
+            "pgce_with_qts",
+            "pgde_with_qts"
+          ],
+          "age_range_in_years": [
+            "11_to_16",
+            "11_to_18",
+            "14_to_19"
+          ],
+          "start_dates": [
+            "October 2019",
+            "November 2019",
+            "December 2019",
+            "January 2020",
+            "February 2020",
+            "March 2020",
+            "April 2020",
+            "May 2020",
+            "June 2020",
+            "July 2020",
+            "August 2020",
+            "September 2020",
+            "October 2020",
+            "November 2020",
+            "December 2020",
+            "January 2021",
+            "February 2021",
+            "March 2021",
+            "April 2021",
+            "May 2021",
+            "June 2021",
+            "July 2021"
+          ],
+          "study_modes": [
+            "full_time",
+            "part_time",
+            "full_time_or_part_time"
+          ],
+          "show_is_send": false,
+          "show_start_date": false,
+          "show_applications_open": false,
+          "subjects": [
+            {
+              "id": "8",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Art and design",
+                "subject_code": "W1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "10",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Biology",
+                "subject_code": "C1",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "11",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Business studies",
+                "subject_code": "08",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "12",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Chemistry",
+                "subject_code": "F1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "13",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Citizenship",
+                "subject_code": "09",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "14",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Classics",
+                "subject_code": "Q8",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "15",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Communication and media studies",
+                "subject_code": "P3",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "16",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Computing",
+                "subject_code": "11",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "17",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Dance",
+                "subject_code": "12",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "18",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Design and technology",
+                "subject_code": "DT",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "19",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Drama",
+                "subject_code": "13",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "20",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Economics",
+                "subject_code": "L1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "21",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "English",
+                "subject_code": "Q3",
+                "bursary_amount": "12000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "22",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Geography",
+                "subject_code": "F8",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": "17000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "23",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Health and social care",
+                "subject_code": "L5",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "24",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "History",
+                "subject_code": "V1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "25",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Mathematics",
+                "subject_code": "G1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "33",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Modern Languages",
+                "subject_code": null,
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "26",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Music",
+                "subject_code": "W3",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "27",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Philosophy",
+                "subject_code": "P1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "28",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physical education",
+                "subject_code": "C6",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "29",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physics",
+                "subject_code": "F3",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "30",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Psychology",
+                "subject_code": "C8",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "31",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Religious education",
+                "subject_code": "V6",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "9",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Science",
+                "subject_code": "F0",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "32",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Social sciences",
+                "subject_code": "14",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            }
+          ],
+          "modern_languages": null
+        }
+      }
+    },
+    {
+      "id": "12927722",
+      "type": "courses",
+      "attributes": {
+        "findable?": true,
+        "open_for_applications?": true,
+        "has_vacancies?": true,
+        "course_code": "26Q6",
+        "name": "English",
+        "study_mode": "full_time",
+        "qualification": "pgce_with_qts",
+        "description": "PGCE with QTS full time with salary",
+        "content_status": "published",
+        "ucas_status": "running",
+        "funding_type": "salary",
+        "level": "secondary",
+        "is_send?": false,
+        "english": "equivalence_test",
+        "maths": "equivalence_test",
+        "science": null,
+        "gcse_subjects_required": [
+          "maths",
+          "english"
+        ],
+        "age_range_in_years": null,
+        "accrediting_provider": {
+          "id": 14379,
+          "address4": "South Yorkshire",
+          "provider_name": "Sheffield Hallam University",
+          "scheme_member": "is_a_UCAS_ITT_member",
+          "contact_name": "Admissions Office",
+          "year_code": "2019",
+          "provider_code": "S21",
+          "provider_type": "university",
+          "postcode": "D2 5TH",
+          "website": "http://sheep.me",
+          "address1": "Floor 4",
+          "address2": "Pancake Street",
+          "address3": "Hull",
+          "email": "info@baa.ac.uk",
+          "telephone": "0445 665 5533",
+          "region_code": "yorkshire_and_the_humber",
+          "created_at": "2019-07-19T08:34:30.242Z",
+          "updated_at": "2019-12-24T15:59:45.659Z",
+          "accrediting_provider": "accredited_body",
+          "changed_at": "2019-12-24T15:59:45.659Z",
+          "recruitment_cycle_id": 2,
+          "discarded_at": null,
+          "train_with_us": "Sheffield Hallam University is one of the UK's largest universities, based in the heart of Sheffield, one of the UK’s biggest student cities.\r\n\r\nSheffield is the fifth biggest city in the UK with over 60,000 students, it has a mix of culture and green spaces. \r\n\r\nWe have invested over £100 million in new buildings and facilities over the last five years, providing innovative, flexible and sustainable spaces to enhance student experience.\r\n\r\nWe pride ourselves on the applied nature of our courses. We offer one of the largest and most diverse range of placements in the region. We’ve built up a network of over 600 partner schools, colleges and other educational establishments, and we work together to our mutual advantage.\r\n\t\r\nYou will study at our centre of education that is recognised for excellence and innovation in teaching and learning. Our academics, researchers and partners in schools work together to ensure you become a committed and professional graduate, with the opportunity to return to us throughout your career to further your professional development.\r\n\t\r\nWe received an overall student satisfaction rating of 86% in the 2019 National Student Survey. This result places us in the top 30 universities in the country for student satisfaction. We also received a Silver rating in the 2017 Teaching Excellence Framework. \r\n\r\n[Find out more on our website] (https://www.shu.ac.uk/Study-here/options/Teach)",
+          "train_with_disability": "If you have a disability, including long term medical conditions, specific learning difficulties (such as dyslexia, dyspraxia and A(D)HD) and mental health conditions, you can access additional support for your academic studies whilst at Sheffield Hallam.\r\n\r\nStudents can receive support for a wide variety of conditions. There is extensive support available, including\r\n\r\n•\tLearning contracts- reasonable adjustments to your course such as extensions or extra time in exams\r\n\r\n•\tSupport workers - like a mentor to help with organisation, or a personal assistant to help with mobility\r\n\r\n•\tEquipment/Assistive Technology and software - such as digital recorders or text to speech software\r\n\r\nWe have an on-site assessment Centre, the Sheffield Regional Assessment Centre, where a range of disability specialists can carry out Study Needs Assessments.\r\n\r\nWe run daily drop in sessions - come and talk to us, no appointment needed. You can also register for support online.\r\n",
+          "accrediting_provider_enrichments": [],
+          "latitude": 53.3781046,
+          "longitude": -1.4665227
+        },
+        "accrediting_provider_code": "S21",
+        "start_date": "September 2020",
+        "applications_open_from": "2019-10-08",
+        "last_published_at": "2019-09-30T11:56:51Z",
+        "about_accrediting_body": "Delta TSA works in close partnership with Sheffield Hallam University, sharing commitment to providing high quality training for all successful School Direct applicants.\r\n\r\nSheffield Institute of Education (SIoE) at Sheffield Hallam recently received an 'Outstanding' rating for primary teacher training. SIoE also received 'Good' grades for secondary and further education provision.\r\n\r\n“We pride ourselves on the applied nature of your learning and quality of our teaching. The recent Ofsted report praised the quality and level of knowledge of our trainees upon completion of their studies and the high regard they are held in by our partners in the region.” (SHU-2018)\r\n",
+        "provider_code": "1DU",
+        "recruitment_cycle_year": "2020",
+        "about_course": "School Direct is a programme where schools or partnerships of schools apply for trainee teacher places. This means that schools can choose the teacher training provider they wish to work with and have more control over what training is provided and how it is delivered, including how much training will take place within the school partnership. Schools recruit the trainees they want, and trainees will go on to teach in their school, or another school in their partnership, once qualified.  It is part of a wider set of reforms designed to help schools take greater responsibility for leading and shaping ITT, including new approaches to university-school partnerships, Teaching Schools ITT role, and the accreditation of new school-led providers.\r\n\r\nFor 2020/21 two types of School Direct training places are available:\r\n•\tThe School Direct Training Programme, which is open to all graduates and funded by tuition fees paid by the trainee, who may be eligible to receive a bursary.\r\n•\tThe School Direct Training Programme (salaried), which is an employment-based route into teaching for high quality graduates with three or more years' career experience. The trainee is employed as an unqualified teacher by a school. The DfE provides funding, which the school can use to subsidise the trainee's salary and/or training.\r\n\r\nDelta Teaching School Alliance School Direct Trainees will:\r\n•\tBe supported by outstanding teachers, have a school-based mentor and an academic tutor from the university who will be an expert specialist in the field. All of these will be dedicated to your development towards becoming a high quality reflective practitioner.\r\n•\tGain a PGCE which includes qualified teacher status and can be used as the first third of a masters degree if you wish to continue with this accredited professional development in the early part of your career.\r\n•\tBenefit from high quality sessions with other trainees across Delta Teaching School Alliance to develop your knowledge and application of effective strategies that underpin learning and achievement in the classroom.\r\n•\tUtilise outstanding current teachers and school leaders to lead taught sessions, ensuring you learn from those who are current teachers and school leaders.\r\n•\tBenefit from high quality sessions with other PGCE students at the university where research-informed practice and theoretical underpinning of classroom practice will be shared and critiqued.\r\n•\tBe supported through our Specialist Leaders of Education (SLEs) who are designated practitioners with national recognition for their expertise.\r\n",
+        "course_length": "OneYear",
+        "fee_details": null,
+        "fee_international": null,
+        "fee_uk_eu": null,
+        "financial_support": null,
+        "how_school_placements_work": "Once candidates have been offered a training place on the School Direct Programme with Delta Teaching School Alliance, we will aim to inform candidates of the area in which they will undertake their first training placement within two weeks of the candidate accepting a place. First placements are confirmed at the Delta TSA School Direct Induction which takes place towards the end of the Summer Term (late June / early July).\r\n\r\nAs Delta Academies Trust has academies based across Yorkshire and the Humber, we will always aim to try and place trainees in academies that are closest to where they live to cut down on commuting time.  For more information as to which academies are part of Delta Teaching School Alliance, please visit our website.\r\n\r\n\r\nTrainees will follow their Academy calendar and the timetable at the University, training in academies four days per week throughout the whole academic year.  Each Friday trainees attend the University to learn as part of a professional cohort of training teachers and spend the rest of the week learning to teach in their Academy. They will also complete a placement in a second academy during the Spring Term that provides an alternative experience, and have the opportunity nearer the end of the course to undertake experience in a range of educational settings such as Sixth form academies, Special Needs Academies etc.  A trained mentor/school based trainer will work with the trainee and support their professional development throughout the year.\r\n\r\nAlthough trainees will be based in an academy, an important element of this School Direct programme will be training days held each week at the University. Training days will be attended by all School Direct trainees on the programme and will provide opportunities for them to reflect on academy experience and to meet with other School Direct trainees in the region.  The course will lead to a Postgraduate Certificate in Education (PGCE) with the opportunity of gaining up to 60 credits at Masters level, as well as meeting the requirements of Teacher Standards (QTS).\r\n",
+        "interview_process": "After applicants have submitted their application via the UCAS system, we will receive the applications and shortlist applications that meet our entry requirements.  We will then invite candidates to a one-day assessment centre, hosted at one of our academies in the Delta Academies Trust group.\r\n\r\nThe assessment centre will test various skills and qualities through different assessment methods. The assessment centre will involve candidates observing lessons, teaching the panel 'something' (either an academic or non-academic subject) and answering a set of interviews questions. In addition to the tasks mentioned, Primary Phase candidates will have to complete Sheffield Hallam University English and Maths tests and Secondary Phase candidates an English test. The tests are a compulsory requirement for all candidates wanting to train with Sheffield Hallam University and Delta Teaching School Alliance.\r\n\r\nOnce candidates have completed the one day assessment centre, Delta Academies Trust will confirm via the UCAS system whether candidates have been successful or not.  Once candidates have confirmed their training place, Delta Teaching School Alliance and Sheffield Hallam University will write to candidates with an offer letter, outlining conditions of the offer.\r\n",
+        "other_requirements": "Trainee responsibilities include:\r\n- Participating fully in the programme of monitoring, support and assessment that is agreed with the ITT Coordinator, Mentor, Delta TSA and SHU.\r\n- Familiarisation with the Teachers’ Standards and monitoring and auditing their own progress in relation to them.\r\n- Ensuring that their conduct throughout the School Direct Programme is always of a professional manner, in line with SHU, Delta TSA and the Academy expectations.\r\n- Planning, preparing thoroughly and keeping good records.  Be conscientious in researching the subject knowledge you need to teach your lessons.\r\n- Being flexible and open to new learning.\r\n",
+        "personal_qualities": "Delta TSA, is looking for candidates who demonstrate a clear passion for teaching and a desire to ensure young people achieve their full potential.  We require our trainee teachers to be enthusiastic and dedicated to the teaching profession and their academy, so that they become outstanding teachers, working always to the highest standards.\r\n\r\nWe want candidates who demonstrate key qualities such as:\r\n- Empathy\r\n- Passion for teaching\r\n- Dedication\r\n- Patience\r\n- Emotional Intelligence\r\n- Excellent communication skills\r\n- Integrity\r\n\r\nOur ultimate goal is for all our trainee teachers to become 'Inspiring Teachers' so that we create 'Inspired Children'.\r\n",
+        "required_qualifications": "A UK Honours degree, preferably at classification 2.2 or above or a recognised equivalent qualification in a relevant subject area. In some circumstances we would accept applications from applicants with a third class honours degree who submit a strong personal statement which demonstrates clear qualities suitable for teaching and who has experience of working with children.\r\n\r\nGCSE English and Maths at Grade C/4 or above or equivalent.\r\n\r\nIf you wish to apply for the School Direct Training Programme (Salaried), typically you are required to have at least three years' work experience in addition to the eligibility requirements detailed above.\r\n",
+        "salary_details": "The School Direct Training Programme (salaried), which is an employment-based route into teaching for high quality graduates with three or more years' career experience. The trainee is employed as an unqualified teacher by a school. The DfE provides funding, which the school can use to subsidise the trainee's salary and/or training."
+      },
+      "relationships": {
+        "provider": {
+          "data": {
+            "type": "providers",
+            "id": "14315"
+          }
+        },
+        "accrediting_provider": {
+          "meta": {
+            "included": false
+          }
+        },
+        "site_statuses": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "subjects": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "meta": {
+        "edit_options": {
+          "entry_requirements": [
+            "must_have_qualification_at_application_time",
+            "expect_to_achieve_before_training_begins",
+            "equivalence_test"
+          ],
+          "qualifications": [
+            "qts",
+            "pgce_with_qts",
+            "pgde_with_qts"
+          ],
+          "age_range_in_years": [
+            "11_to_16",
+            "11_to_18",
+            "14_to_19"
+          ],
+          "start_dates": [
+            "October 2019",
+            "November 2019",
+            "December 2019",
+            "January 2020",
+            "February 2020",
+            "March 2020",
+            "April 2020",
+            "May 2020",
+            "June 2020",
+            "July 2020",
+            "August 2020",
+            "September 2020",
+            "October 2020",
+            "November 2020",
+            "December 2020",
+            "January 2021",
+            "February 2021",
+            "March 2021",
+            "April 2021",
+            "May 2021",
+            "June 2021",
+            "July 2021"
+          ],
+          "study_modes": [
+            "full_time",
+            "part_time",
+            "full_time_or_part_time"
+          ],
+          "show_is_send": false,
+          "show_start_date": false,
+          "show_applications_open": false,
+          "subjects": [
+            {
+              "id": "8",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Art and design",
+                "subject_code": "W1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "10",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Biology",
+                "subject_code": "C1",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "11",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Business studies",
+                "subject_code": "08",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "12",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Chemistry",
+                "subject_code": "F1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "13",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Citizenship",
+                "subject_code": "09",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "14",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Classics",
+                "subject_code": "Q8",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "15",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Communication and media studies",
+                "subject_code": "P3",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "16",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Computing",
+                "subject_code": "11",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "17",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Dance",
+                "subject_code": "12",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "18",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Design and technology",
+                "subject_code": "DT",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "19",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Drama",
+                "subject_code": "13",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "20",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Economics",
+                "subject_code": "L1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "21",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "English",
+                "subject_code": "Q3",
+                "bursary_amount": "12000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "22",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Geography",
+                "subject_code": "F8",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": "17000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "23",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Health and social care",
+                "subject_code": "L5",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "24",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "History",
+                "subject_code": "V1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "25",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Mathematics",
+                "subject_code": "G1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "33",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Modern Languages",
+                "subject_code": null,
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "26",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Music",
+                "subject_code": "W3",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "27",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Philosophy",
+                "subject_code": "P1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "28",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physical education",
+                "subject_code": "C6",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "29",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physics",
+                "subject_code": "F3",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "30",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Psychology",
+                "subject_code": "C8",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "31",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Religious education",
+                "subject_code": "V6",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "9",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Science",
+                "subject_code": "F0",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "32",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Social sciences",
+                "subject_code": "14",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            }
+          ],
+          "modern_languages": null
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "14361",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "1J1",
+        "provider_name": "South East Learning Alliance",
+        "accredited_body?": false,
+        "can_add_more_sites?": true,
+        "accredited_bodies": [
+          {
+            "provider_name": "Roehampton University",
+            "provider_code": "R48",
+            "description": "Roehampton has been at the forefront of education for over 100 years and has a long established reputation as one of the principal providers of teacher education in the UK.\r\nMembers of the academic staff are at the cutting edge of research in education. The strengths of the partnership; as identified in the 2013 Ofsted inspection include:\r\n* the partnership’s strong reputation that helps to maintain high employment rates\r\n* outstanding training in subject teaching enabling trainees to apply the best practice in subject-specific pedagogy\r\n* the quality of training contributes to trainees’ strong professional skills.\r\n"
+          },
+          {
+            "provider_name": "e-Qualitas",
+            "provider_code": "E69",
+            "description": "e-Qualitas offers a route into teacher training, through the South East Learning Alliance, where your study is completed through the distance-learning resources on the eQ virtual learning environment (VLE). Training sessions are provided by experienced school staff, and you are invited to attend training days led by eQ at a central London location. You will also benefit from a subject-specialist visiting Tutor from e-Qualitas, who will support you through your training. You will follow a course that leads to QTS. The course content is organised into six modules, the first three of which may be worked on concurrently."
+          },
+          {
+            "provider_name": "King's College London (University of London)",
+            "provider_code": "K60",
+            "description": "Located in the heart of London, PGCE courses at King’s are rated Outstanding by Ofsted with excellent tutors on hand to support you through your training. In the last research assessment exercise, the department was rated second in the UK (REF, 2014). You will have the opportunity to work with experienced tutors who are actively engaged in research in their subject and in pedagogy more widely. 96% of 2017 graduates who sought teaching posts were employed within 6 months of qualifying. In our 2018 student survey, 92% of trainees rated the quality of their training as very good or good. "
+          }
+        ],
+        "train_with_us": "Thank you for taking an interest in the South East Learning Alliance School Direct training programme. We have run this teacher development programme since September 2014 and it is proving to be an exciting experience for all involved. Our School Direct Alliance is coordinated through Riddlesdown Collegiate in Purley, Surrey, which is an Outstanding Multi Academy Trust. We are an innovative partnership, which is continually developing its approaches to training and pedagogy. We invest greatly in the professional development of all our staff and those who choose to train alongside us. \r\n\r\nThe South East Learning Alliance is a relatively small Alliance, but we pride ourselves on ensuring personal and bespoke training opportunities for all our trainees, which is reflected in the excellent success and retention rates we have achieved over the last four years. Our size has added to our ability to provide a full and comprehensive range of support and ensures a variety of opportunities to work across a wide plethora of demographics and institutions. Ensuring our trainees receive the right support; in the most appropriate setting possible, is at the forefront of our ethos. ",
+        "train_with_disability": "We will make every effort to support any disabilities or additional needs candidates may have. However, as we work with over 10 different partner-schools and Universities; we strongly advise you to check directly with the individual school/Higher Education Institute to discuss your needs in greater depth. ",
+        "latitude": 51.3258269,
+        "longitude": -0.0876413,
+        "address1": "South East Learning Alliance",
+        "address2": "Riddlesdown Collegiate",
+        "address3": "Purley, South Croydon",
+        "address4": "Surrey",
+        "postcode": "CR8 1EX",
+        "region_code": "london",
+        "telephone": "02086685136",
+        "email": "schoolsdirect@riddlesdown.org",
+        "website": "https://tct-academies.org/train-to-teach/",
+        "recruitment_cycle_year": "2020",
+        "admin_contact": null,
+        "utt_contact": null,
+        "web_link_contact": null,
+        "fraud_contact": null,
+        "finance_contact": null,
+        "gt12_contact": null,
+        "application_alert_contact": null,
+        "type_of_gt12": "coming_or_not",
+        "send_application_alerts": "all"
+      },
+      "relationships": {
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "courses": {
+          "meta": {
+            "count": 38
+          }
+        }
+      }
+    },
+    {
+      "id": "14315",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "1DU",
+        "provider_name": "Delta Teaching School Alliance",
+        "accredited_body?": false,
+        "can_add_more_sites?": true,
+        "accredited_bodies": [
+          {
+            "provider_name": "Sheffield Hallam University",
+            "provider_code": "S21",
+            "description": "Delta TSA works in close partnership with Sheffield Hallam University, sharing commitment to providing high quality training for all successful School Direct applicants.\r\n\r\nSheffield Institute of Education (SIoE) at Sheffield Hallam recently received an 'Outstanding' rating for primary teacher training. SIoE also received 'Good' grades for secondary and further education provision.\r\n\r\n“We pride ourselves on the applied nature of your learning and quality of our teaching. The recent Ofsted report praised the quality and level of knowledge of our trainees upon completion of their studies and the high regard they are held in by our partners in the region.” (SHU-2018)\r\n"
+          }
+        ],
+        "train_with_us": "Delta Teaching School Alliance is part of Delta Academies Trust, a multi academy sponsor of over 50 academies in the Yorkshire and Humber region.  Our academy group consists of Secondary, Primary, Infant, Junior, all through schools and Free Schools.\r\n\r\nDelta Teaching School Alliance has two designated Teaching Schools embracing outstanding teaching and leadership of Early Years, Primary, Secondary and Post-16.  Depending on the age range that you would like to train to teach, here are just some of the academies where you could complete your School Direct training through our two outstanding Alliances:\r\n\r\nWest Region (Leeds, Knottingley, Dewsbury, Bradford)\r\n- Garforth Academy\r\n- De Lacy Academy\r\n- The Vale Primary Academy\r\n- Green Lane Primary Academy\r\n\r\nSouth Region (Doncaster, North Notts)\r\n- Rowena Primary Academy\r\n- Crookesbroom Primary Academy\r\n- Serlby Park Academy\r\n- Rossington All Saints Academy\r\n\r\nEast Region (Scunthorpe, Grimsby, Hull, Brigg)\r\n- The Vale Academy\r\n- Hull Trinity House Academy\r\n- Craven Primary Academy\r\n- Macaulay Primary Academy\r\n\r\nWe believe due to the geographical location of all our academies, we can provide the best teacher training opportunities and provide excellent support through outreach work and sharing best practice. There are many career opportunities available to all our trainees who succeed on the School Direct Programme.  We support, motivate and inspire teachers throughout their career to become leaders of the future. We strongly believe the excellence in the quality of training teachers receive, leads to excellence in education for children.\r\n",
+        "train_with_disability": "Delta Academies Trust \u0026 Delta Teaching School Alliance, in accordance with its Equality and Diversity Policy, the Organisation will provide equal opportunities to all trainees and applicants and will not discriminate either directly or indirectly because of age, disability, gender reassignment, marriage and civil partnership, pregnancy and maternity, race (including colour, nationality and ethnic or national origins), religion or belief, sex and/or sexual orientation.\r\n\r\nSheffield Hallam University is committed to advancing equality of opportunity, experience and outcome, ensuring that students and staff realise their full potential. This is reflected through the University’s values of inclusion and supportiveness, with equality, diversity and inclusion acting as key enablers to the University Strategy.",
+        "latitude": 53.7047093,
+        "longitude": -1.2427965,
+        "address1": "Education House",
+        "address2": "Spawd Bone Lane",
+        "address3": "Knottingley",
+        "address4": "West Yorkshire",
+        "postcode": "WF11 0EP",
+        "region_code": null,
+        "telephone": "0345 196 0033",
+        "email": "schooldirect@deltatrust.org.uk",
+        "website": "http://teach.deltatrust.org.uk/",
+        "recruitment_cycle_year": "2020",
+        "admin_contact": null,
+        "utt_contact": null,
+        "web_link_contact": null,
+        "fraud_contact": null,
+        "finance_contact": null,
+        "gt12_contact": null,
+        "application_alert_contact": null,
+        "type_of_gt12": "coming_or_not",
+        "send_application_alerts": "none"
+      },
+      "relationships": {
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "courses": {
+          "meta": {
+            "count": 32
+          }
+        }
+      }
+    }
+  ],
+  "links": {
+    "next": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026include=provider\u0026page%5Bpage%5D=2\u0026page%5Bper_page%5D=2",
+    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026include=provider\u0026page%5Bpage%5D=890\u0026page%5Bper_page%5D=2"
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/fixtures/api_responses/empty_courses.json
+++ b/spec/fixtures/api_responses/empty_courses.json
@@ -1,1 +1,9 @@
-{"data":[],"links":{"last":"/api/v3/recruitment_cycles/2020/providers/B1T/courses?page%5Bpage%5D=1"},"jsonapi":{"version":"1.0"}}
+{
+  "data": [],
+  "links": {
+    "last": "/api/v3/recruitment_cycles/2020/providers/B1T/courses?page%5Bpage%5D=1"
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/fixtures/api_responses/empty_courses.json
+++ b/spec/fixtures/api_responses/empty_courses.json
@@ -1,0 +1,1 @@
+{"data":[],"links":{"last":"/api/v3/recruitment_cycles/2020/providers/B1T/courses?page%5Bpage%5D=1"},"jsonapi":{"version":"1.0"}}

--- a/spec/fixtures/api_responses/empty_providers.json
+++ b/spec/fixtures/api_responses/empty_providers.json
@@ -1,0 +1,6 @@
+{
+  "data": [],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/fixtures/api_responses/one_provider.json
+++ b/spec/fixtures/api_responses/one_provider.json
@@ -1,0 +1,15 @@
+{
+  "data": [
+    {
+      "id": "3",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A0",
+        "provider_name": "ACME SCITT 0"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/fixtures/api_responses/providers.json
+++ b/spec/fixtures/api_responses/providers.json
@@ -1,0 +1,95 @@
+{
+  "data": [
+    {
+      "id": "3",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A0",
+        "provider_name": "ACME SCITT 0"
+      }
+    },
+    {
+      "id": "4",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A1",
+        "provider_name": "ACME SCITT 1"
+      }
+    },
+    {
+      "id": "5",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A2",
+        "provider_name": "ACME SCITT 2"
+      }
+    },
+    {
+      "id": "6",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A3",
+        "provider_name": "ACME SCITT 3"
+      }
+    },
+    {
+      "id": "7",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A4",
+        "provider_name": "ACME SCITT 4"
+      }
+    },
+    {
+      "id": "8",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A5",
+        "provider_name": "ACME SCITT 5"
+      }
+    },
+    {
+      "id": "9",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A6",
+        "provider_name": "ACME SCITT 6"
+      }
+    },
+    {
+      "id": "10",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A7",
+        "provider_name": "ACME SCITT 7"
+      }
+    },
+    {
+      "id": "11",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A8",
+        "provider_name": "ACME SCITT 8"
+      }
+    },
+    {
+      "id": "12",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A9",
+        "provider_name": "ACME SCITT 9"
+      }
+    },
+    {
+      "id": "1",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A01",
+        "provider_name": "Acme SCITT"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -2,7 +2,29 @@ require "rails_helper"
 
 describe "/results", type: :request do
   before do
+    default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+
+    base_parameters = {
+      "filter[vacancies]" => "true",
+      "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
+      "include" => "provider",
+      "page[page]" => 1,
+      "page[per_page]" => 10,
+    }
     allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(true)
+
+    stub_api_v3_resource(
+      type: SubjectArea,
+      resources: nil,
+      include: [:subjects],
+    )
+
+    stub_request(:get, default_url)
+        .with(query: base_parameters)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+        )
   end
 
   it "redirects to c sharp version" do

--- a/spec/site_prism/page_objects/page/result_filters/funding.rb
+++ b/spec/site_prism/page_objects/page/result_filters/funding.rb
@@ -4,6 +4,7 @@ module PageObjects
       class Funding < SitePrism::Page
         set_url "/results/filter/funding{?query*}"
 
+        element :heading, '[data-qa="heading"]'
         element :back_link, '[data-qa="page-back"]'
         element :all_courses, '[data-qa="all_courses"]'
         element :salary_courses, '[data-qa="salary_courses"]'

--- a/spec/site_prism/page_objects/page/result_filters/qualification.rb
+++ b/spec/site_prism/page_objects/page/result_filters/qualification.rb
@@ -4,6 +4,7 @@ module PageObjects
       class Qualification < SitePrism::Page
         set_url "/results/filter/qualification{?query*}"
 
+        element :heading, '[data-qa="heading"]'
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
         element :qts_only, '[data-qa="qts_only"]'

--- a/spec/site_prism/page_objects/page/result_filters/study_type.rb
+++ b/spec/site_prism/page_objects/page/result_filters/study_type.rb
@@ -6,6 +6,7 @@ module PageObjects
 
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
+        element :heading, '[data-qa="heading"]'
         element :full_time, '[data-qa="full_time"]'
         element :part_time, '[data-qa="part_time"]'
         element :find_courses, '[data-qa="find-courses"]'

--- a/spec/site_prism/page_objects/page/result_filters/vacancy.rb
+++ b/spec/site_prism/page_objects/page/result_filters/vacancy.rb
@@ -4,6 +4,7 @@ module PageObjects
       class Vacancy < SitePrism::Page
         set_url "/results/filter/vacancy{?query*}"
 
+        element :heading, '[data-qa="heading"]'
         element :back_link, '[data-qa="page-back"]'
         element :error, '[data-qa="error"]'
         element :with_vacancies, '[data-qa="with_vacancies"]'

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -36,6 +36,10 @@ module PageObjects
 
     class QualificationsSection < SitePrism::Section
       elements :qualifications, '[data-qa="qualifications"]'
+      element :link, '[data-qa="link"]'
+      element :qts_only, '[data-qa="qts_only"]'
+      element :pgde_pgce_with_qts, '[data-qa="pgde_pgce_with_qts"]'
+      element :other_qualifications, '[data-qa="other_qualifications"]'
     end
 
     class FundingSection < SitePrism::Section

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -44,6 +44,8 @@ module PageObjects
 
     class FundingSection < SitePrism::Section
       element :funding, '[data-qa="funding"]'
+      element :with_or_without_salary, '[data-qa="with-or-without-salary"]'
+      element :with_salary, '[data-qa="with-salary"]'
       element :link, '[data-qa="link"]'
     end
 

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -40,6 +40,7 @@ module PageObjects
 
     class FundingSection < SitePrism::Section
       element :funding, '[data-qa="funding"]'
+      element :link, '[data-qa="link"]'
     end
 
     class LocationSection < SitePrism::Section
@@ -68,6 +69,7 @@ module PageObjects
       section :provider_filter, ProviderSection, '[data-qa="filters__provider"]'
 
       element :provider_title, '[data-qa="provider_title"]'
+      element :heading, '[data-qa="heading"]'
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
 

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -78,7 +78,7 @@ module PageObjects
       element :heading, '[data-qa="heading"]'
       element :next_button, '[data-qa="next_button"]'
       element :previous_button, '[data-qa="previous_button"]'
-
+      element :course_count, '[data-qa="course-count"]'
       element :location_link, '[data-qa="filters__location_link"]'
       element :subject_link, '[data-qa="filters__subject"]'
       element :qualification_link, '[data-qa="filters__qualification_link"]'

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -292,6 +292,14 @@ RSpec.describe ResultsView do
     end
   end
 
+  describe "#courses" do
+    let(:results_view) { described_class.new(query_parameters: {}) }
+
+    it "returns an JSON query builder" do
+      expect(results_view.courses).to be_a(JsonApiClient::Query::Builder)
+    end
+  end
+
   describe "#map_image_url" do
     subject { described_class.new(query_parameters: parameter_hash).map_image_url }
 


### PR DESCRIPTION
### Context

Adds filtering for salary, qualification, vacancies and study type.

### Changes proposed in this pull request
When filtering, calls can now be made to V3 API 😸 

### Guidance to review
- This is a big PR
- There is very little logic added to make the filtering work. However there are lots of changes in the specs. As discussed at the last tech brakedance we propose that specs should use a simpler method for stubbing JSON responses from the V3 API - i.e. stub at the network level rather than the JSON API resource layer.
- We have moved a lot of the specs out of the `results_spec` and put them into the filter specs. This is because feature specs should be testing the entire feature end to end, not just a page.