### PR TITLE
[3057] - Fix course count

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -117,7 +117,7 @@ class ResultsView
   end
 
   def course_count
-    courses.total_count
+    courses.meta["count"]
   end
 
   def subjects

--- a/spec/fixtures/api_responses/courses.json
+++ b/spec/fixtures/api_responses/courses.json
@@ -1055,6 +1055,9 @@
       }
     }
   ],
+  "meta": {
+    "count": 8900
+  },
   "links": {
     "next": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026include=provider\u0026page%5Bpage%5D=2\u0026page%5Bper_page%5D=2",
     "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026include=provider\u0026page%5Bpage%5D=890\u0026page%5Bper_page%5D=2"


### PR DESCRIPTION
NB: this fix requires merging https://github.com/DFE-Digital/teacher-training-api/pull/1207

### Context

- The 'total_courses' helper method provided by the json_api_client gem is an estimate only (it is calculated by multiplying number of pages by the number per page). This results in course count inaccuracies under certain search conditions

- The course count is now determined by the value provided via the meta object in the API response (See https://github.com/DFE-Digital/teacher-training-api/pull/1207). Doing it in this way also follows the JSON API spec recommendations

### Changes proposed in this pull request
- Calculate course count using the value provided in the API response meta object
- Update JSON fixture

### Guidance to review

