### PR TITLE
[3044] Add location filtering

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -68,12 +68,12 @@ class ResultsView
     query_parameters["loc"] || "Across England"
   end
 
-  def distance
+  def radius
     query_parameters["rad"]
   end
 
   def show_map?
-    latitude.present? && longitude.present? && distance.present?
+    latitude.present? && longitude.present? && radius.present?
   end
 
   def map_image_url
@@ -88,6 +88,14 @@ class ResultsView
 
   def provider
     query_parameters["query"]
+  end
+
+  def location_filter?
+    query_parameters["l"] == "1"
+  end
+
+  def england_filter?
+    query_parameters["l"] == "2"
   end
 
   def provider_filter?
@@ -106,6 +114,13 @@ class ResultsView
                    base_query = base_query.where(qualifications: qualifications)
                    base_query = base_query.where(subjects: subject_codes.join(",")) if subject_codes.any?
                    base_query = base_query.where(send_courses: true) if send_courses?
+
+                   if location_filter?
+                     base_query = base_query.where("latitude" => latitude)
+                     base_query = base_query.where("longitude" => longitude)
+                     base_query = base_query.where("radius" => radius)
+                   end
+
                    base_query = base_query.where("provider.provider_name" => provider) if provider.present?
 
                    base_query
@@ -127,10 +142,6 @@ class ResultsView
 private
 
   attr_reader :query_parameters
-
-  def provider_option_selected?
-    filter_params[:l] == "3"
-  end
 
   def results_order
     return :desc if query_parameters[:sortby] == "1"
@@ -183,7 +194,7 @@ private
   end
 
   def google_map_zoom
-    case distance
+    case radius
     when "5"
       "12"
     when "10"

--- a/app/views/results/_location.html.erb
+++ b/app/views/results/_location.html.erb
@@ -7,10 +7,10 @@
       <%= @results_view.location %>
       <% if @results_view.show_map? %>
         <span class="govuk-caption-m" data-qa="distance">Within
-          <%= @results_view.distance %>
+          <%= @results_view.radius %>
          miles of the pin</span>
         <img src="<%= @results_view.map_image_url %>"
-             alt="Map showing <%= @results_view.distance %> miles
+             alt="Map showing <%= @results_view.radius %> miles
              of <%= @results_view.location %>"class="filter-form__map"
              data-qa="map" />
       <% end %>

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -69,6 +69,35 @@ feature "Location filter", type: :feature do
     end
   end
 
+  describe "filtering by location" do
+    before do
+      stub_request(:get, courses_url)
+        .with(
+          query: base_parameters.merge("filter[longitude]" => "-0.1300436",
+                                       "filter[latitude]" => "51.4980188",
+                                       "filter[radius]" => "20"),
+        )
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/courses.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+    end
+
+    it "displays the courses" do
+      results_page.load
+      results_page.location_filter.link.click
+      filter_page.by_postcode_town_or_city.click
+      filter_page.location_query.fill_in(with: "SW1P 3BT")
+      filter_page.find_courses.click
+
+      expect(results_page.heading.text).to eq("Teacher training courses")
+
+      expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
+      expect(results_page.location_filter.map).to be_present
+      expect(results_page.courses.count).to eq(2)
+    end
+  end
+
   describe "default text" do
     it "displays the query text specified in the params if it exists" do
       filter_page.load(query: { query: "marble" })
@@ -129,28 +158,6 @@ feature "Location filter", type: :feature do
 
   describe "Selecting an option" do
     before { filter_page.load(query: query_params) }
-
-    it "Allows the user to select 'by postcode, town or city'" do
-      location_filter_results_page = PageObjects::Page::ResultFilters::LocationFilterResults.new
-
-      filter_page.by_postcode_town_or_city.click
-      filter_page.location_query.set "SW1P 3BT"
-      filter_page.search_radius.select "5 miles"
-
-      filter_page.find_courses.click
-
-      expect_page_to_be_displayed_with_query(
-        page: location_filter_results_page,
-        expected_query_params: {
-          "l" => "1",
-          "lat" => "51.4980188",
-          "lng" => "-0.1300436",
-          "loc" => "Westminster, London SW1P 3BT, UK",
-          "lq" => "SW1P 3BT",
-          "rad" => "5",
-        },
-      )
-    end
 
     it "Allows the user to select across england" do
       filter_page.across_england.click

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -221,29 +221,6 @@ feature "results", type: :feature do
   end
 
   describe "location filter" do
-    context "location selected within 10 miles" do
-      let(:params) do
-        {
-          loc: "Hogwarts, Reading, UK",
-          rad: "10",
-          lng: "-27.1504002",
-          lat: "-109.3042697",
-          l: 1,
-        }
-      end
-
-      it "displays the location filter" do
-        expected_url = "https://maps.googleapis.com/maps/api/staticmap?key=alohomora&center=-109.3042697,-27.1504002&zoom=11&size=300x200&scale=2&markers=-109.3042697,-27.1504002"
-        expect(results_page.location_filter.name).to have_content("Hogwarts, Reading, UK")
-        expect(results_page.location_filter.distance).to have_content("Within 10 miles of the pin")
-        expect(results_page.location_filter.map["src"]).to have_content(expected_url)
-        results_page.location_filter.link.click
-        location_filter_uri = URI(current_url)
-        expect(location_filter_uri.path).to eq("/results/filter/location")
-        expect(location_filter_uri.query).to eq("l=1&lat=-109.3042697&lng=-27.1504002&loc=Hogwarts,+Reading,+UK&rad=10&qualifications=QtsOnly,PgdePgceWithQts,Other&fulltime=False&parttime=False&hasvacancies=True&senCourses=False")
-      end
-    end
-
     context "location with blank provider name" do
       let(:params) do
         {

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -256,8 +256,8 @@ describe ResultsView do
     end
   end
 
-  describe "#distance" do
-    subject { described_class.new(query_parameters: parameter_hash).distance }
+  describe "#radius" do
+    subject { described_class.new(query_parameters: parameter_hash).radius }
 
     context "when rad is passed" do
       let(:parameter_hash) { { "rad" => "10" } }
@@ -335,6 +335,38 @@ describe ResultsView do
       let(:parameter_hash) { { "query" => "Kamino" } }
 
       it { is_expected.to eq("Kamino") }
+    end
+  end
+
+  describe "#location_filter?" do
+    subject { described_class.new(query_parameters: parameter_hash).location_filter? }
+
+    context "when l param is set to 1" do
+      let(:parameter_hash) { { "l" => "1" } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when l param is not set to 1" do
+      let(:parameter_hash) { { "l" => "2" } }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe "#england_filter?" do
+    subject { described_class.new(query_parameters: parameter_hash).england_filter? }
+
+    context "when l param is set to 2" do
+      let(:parameter_hash) { { "l" => "2" } }
+
+      it { is_expected.to be(true) }
+    end
+
+    context "when l param is not set to 2" do
+      let(:parameter_hash) { { "l" => "3" } }
+
+      it { is_expected.to be(false) }
     end
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/SNDaCBWV/3044-make-find-request-location-filtering
- This hooks up location filtering from backend to the frontend

### Changes proposed in this pull request

- Hookup location filtering backend to frontend
- Removed redundant tests, asserting against query parameters
- Rename #distance to #radius

### Guidance to review

- This PR depends on the backend surfacing the `latitude`, `longitude` and `radius` otherwise this feature will not work
- See https://trello.com/c/UkVHbumo/2835-l-location-filter-add-filtering-to-api
- Should wait for that before this card is tested/merged
- Perform a search with any geocoded location e.g. postcode
- Should see results page
- Correct address shows above google map
- Above google map correct radius should show
- Google maps should show with pin in correct location
- Assuming backend works correctly relevant location results should be shown