### PR TITLE
[3043] Fix missing filter button copy for mobile users

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -17,6 +17,7 @@
     <div class="govuk-grid-column-one-third">
       <div class="govuk-toggle" data-module="toggle">
         <button class="govuk-toggle__link js-toggle" aria-expanded="false" aria-controls="searchFilters">
+          Filter the results
         </button>
         <div class="govuk-toggle__target" id="searchFilters" data-qa="filters">
           <% if @results_view.provider_filter? %>


### PR DESCRIPTION
### Context
Mobile users would not be able to see or change filters. This bug is in production.

### Changes proposed in this pull request
the Filter button that was displayed for mobile users looked broken without any copy. c# version did have some copy
![image](https://user-images.githubusercontent.com/3441519/75247330-951d7480-57c9-11ea-9e19-78e19290a73f.png)


I added the copy which fixed the layout:

![image](https://user-images.githubusercontent.com/3441519/75247430-d0b83e80-57c9-11ea-9ae2-16c269cda7ad.png)


### Guidance to review

