### PR TITLE
[2994] Ensure results filter funding input and radios match

### DIFF
--- a/app/views/result_filters/funding/new.html.erb
+++ b/app/views/result_filters/funding/new.html.erb
@@ -24,7 +24,7 @@
                                   checked: params[:funding] == '15' || params[:funding].blank?,
                                   data: { qa: 'all_courses'} %>
 
-            <%= form.label :all_courses, "All courses (with or without a salary)", class: 'govuk-label govuk-radios__label' %>
+            <%= form.label :funding_15, "All courses (with or without a salary)", class: 'govuk-label govuk-radios__label' %>
           </div>
           <div class="govuk-radios__item">
             <%= form.radio_button :funding,
@@ -33,7 +33,7 @@
                                   checked: params[:funding] == '8',
                                   data: { qa: 'salary_courses'} %>
 
-            <%= form.label :salary_courses, "Only courses that come with a salary", class: 'govuk-label govuk-radios__label' %>
+            <%= form.label :funding_8, "Only courses that come with a salary", class: 'govuk-label govuk-radios__label' %>
           </div>
         </div>
         <br>


### PR DESCRIPTION
### Context
User should be able to click the label to select the inputs on the results funding view.

### Changes proposed in this pull request
Match radio and inputs on Results Funding view.

### Guidance to review
`/results/filter/funding?l=2&subjects=32&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=True&parttime=False&hasvacancies=True&senCourses=False`
