### PR TITLE
[3031] Add a healthcheck endpoint

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -6,9 +6,7 @@ class HeartbeatController < ActionController::API
         teacher_training_api: api_alive?,
     }
 
-    status = :ok
-    status = :bad_gateway unless checks.values.all?
-    render status: status, json: {
+    render status: (checks.values.all? ? :ok : :bad_gateway), json: {
       checks: checks,
     }
   end

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,0 +1,24 @@
+class HeartbeatController < ActionController::API
+  include HTTParty
+
+  def healthcheck
+    checks = {
+        teacher_training_api: api_alive?,
+    }
+
+    status = :ok
+    status = :bad_gateway unless checks.values.all?
+    render status: status, json: {
+      checks: checks,
+    }
+  end
+
+private
+
+  def api_alive?
+    response = HeartbeatController.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+    response.success?
+  rescue StandardError
+    false
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
+  get :healthcheck, controller: :heartbeat
+
   scope module: "result_filters" do
     root to: "location#start"
   end

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+describe "GET /healthcheck" do
+  let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+
+  context "when everything is ok" do
+    before do
+      stub_request(:get, healthcheck_endpoint)
+          .to_return(status: 200)
+      get "/healthcheck"
+    end
+
+    it "returns HTTP success" do
+      expect(response.status).to eq(200)
+    end
+
+    it "returns JSON" do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq({ checks: {
+          teacher_training_api: true,
+      } }.to_json)
+    end
+  end
+
+  context "when the api returns 502" do
+    before do
+      stub_request(:get, healthcheck_endpoint)
+          .to_return(status: 502)
+      get "/healthcheck"
+    end
+
+    it "returns status bad gateway" do
+      expect(response.status).to eq(502)
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq({ checks: {
+        teacher_training_api: false,
+      } }.to_json)
+    end
+  end
+
+  context "when the api times out" do
+    before do
+      stub_request(:get, healthcheck_endpoint)
+          .to_timeout
+      get "/healthcheck"
+    end
+
+    it "returns status bad gateway" do
+      expect(response.status).to eq(502)
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq({ checks: {
+        teacher_training_api: false,
+      } }.to_json)
+    end
+  end
+
+  context "when the api refuses the connection" do
+    before do
+      stub_request(:get, healthcheck_endpoint)
+          .to_raise(StandardError) # https://stackoverflow.com/questions/25552239/webmock-simulate-failing-api-no-internet-timeout/25559291#25559291
+      get "/healthcheck"
+    end
+
+    it "returns status bad gateway" do
+      expect(response.status).to eq(502)
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq({ checks: {
+        teacher_training_api: false,
+      } }.to_json)
+    end
+  end
+end


### PR DESCRIPTION
### Context

DevOps

### Changes proposed in this pull request

* [3031] Add a healthcheck endpoint

This new `/healthcheck` endpoint checks whether the dependencies of this
service are up. By implication of having returned a 200 OK status you
can also tell that this service is up.

Failure of dependencies results in a 502 bad-gateway status and a json
body showing which dependencies failed.

Front-door will probably continue to check root `/` for a 200 status as
that doesn't have any dependencies currently, so no need for a ping
endpoint as well.

This code is based on
https://github.com/DFE-Digital/teacher-training-api/pull/1202

### Guidance to review

:ship: