### PR TITLE
[2933] Remove results page redirect

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,26 +1,5 @@
 class ResultsController < ApplicationController
-  before_action :redirect_to_c_sharp
-
   def index
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
-  end
-
-private
-
-  def redirect_to_c_sharp
-    return unless Settings.redirect_results_to_c_sharp
-
-    query_string = request.query_string
-    base_url = Settings.search_and_compare_ui.base_url
-
-    redirect_uri = URI(base_url)
-    redirect_uri.path = "/results"
-    redirect_uri.query = query_string.gsub("%2C", ",") if query_string.present?
-
-    redirect_to redirect_uri.to_s
-  end
-
-  def subjects_params_array
-    params["subjects"].split(",")
   end
 end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -4,8 +4,6 @@ describe "/results", type: :request do
   before do
     default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
 
-    allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(true)
-
     stub_api_v3_resource(
       type: SubjectArea,
       resources: nil,
@@ -20,18 +18,8 @@ describe "/results", type: :request do
         )
   end
 
-  it "redirects to c sharp version" do
+  it "returns success (200)" do
     get "/results"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results")
-  end
-
-  it "forwards querystring params" do
-    get "/results?test=one&test_two=%26booyah"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=%26booyah")
-  end
-
-  it "decodes querystring commas" do
-    get "/results?test=one&test_two=booyah%2Ckasha"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=booyah,kasha")
+    expect(response).to have_http_status(200)
   end
 end


### PR DESCRIPTION
### Context
Being able to manually view and test the results page

### Changes proposed in this pull request
- Remove redirect to c# results page

### Guidance to review
`/results`
