### PR TITLE
[3037] - Provider search validation: copy update

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,7 @@ en:
       no_option: "Please choose an option"
       unknown_location: "We couldn't find this location, please check your input and try again"
       missing_location: "Please enter a postcode, city or town in England"
-      missing_provider: "Please enter the name of a training provider"
+      missing_provider: "We couldn't find this provider, please check your input and try again"
     fields:
       location: "Postcode, town or city"
       provider: "Training provider"

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -126,7 +126,7 @@ feature "Provider filter", type: :feature do
         expect(current_path).to eq(location_filter_page.url)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq("query" => "ACME")
         expect(location_filter_page.error_text.text).to eq("Training provider")
-        expect(location_filter_page.provider_error.text).to eq("Error: Please enter the name of a training provider")
+        expect(location_filter_page.provider_error.text).to eq("Error: We couldn't find this provider, please check your input and try again")
       end
     end
   end


### PR DESCRIPTION
### Context

Copy update to error message when searching by school, location or other training provider

### Changes proposed in this pull request

<img width="824" alt="error" src="https://user-images.githubusercontent.com/5256922/75253555-aa4cd000-57d6-11ea-943b-ce702191000e.png">
