### PR TITLE
[2933] Dont count philsophy/modern languages subjects in total

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -1,6 +1,7 @@
 class ResultsView
   include CsharpRailsSubjectConversionHelper
 
+  MAXIMUM_NUMBER_OF_SUBJECTS = 43
   NUMBER_OF_SUBJECTS_DISPLAYED = 4
 
   def initialize(query_parameters:)
@@ -58,6 +59,8 @@ class ResultsView
   end
 
   def number_of_extra_subjects
+    return 37 if number_of_subjects_selected == MAXIMUM_NUMBER_OF_SUBJECTS
+
     number_of_subjects_selected - NUMBER_OF_SUBJECTS_DISPLAYED
   end
 

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -93,7 +93,7 @@ feature "results", type: :feature do
             "Chemistry",
           ],
       )
-      expect(results_page.subjects_filter.extra_subjects.text).to eq("and 39 more...")
+      expect(results_page.subjects_filter.extra_subjects.text).to eq("and 37 more...")
     end
   end
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -216,6 +216,14 @@ describe ResultsView do
   describe "#number_of_extra_subjects" do
     let(:results_view) { described_class.new(query_parameters: parameter_hash) }
 
+    context "The maximum number of subjects are selected" do
+      let(:parameter_hash) { { "subjects" => (1..43).to_a.join(",") } }
+
+      it "Returns the number of extra subjects - 2" do
+        expect(results_view.number_of_extra_subjects).to eq(37)
+      end
+    end
+
     context "more than NUMBER_OF_SUBJECTS_DISPLAYED subjects are selected" do
       let(:parameter_hash) { { "subjects" => "1,2,3,4,5" } }
 


### PR DESCRIPTION
### Context

Modern languages/Philsophy do not have any courses associated with them. To prevent them being counted 
in the "and X more" subjects filter summary, we have subtracted two for now.

### Changes proposed in this pull request

- Subtract two from the subject count when all subjects are selected

