### PR TITLE
[3015] Add XML Sitemap

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,0 +1,8 @@
+class SitemapsController < ApplicationController
+  def show
+    @courses = Course
+      .includes(:provider)
+      .where(recruitment_cycle_year: Settings.current_cycle)
+      .all
+  end
+end

--- a/app/views/sitemaps/show.xml.builder
+++ b/app/views/sitemaps/show.xml.builder
@@ -1,0 +1,17 @@
+xml.instruct!
+xml.urlset "xmlns" => "http://www.google.com/schemas/sitemap/0.9", "xmlns:xhtml" => "http://www.w3.org/1999/xhtml" do
+  xml.url do
+    xml.loc root_url
+  end
+
+  xml.url do
+    xml.loc results_url
+  end
+
+  @courses.each do |course|
+    xml.url do
+      xml.loc course_url(course.provider_code, course.course_code)
+      xml.lastmod course.last_published_at.to_date.strftime("%Y-%m-%d")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
   get "/422", to: "errors#unprocessable_entity", via: :all
   get "/500", to: "errors#internal_server_error", via: :all
 
+  resource :sitemap, only: :show
+
   get "/course/:provider_code/:course_code", to: "courses#show", as: "course"
   get "/results", to: "results#index", as: "results"
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
 Disallow: /provider-suggestions
+Sitemap: https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.xml

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe "/sitemap.xml", type: :request do
+  let(:provider) { build(:provider, provider_code: "T92") }
+  let(:current_recruitment_cycle) { build :recruitment_cycle }
+  let(:course) do
+    build(:course,
+          course_code: "X102",
+          provider: provider,
+          provider_code: provider.provider_code,
+          recruitment_cycle: current_recruitment_cycle)
+  end
+
+  before do
+    stub_api_v3_resource(
+      type: RecruitmentCycle,
+      params: {
+        recruitment_cycle_year: Settings.current_cycle,
+      },
+      resources: current_recruitment_cycle,
+    )
+
+    stub_api_v3_resource(
+      type: Course,
+      params: {
+        recruitment_cycle_year: Settings.current_cycle,
+      },
+      resources: course,
+      include: %w[provider],
+    )
+
+    get "/sitemap.xml"
+  end
+
+  it "renders sitemap" do
+    expect(response).to have_http_status(200)
+    expect(response.body).to eq(
+      <<~XML,
+        <?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.google.com/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+          <url>
+            <loc>http://www.example.com/</loc>
+          </url>
+          <url>
+            <loc>http://www.example.com/results</loc>
+          </url>
+          <url>
+            <loc>http://www.example.com/course/T92/X102</loc>
+            <lastmod>2019-01-01</lastmod>
+          </url>
+        </urlset>
+      XML
+     )
+  end
+end


### PR DESCRIPTION
### Context
Sitemap

### Changes proposed in this pull request
Add an XML sitemap to replace https://www.find-postgraduate-teacher-training.service.gov.uk/sitemap.txt, not sure why we opted for a TXT version in the c# version when XML is the default.

Note: We need the API to return *all* records and not just the first 10

### Guidance to review
`/sitemap.xml`

<img width="1552" alt="Screenshot 2020-02-22 at 18 09 04" src="https://user-images.githubusercontent.com/3071606/75097089-6f605780-559e-11ea-8ad3-aee21aa88e7b.png">

