### PR TITLE
[3062] Add ping endpoint

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,6 +1,10 @@
 class HeartbeatController < ActionController::API
   include HTTParty
 
+  def ping
+    render body: "PONG"
+  end
+
   def healthcheck
     checks = {
         teacher_training_api: api_alive?,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
+  get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
 
   scope module: "result_filters" do

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -1,81 +1,91 @@
 require "rails_helper"
 
-describe "GET /healthcheck" do
-  let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+describe "heartbeat requests" do
+  describe "GET /ping" do
+    it "returns PONG" do
+      get "/ping"
 
-  context "when everything is ok" do
-    before do
-      stub_request(:get, healthcheck_endpoint)
-          .to_return(status: 200)
-      get "/healthcheck"
-    end
-
-    it "returns HTTP success" do
-      expect(response.status).to eq(200)
-    end
-
-    it "returns JSON" do
-      expect(response.content_type).to eq("application/json")
-    end
-
-    it "returns the expected response report" do
-      expect(response.body).to eq({ checks: {
-          teacher_training_api: true,
-      } }.to_json)
+      expect(response.body).to eq "PONG"
     end
   end
 
-  context "when the api returns 502" do
-    before do
-      stub_request(:get, healthcheck_endpoint)
-          .to_return(status: 502)
-      get "/healthcheck"
+  describe "GET /healthcheck" do
+    let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+
+    context "when everything is ok" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+            .to_return(status: 200)
+        get "/healthcheck"
+      end
+
+      it "returns HTTP success" do
+        expect(response.status).to eq(200)
+      end
+
+      it "returns JSON" do
+        expect(response.content_type).to eq("application/json")
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+            teacher_training_api: true,
+        } }.to_json)
+      end
     end
 
-    it "returns status bad gateway" do
-      expect(response.status).to eq(502)
+    context "when the api returns 502" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+            .to_return(status: 502)
+        get "/healthcheck"
+      end
+
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
     end
 
-    it "returns the expected response report" do
-      expect(response.body).to eq({ checks: {
-        teacher_training_api: false,
-      } }.to_json)
-    end
-  end
+    context "when the api times out" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+            .to_timeout
+        get "/healthcheck"
+      end
 
-  context "when the api times out" do
-    before do
-      stub_request(:get, healthcheck_endpoint)
-          .to_timeout
-      get "/healthcheck"
-    end
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
 
-    it "returns status bad gateway" do
-      expect(response.status).to eq(502)
-    end
-
-    it "returns the expected response report" do
-      expect(response.body).to eq({ checks: {
-        teacher_training_api: false,
-      } }.to_json)
-    end
-  end
-
-  context "when the api refuses the connection" do
-    before do
-      stub_request(:get, healthcheck_endpoint)
-          .to_raise(StandardError) # https://stackoverflow.com/questions/25552239/webmock-simulate-failing-api-no-internet-timeout/25559291#25559291
-      get "/healthcheck"
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
     end
 
-    it "returns status bad gateway" do
-      expect(response.status).to eq(502)
-    end
+    context "when the api refuses the connection" do
+      before do
+        stub_request(:get, healthcheck_endpoint)
+            .to_raise(StandardError) # https://stackoverflow.com/questions/25552239/webmock-simulate-failing-api-no-internet-timeout/25559291#25559291
+        get "/healthcheck"
+      end
 
-    it "returns the expected response report" do
-      expect(response.body).to eq({ checks: {
-        teacher_training_api: false,
-      } }.to_json)
+      it "returns status bad gateway" do
+        expect(response.status).to eq(502)
+      end
+
+      it "returns the expected response report" do
+        expect(response.body).to eq({ checks: {
+          teacher_training_api: false,
+        } }.to_json)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Devop
### Changes proposed in this pull request
The reason for adding this is because of our other repos publish-teacher-training
and teacher-training-api all have a ping endpoint that azure uses to check
if the service is up and online.

### Guidance to review

