### PR TITLE
2968 - Change how we load in Google Analytics

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,33 +17,6 @@
     <%= stylesheet_pack_tag 'application' %>
     <%= content_for(:head) %>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-112932657-1', 'auto');
-      ga('set', 'transport', 'beacon');
-      ga('set', 'anonymizeIp', true);
-
-      if (location.search) {
-        var search = location.search;
-        var params = ['lat', 'lng', 'loc', 'lq'];
-        for( i = 0; i < params.length; i++ ){
-          search = search.replace( new RegExp( '([?&])'+params[i]+'(=[^&]*)?&?', 'gi' ), '$1' );
-        }
-        ga('set', 'location', window.location.protocol + "//" + window.location.host + window.location.pathname + search)
-      }
-
-      ga('send', 'pageview');
-    </script>
-    <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-NLFBX9D');
-    </script>
   </head>
 
   <body class="govuk-template__body ">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -6,10 +6,7 @@ import initLocationsMap from "scripts/locations-map";
 import backLink from "scripts/back-link";
 import initAutocomplete from "scripts/autocomplete";
 import toggle from "scripts/toggle";
-import { initFormAnalytics, initExternalLinkAnalytics, initNavigationAnalytics } from "scripts/analytics.js";
-import scrollTracking from "scripts/scroll-tracking";
-import copyTracking from "scripts/copy-tracking";
-import noResultsTracking from "scripts/no-results-tracking";
+import { loadAnalytics } from "scripts/analytics.js";
 
 initAll();
 
@@ -36,17 +33,6 @@ initAutocomplete(
   }
 );
 
-if (typeof ga !== "undefined") {
-  initFormAnalytics();
-  initExternalLinkAnalytics();
-  initNavigationAnalytics();
+initAutocomplete("provider-autocomplete", "provider");
 
-  const $page = document.querySelector('[data-module*="ga-track"]');
-  new scrollTracking($page).init();
-  new copyTracking($page).init();
-
-  const $searchInput = document.querySelector('[data-module="track-no-provider-results"]');
-  new noResultsTracking($searchInput).init();
-} else {
-  console.log("Google Analytics `window.ga` object not found. Skipping analytics.");
-}
+loadAnalytics()

--- a/app/webpacker/scripts/__snapshots__/analytics.spec.js.snap
+++ b/app/webpacker/scripts/__snapshots__/analytics.spec.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Analytics initExternalLinkAnalytics triggers correct GA events when users click on external links 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "http://example.com",
+      "eventCategory": "External Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "https://google.com",
+      "eventCategory": "External Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+]
+`;
+
+exports[`Analytics initFormAnalytics triggers correct GA event when users submit with checked checkboxes 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "A ticked item, Another ticked item",
+      "eventCategory": "Form: Some form",
+      "transport": "beacon",
+    },
+  ],
+]
+`;
+
+exports[`Analytics initNavigationAnalytics triggers correct GA events when users click on navigation links 1`] = `
+Array [
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "#about",
+      "eventCategory": "Some navigation Navigation Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+  Array [
+    "send",
+    "event",
+    Object {
+      "eventAction": "http://example.com",
+      "eventCategory": "Some navigation Navigation Link Clicked",
+      "transport": "beacon",
+    },
+  ],
+]
+`;

--- a/app/webpacker/scripts/analytics.js
+++ b/app/webpacker/scripts/analytics.js
@@ -1,3 +1,7 @@
+import scrollTracking from "./scroll-tracking";
+import copyTracking from "./copy-tracking";
+import noResultsTracking from "./no-results-tracking";
+
 const triggerAnalyticsEvent = (category, action) => {
   ga("send", "event", {
     eventCategory: category,
@@ -5,6 +9,45 @@ const triggerAnalyticsEvent = (category, action) => {
     transport: "beacon"
   });
 };
+
+/** @description Dynamically downloads our analytical platform (GA)
+ * @param {string} trackingCode Google Analytical unique tracking code
+ * @return {number}
+ */
+export const loadAnalytics = (trackingCode) => {
+  /* jshint ignore:start */
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', trackingCode || 'UA-112932657-1', 'auto');
+  ga('set', 'transport', 'beacon');
+  ga('set', 'anonymizeIp', true);
+
+  if (location.search) {
+    var search = location.search;
+    var params = ['lat', 'lng', 'loc', 'lq'];
+    for( let param = 0; param < params.length; param++ ){
+      search = search.replace( new RegExp( '([?&])'+params[param]+'(=[^&]*)?&?', 'gi' ), '$1' );
+    }
+    ga('set', 'location', window.location.protocol + "//" + window.location.host + window.location.pathname + search)
+  }
+
+  ga('send', 'pageview');
+
+  initFormAnalytics();
+  initExternalLinkAnalytics();
+  initNavigationAnalytics();
+
+  const $page = document.querySelector('[data-module*="ga-track"]');
+  new scrollTracking($page).init();
+  new copyTracking($page).init();
+
+  const $searchInput = document.querySelector('[data-module="track-no-provider-results"]');
+  new noResultsTracking($searchInput).init();
+  /* jshint ignore:end */
+}
 
 export const initFormAnalytics = () => {
   // How to use:

--- a/app/webpacker/scripts/analytics.spec.js
+++ b/app/webpacker/scripts/analytics.spec.js
@@ -17,19 +17,19 @@ describe("Analytics", () => {
       document.head.appendChild(document.createElement('script'));
     })
   
-    it('adds dynamically adds a script tag', () => {
+    it('dynamically adds a script tag', () => {
       loadAnalytics()
       // GTM will have a src and it will be the only script tag
       expect(document.querySelectorAll('script[src]')).toHaveLength(1)
     })
 
-    it ('takes uses a default tracking ID', () => {
+    it ('uses a default tracking ID', () => {
       loadAnalytics()
       const createGAInstanceWithID = ga.mock.calls[0][1]
       expect(createGAInstanceWithID).toEqual('UA-112932657-1')
     })
 
-    it ('takes accepts a custom tracking ID', () => {
+    it ('accepts a custom tracking ID', () => {
       loadAnalytics('NoT-a-Real-ID-123')
 
       const createGAInstanceWithID = ga.mock.calls[0][1]

--- a/app/webpacker/scripts/analytics.spec.js
+++ b/app/webpacker/scripts/analytics.spec.js
@@ -1,10 +1,52 @@
-import { initFormAnalytics, initExternalLinkAnalytics, initNavigationAnalytics } from "./analytics"
+import { initFormAnalytics, 
+  initExternalLinkAnalytics, 
+  initNavigationAnalytics, 
+  loadAnalytics } from "./analytics"
 
 global.ga = jest.fn()
 
 describe("Analytics", () => {
   afterEach(() => {
     global.ga.mockClear()
+  })
+
+  describe("loadAnalytics", () => {
+    beforeEach(() => {
+      // GTM needs a script tag on the page so we create an emptry script
+      // tag. It doesn't have an attributes so we can ignore it in the tests
+      document.head.appendChild(document.createElement('script'));
+    })
+  
+    it('adds dynamically adds a script tag', () => {
+      loadAnalytics()
+      // GTM will have a src and it will be the only script tag
+      expect(document.querySelectorAll('script[src]')).toHaveLength(1)
+    })
+
+    it ('takes uses a default tracking ID', () => {
+      loadAnalytics()
+      const createGAInstanceWithID = ga.mock.calls[0][1]
+      expect(createGAInstanceWithID).toEqual('UA-112932657-1')
+    })
+
+    it ('takes accepts a custom tracking ID', () => {
+      loadAnalytics('NoT-a-Real-ID-123')
+
+      const createGAInstanceWithID = ga.mock.calls[0][1]
+      expect(createGAInstanceWithID).toEqual('NoT-a-Real-ID-123')
+    })
+
+    it ('records a page view', () => {
+      loadAnalytics()
+      const sendPageView = ga.mock.calls.filter(currentvalue => {if (currentvalue[0] === 'send') return currentvalue })[0]
+      expect(sendPageView[1]).toEqual('pageview')
+    })
+
+    it ('anonymises the users IP Address', () => {
+      loadAnalytics()
+      const sendPageView = ga.mock.calls.filter(currentvalue => {if (currentvalue[1] === 'anonymizeIp') return currentvalue })[0]
+      expect(sendPageView[2]).toEqual(true)
+    })
   })
 
   describe("initFormAnalytics", () => {


### PR DESCRIPTION
We used to automatically add in Google Analytics (GA), we now 
have to ask users for consent before adding cookies to their devices.
At the same time we should only inject GA if the user consents
otherwise they are downloading more javascript that will not be
used or needed.

This commit removes GTM (we decided to not replace GA with GTM).
GA should still load as before but we will add the cookie policy
control to this to ensure it only gets used if the user consents
to cookies

### Context

### Changes proposed in this pull request

### Guidance to review

