### PR TITLE
[3035] Fix whitespace on pick provider

### DIFF
--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -25,11 +25,14 @@
       <div class="govuk-details__text">
         <%= form_with url: provider_path, method: :get do |form| %>
           <fieldset class="govuk-fieldset">
-            <%= form.label :query, class: "govuk-label" do %>
-              <strong>School, university or other training provider</strong>
-              <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
-            <% end %>
-            <%= form.text_field :query, class: "govuk-input", data: { qa: "search__input" } %>
+            <div class="govuk-form-group">
+              <%= form.label :query, class: "govuk-label" do %>
+                <strong>School, university or other training provider</strong>
+                <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
+              <% end %>
+              <%= form.text_field :query, class: "govuk-input", data: { qa: "search__input" } %>
+            </div>
+
             <%= form.submit "Search again", name: nil, class: "govuk-button", data: { qa: 'search__submit' } %>
           </fieldset>
         <% end %>


### PR DESCRIPTION
### Context

- https://trello.com/c/ZIFxr5BH/3035-provider-search-formatting
- Accessing the non-js page of pick provider
- There were whitespace issues on a text field and submit button below

### Changes proposed in this pull request

- This fixes the whitespace between submit button and form field
- Text field was missing wrapping div `govuk-form-group`
- This page is accessible when javascript is disabled

### Guidance to review

- disable javascript
- navigate to `/results/filter/provider?l=3&query=king`
- open the `Try another provider` details box
- there should be correct spacing between input field and submit button

![image](https://user-images.githubusercontent.com/92580/75234658-deae9500-57b2-11ea-8875-b19551356f42.png)