### PR TITLE
2968 Hide cookie banner on cookie page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
     </script>
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
-    <%= render partial: 'layouts/cookie-banner' %>
+    <%= render partial: 'layouts/cookie-banner' unless current_page?(cookies_path)%>
     <header class="govuk-header" role="banner" data-module="govuk-header">
       <div class="govuk-header__container govuk-width-container">
         <div class="govuk-header__logo">

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -49,4 +49,9 @@ feature "cookie banner", type: :feature do
     expect(results_page.cookie_banner).to have_accept_all_cookies
     expect(results_page.cookie_banner).to have_set_preference_link
   end
+
+  it "does not display on the cookies page" do
+    visit cookies_path
+    expect(page).not_to have_selector('[data-qa="cookie-banner"]')
+  end
 end


### PR DESCRIPTION
### Context
Users should not be prompted with the cookie banner on the cookie page. They can set their preferences using the new form which will be added to it.

### Changes proposed in this pull request

### Guidance to review
Currently the banner is not visible but if you go to the the cookies page you should not see any markup in the html relating to the cookie banner.
