### PR TITLE
[3004] - Return status 400 (bad request) for invalid provider suggestion query

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -1,7 +1,15 @@
 class ProviderSuggestionsController < ApplicationController
   def index
+    return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
+
     suggestions = ProviderSuggestion.suggest(params[:query])
       .map { |provider| { code: provider.provider_code, name: provider.provider_name } }
     render json: suggestions
+  end
+
+private
+
+  def params_invalid?
+    params[:query].nil? || params[:query].length < 3
   end
 end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,3 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /provider-suggestions

--- a/spec/fixtures/api_responses/provider-suggestions.json
+++ b/spec/fixtures/api_responses/provider-suggestions.json
@@ -1,0 +1,25 @@
+{
+  "data": [
+    {
+      "id": "3",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A0",
+        "provider_name": "ACME SCITT 0",
+        "recruitment_cycle_year": "2020"
+      }
+    },
+    {
+      "id": "1",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "A01",
+        "provider_name": "Acme SCITT",
+        "recruitment_cycle_year": "2020"
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "/provider-suggestions", type: :request do
+  context "when provider suggestion is blank" do
+    it "returns bad request (400)" do
+      get "/provider-suggestions"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq("error" => "Bad request")
+    end
+  end
+  context "when provider suggestion is less than three characters" do
+    it "returns bad request (400)" do
+      get "/provider-suggestions?query=St"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq("error" => "Bad request")
+    end
+  end
+  context "when provider suggestion ids valid" do
+    let(:provider_suggestions) {
+      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=Str")
+        .to_return(
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
+        )
+    }
+
+    before do
+      provider_suggestions
+    end
+
+    it "returns success (200)" do
+      get "/provider-suggestions?query=Str"
+
+      expect(provider_suggestions).to have_been_requested
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)).to eq(
+        [
+           {
+             "code" => "A0",
+             "name" => "ACME SCITT 0",
+           },
+           {
+             "code" => "A01",
+             "name" => "Acme SCITT",
+           },
+         ],
+       )
+    end
+  end
+end


### PR DESCRIPTION
### Context
The provider autocomplete feature uses a local endpoint ('/provider-suggestions') to query for providers. The autocomplete library is configured to only fire once three characters have been entered in the input field. However because the endpoint is publicly accessible it would be possible to query the endpoint with an invalid query (e.g. less than two characters). 

<img width="1482" alt="client_error" src="https://user-images.githubusercontent.com/5256922/74948485-4bf9a900-53f4-11ea-80e3-8a5115a1fa69.png">


### Changes proposed in this pull request
The provider suggestion query is now validated before passing through to the Teacher Training API. If invalid a 400 response is returned.

<img width="1393" alt="400 error" src="https://user-images.githubusercontent.com/5256922/74948619-764b6680-53f4-11ea-92f4-1681da26c6b8.png">
