### PR TITLE
[3059] Make predicate helper methods consistent and add unit tests

### DIFF
--- a/app/helpers/result_filters/location_helper.rb
+++ b/app/helpers/result_filters/location_helper.rb
@@ -1,15 +1,21 @@
 module ResultFilters
   module LocationHelper
     def provider_error?
-      flash[:error] && flash[:error].include?(I18n.t("location_filter.fields.provider"))
+      return false if flash[:error].nil?
+
+      flash[:error].include?(I18n.t("location_filter.fields.provider"))
     end
 
     def location_error?
-      flash[:error] && flash[:error].include?(I18n.t("location_filter.fields.location"))
+      return false if flash[:error].nil?
+
+      flash[:error].include?(I18n.t("location_filter.fields.location"))
     end
 
     def no_option_selected?
-      flash[:error] && flash[:error].include?(I18n.t("location_filter.errors.no_option"))
+      return false if flash[:error].nil?
+
+      flash[:error].include?(I18n.t("location_filter.errors.no_option"))
     end
   end
 end

--- a/spec/helpers/result_filters/location_helper_spec.rb
+++ b/spec/helpers/result_filters/location_helper_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+feature "ResultFilters::LocationHelper", type: :helper do
+  describe "#provider_error?" do
+    it "returns true if provider error is displayed" do
+      allow(controller).to receive(:flash).and_return(error: I18n.t("location_filter.fields.provider"))
+
+      expect(helper.provider_error?).to eq(true)
+    end
+
+    it "returns false if no error is displayed" do
+      expect(helper.provider_error?).to eq(false)
+    end
+  end
+
+  describe "#location_error?" do
+    it "returns true if location error is displayed" do
+      allow(controller).to receive(:flash).and_return(error: I18n.t("location_filter.fields.location"))
+
+      expect(helper.location_error?).to eq(true)
+    end
+
+    it "returns false if no error is displayed" do
+      expect(helper.location_error?).to eq(false)
+    end
+  end
+
+  describe "#no_option_selected?" do
+    it "returns true if no option selected error is displayed" do
+      allow(controller).to receive(:flash).and_return(error: I18n.t("location_filter.errors.no_option"))
+
+      expect(helper.no_option_selected?).to eq(true)
+    end
+
+    it "returns false if no error is displayed" do
+      expect(helper.no_option_selected?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
### Context / changes
We agreed that those methods should return `true`/`false` https://github.com/DFE-Digital/find-teacher-training/pull/102#discussion_r379853735. It's making it consistent with the subject_helper methods and adds unit tests.

### Guidance to review
Errors on location filter page still work 
https://find-teacher-3059-predi-3hvnba.herokuapp.com/results/filter/location
