### PR TITLE
[3041] - Remove England geocoding restriction

### DIFF
--- a/app/form_objects/result_filters/location_filter_form.rb
+++ b/app/form_objects/result_filters/location_filter_form.rb
@@ -41,13 +41,12 @@ module ResultFilters
     end
 
     def geocode_params_for(query)
-      results = Geocoder.search(query, components: "country:UK")
-      england_results = results.select { |r| r.state == "England" }.first
-      if england_results
+      results = Geocoder.search(query, components: "country:UK").first
+      if results
         {
-            lat: england_results.latitude,
-            lng: england_results.longitude,
-            loc: england_results.address,
+            lat: results.latitude,
+            lng: results.longitude,
+            loc: results.address,
             lq: location_query,
         }
       end


### PR DESCRIPTION
### Context
- We do not want to filter geocoding results as there may be users who wish to search for courses near England (e.g Scotland, Wales) within the accepted ranges

### Changes proposed in this pull request
- Removes England geocoding restriction
- Brings functionality in line with C# legacy application

### Guidance to review

