### PR TITLE
[3019] - Display correct course count on results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -116,7 +116,7 @@ class ResultsView
   end
 
   def course_count
-    courses.count
+    courses.total_count
   end
 
   def subjects

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -42,19 +42,9 @@ feature "results", type: :feature do
   end
 
   describe "course count" do
-    context "when API returns two courses" do
+    context "when API returns courses" do
       it "displays the correct course count" do
-        expect(results_page.course_count).to have_content("2 courses found")
-      end
-    end
-
-    context "when API return no courses" do
-      let(:courses) do
-        File.new("spec/fixtures/api_responses/empty_courses.json")
-      end
-
-      it "displays the correct course count" do
-        expect(results_page.course_count).to have_content("0 courses found")
+        expect(results_page.course_count).to have_content("8,900 courses found")
       end
     end
   end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -354,6 +354,23 @@ describe ResultsView do
     end
   end
 
+  describe "#course_count" do
+    subject { described_class.new(query_parameters: {}).course_count }
+
+    context "there are 8900 results" do
+      before do
+        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+          .with(query: results_page_parameters)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
+      end
+
+      it { is_expected.to be(8900) }
+    end
+  end
+
   describe "#subjects" do
     context "when no parameters are passed" do
       let(:results_view) { described_class.new(query_parameters: {}) }


### PR DESCRIPTION
### Context

Use Json Api gem's 'total_count' method rather than 'count'. The latter provides the count of the paginated response (i.e. X per page) rather than the total results count

<img width="1247" alt="count" src="https://user-images.githubusercontent.com/5256922/75162190-0818e380-5715-11ea-8281-4ba3744f3981.png">


### Changes proposed in this pull request
- use of correct method
- added spec

