### PR TITLE
[3044] - Display distance to nearest site and nearest address

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem "jsonapi-serializable"
 # Settings for the app
 gem "config"
 
+# Calculate distance between two locations
+gem "geokit"
+
 # Error tracking
 gem "sentry-raven"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,7 @@ GEM
     ffi (1.12.2)
     foreman (0.87.0)
     geocoder (1.6.1)
+    geokit (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashdiff (1.0.0)
@@ -384,6 +385,7 @@ DEPENDENCIES
   faker
   foreman
   geocoder
+  geokit
   httparty
   json_api_client
   jsonapi-deserializable

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -137,10 +137,8 @@ class ResultsView
   end
 
   def site_distance(course)
-    query_location = Geokit::LatLng.new(latitude.to_f, longitude.to_f)
-
     distances = course.sites.map do |site|
-      query_location.distance_to("#{site[:latitude]},#{site[:longitude]}")
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
     end
 
     min_distance = distances.min
@@ -152,11 +150,33 @@ class ResultsView
     end
   end
 
+  def nearest_address(course)
+    ordered_sites = course.sites.sort_by do |site|
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
+    end
+
+    sites_addresses = ordered_sites.map do |address|
+      [
+        address.address1,
+        address.address2,
+        address.address3,
+        address.address4,
+        address.postcode,
+      ].select(&:present?).join(", ").html_safe
+    end
+
+    sites_addresses.first
+  end
+
   def subjects
     subject_codes.any? ? filtered_subjects : all_subjects[0...NUMBER_OF_SUBJECTS_DISPLAYED]
   end
 
 private
+
+  def lat_long
+    Geokit::LatLng.new(latitude.to_f, longitude.to_f)
+  end
 
   attr_reader :query_parameters
 

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -104,10 +104,12 @@
                 <dt>Accredited body</dt>
                 <dd data-qa="course__accrediting_provider"><%= course.accrediting_provider.provider_name %></dd>
               <% end %>
-              <dt class="govuk-list--description__label">Main address</dt>
-              <dd data-qa="course__main_address">
-                <%= course.provider.decorate.short_address %>
-              </dd>
+              <% unless @results_view.location_filter?  %>
+                <dt class="govuk-list--description__label">Main address</dt>
+                <dd data-qa="course__main_address">
+                  <%= course.provider.decorate.short_address %>
+                </dd>
+              <% end %>
             </dl>
           </li>
         <% end %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -95,15 +95,17 @@
               <% if @results_view.location_filter?  %>
                 <dt class="govuk-list--description__label">Distance</dt>
                 <dd data-qa="course__site_distance"><%= @results_view.site_distance(course) %> miles <span class="govuk-list--description__hint">to the training provider or their nearest training location</span></dd>
+                <dt class="govuk-list--description__label">Nearest address</dt>
+                <dd data-qa="course__nearest_address"><%= @results_view.nearest_address(course) %></dd>
               <% end %>
               <dt class="govuk-list--description__label">Financial support</dt>
               <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
               <% if course.accrediting_provider.present? %>
                 <dt>Accredited body</dt>
                 <dd data-qa="course__accrediting_provider"><%= course.accrediting_provider.provider_name %></dd>
-                <% end %>
-                  <dt class="govuk-list--description__label">Main address</dt>
-                  <dd data-qa="course__main_address">
+              <% end %>
+              <dt class="govuk-list--description__label">Main address</dt>
+              <dd data-qa="course__main_address">
                 <%= course.provider.decorate.short_address %>
               </dd>
             </dl>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -92,6 +92,10 @@
             <dl class="govuk-list--description">
               <dt class="govuk-list--description__label">Course</dt>
               <dd data-qa="course__description"><%= course.description%></dd>
+              <% if @results_view.location_filter?  %>
+                <dt class="govuk-list--description__label">Distance</dt>
+                <dd data-qa="course__site_distance"><%= @results_view.site_distance(course) %> miles <span class="govuk-list--description__hint">to the training provider or their nearest training location</span></dd>
+              <% end %>
               <dt class="govuk-list--description__label">Financial support</dt>
               <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
               <% if course.accrediting_provider.present? %>

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -63,6 +63,7 @@ feature "Location filter", type: :feature do
       provider_page.provider_suggestions[0].hyperlink.click
 
       expect(results_page.courses.first.site_distance_to_location_query).to_not be_present
+      expect(results_page.courses.first.nearest_address).to_not be_present
 
       expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
       expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
@@ -95,6 +96,7 @@ feature "Location filter", type: :feature do
       expect(results_page.heading.text).to eq("Teacher training courses")
 
       expect(results_page.courses.first.site_distance_to_location_query).to be_present
+      expect(results_page.courses.first.nearest_address).to be_present
 
       expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
       expect(results_page.location_filter.map).to be_present

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -62,8 +62,9 @@ feature "Location filter", type: :feature do
       expect(provider_page.heading.text).to eq("Pick a provider")
       provider_page.provider_suggestions[0].hyperlink.click
 
-      expect(results_page.courses.first.site_distance_to_location_query).to_not be_present
-      expect(results_page.courses.first.nearest_address).to_not be_present
+      expect(results_page.courses.first).to have_main_address
+      expect(results_page.courses.first).not_to have_site_distance_to_location_query
+      expect(results_page.courses.first).not_to have_nearest_address
 
       expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
       expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
@@ -95,8 +96,9 @@ feature "Location filter", type: :feature do
 
       expect(results_page.heading.text).to eq("Teacher training courses")
 
-      expect(results_page.courses.first.site_distance_to_location_query).to be_present
-      expect(results_page.courses.first.nearest_address).to be_present
+      expect(results_page.courses.first).to have_site_distance_to_location_query
+      expect(results_page.courses.first).to have_nearest_address
+      expect(results_page.courses.first).not_to have_main_address
 
       expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
       expect(results_page.location_filter.map).to be_present

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -47,7 +47,7 @@ feature "Location filter", type: :feature do
           query: base_parameters.merge("filter[provider.provider_name]" => "ACME SCITT 0"),
         )
         .to_return(
-          body: File.new("spec/fixtures/api_responses/courses.json"),
+          body: File.new("spec/fixtures/api_responses/two_courses_with_sites.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
@@ -61,6 +61,8 @@ feature "Location filter", type: :feature do
 
       expect(provider_page.heading.text).to eq("Pick a provider")
       provider_page.provider_suggestions[0].hyperlink.click
+
+      expect(results_page.courses.first.site_distance_to_location_query).to_not be_present
 
       expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
       expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
@@ -78,7 +80,7 @@ feature "Location filter", type: :feature do
                                        "filter[radius]" => "20"),
         )
         .to_return(
-          body: File.new("spec/fixtures/api_responses/courses.json"),
+          body: File.new("spec/fixtures/api_responses/two_courses_with_sites.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
     end
@@ -91,6 +93,8 @@ feature "Location filter", type: :feature do
       filter_page.find_courses.click
 
       expect(results_page.heading.text).to eq("Teacher training courses")
+
+      expect(results_page.courses.first.site_distance_to_location_query).to be_present
 
       expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
       expect(results_page.location_filter.map).to be_present

--- a/spec/fixtures/api_responses/two_courses_with_sites.json
+++ b/spec/fixtures/api_responses/two_courses_with_sites.json
@@ -1,0 +1,1139 @@
+{
+  "data": [
+    {
+      "id": "12933137",
+      "type": "courses",
+      "attributes": {
+        "findable?": true,
+        "open_for_applications?": true,
+        "has_vacancies?": true,
+        "course_code": "3CVC",
+        "name": "Business Studies",
+        "study_mode": "full_time",
+        "qualification": "pgce_with_qts",
+        "description": "PGCE with QTS full time",
+        "content_status": "published",
+        "ucas_status": "running",
+        "funding_type": "fee",
+        "level": "secondary",
+        "is_send?": false,
+        "english": "must_have_qualification_at_application_time",
+        "maths": "must_have_qualification_at_application_time",
+        "science": null,
+        "gcse_subjects_required": [
+          "maths",
+          "english"
+        ],
+        "age_range_in_years": "11_to_18",
+        "accrediting_provider": {
+          "id": 14956,
+          "address4": "Hertfordshire",
+          "provider_name": "University of Hertfordshire",
+          "scheme_member": "is_a_UCAS_ITT_member",
+          "contact_name": "School of Education",
+          "year_code": "2019",
+          "provider_code": "H36",
+          "provider_type": "university",
+          "postcode": "AL10 9AB",
+          "website": "https://go.herts.ac.uk/teachertraining",
+          "address1": "University of Hertfordshire",
+          "address2": null,
+          "address3": "Hatfield",
+          "email": "admcom@herts.ac.uk",
+          "telephone": "01707 284800",
+          "region_code": "eastern",
+          "created_at": "2019-07-19T08:44:30.691Z",
+          "updated_at": "2019-12-12T15:42:31.568Z",
+          "accrediting_provider": "accredited_body",
+          "changed_at": "2019-12-12T15:42:31.568Z",
+          "recruitment_cycle_id": 2,
+          "discarded_at": null,
+          "train_with_us": "The University of Hertfordshire is a leading regional provider of [Initial Teacher Education](https://www.herts.ac.uk/study/schools-of-study/education/initial-teacher-education).  Consistently high achieving in its Ofsted inspections and in the Guardian and Times League tables, it is rightly proud of its excellent reputation with local and regional schools who often employ our student teachers.\r\n\r\nThe School of Education has an excellent record of employment for trainees on their Initial Teacher Education programmes, and those who actively seek a teaching post at the end of their programme are successful in joining the profession.\r\n\r\nAfter completing Initial Teacher Education there are opportunities to continue your studies with the University through the [MA Education Framework](https://www.herts.ac.uk/study/schools-of-study/education/postgraduate-courses-education/ma-education-framework).\r\n\r\nThe University of Hertfordshire has achieved the top gold ranking in the Government's [Teaching Excellence Framework 2018](https://www.herts.ac.uk/about-us/learning-and-teaching/tef-teaching-excellence-framework). The gold award recognises the outstanding teaching at the University and is valid for up to three years.\r\n",
+          "train_with_disability": "The University of Hertfordshire is committed to promoting equality of opportunity to ensure that it meets the needs of disabled people and has policies that are intended to support all students both in their studies and in developing their professional practice.\r\n\r\nIf you have a disability or other need we encourage you to disclose this and any other relevant information that could support your studies.\r\nThe School of Education at the University of Hertfordshire provides both academic and practice placement support for teachers in training with disabilities and other needs.\r\n\r\nOne key aspect of the PGCE course is to raise awareness of mental health and well-being and to support the removal of unnecessary workload. \r\n[University of Hertfordshire disability support](https://www.herts.ac.uk/life/student-support/disability-services)\r\n[University of Hertfordshire statement on disability disclosure by students](https://www.herts.ac.uk/life/student-support/disability-services/statement-on-disability-disclosure-by-students)\r\n",
+          "accrediting_provider_enrichments": [],
+          "latitude": 51.7518204,
+          "longitude": -0.2387957
+        },
+        "accrediting_provider_code": "H36",
+        "start_date": "September 2020",
+        "applications_open_from": "2019-10-08",
+        "last_published_at": "2020-01-30T13:49:31Z",
+        "about_accrediting_body": "Hertfordshire University is a well established provider of quality teacher training.  They provide a strong support network within the University and have long established rigorous selection criteria both for Schools and Alliances entitled to train and candidates who will succeed on their courses.    Coupled with the Mentor network within the Alliance all candidates can be assured of a quality training programme.",
+        "provider_code": "2FR",
+        "recruitment_cycle_year": "2020",
+        "about_course": "\r\n\r\nAs a school-led route the great majority of your time will be spent in your training school, and the content and focus of many aspects of the training programme will be targeted to meet your individual needs.  We utilise the resources of the school and our alliance partners to achieve this aim. Whether you are attending your one day per week at University or additional professional sessions within your host school, you will be working towards meeting the national Teaching Standards. Within the school setting, as your confidence and knowledge develops, you will be mentored and guided to work towards managing a trainees teaching timetable by the final term of your course.  You will then be prepared to teach a Newly Qualified Teachers timetable the following year.  We will fully support you and tailor the programme as much as possible to accommodate  your needs.  In addition, at Hertfordshire University you will also benefit from access to the University's extensive resources, including those provided by the library and student support services.\r\n\r\nThe School Direct programme provides you with a series of subject enhancement sessions, and a programme of professional studies which will be run at the University and at your host school. These may include sessions which:\r\n•Allow you to visit a variety of partnership schools and non-formal educational sites to enhance learning in specialist areas.\r\n•Provide you with opportunities to enhance your knowledge and pedagogy of your subject, or specialist area of the curriculum.\r\n•Develop your understanding of key contemporary issues within education, such as those around inclusion or EAL and SEND provision in schools.\r\n\r\nYou will critically evaluate the effectiveness of a wide range of resources and your own lesson plans. You will analyse research data and critically evaluate how research has contributed to the knowledge and understanding of how to teach effectively.\r\n\r\n\r\nIn addition to developing the knowledge and skills required to teach, you will also be able to identify and evaluate effective strategies for assessing children's learning through formative and summative assessment strategies. You will learn to critically evaluate the effectiveness of a wide range of resources for your subject and understand the importance of literacy, numeracy and ICT in delivering the curriculum.\r\n",
+        "course_length": "OneYear",
+        "fee_details": "You will pay £9250 to the university however you may be entitled to a bursary. ",
+        "fee_international": null,
+        "fee_uk_eu": 9250,
+        "financial_support": null,
+        "how_school_placements_work": "\r\nWhen you are training with us you will train for the 1st and 3rd term within your 'host' school and then experience another school within the Alliance in the 2nd term.  \r\n\r\nOur lead mentor will visit you within your second setting to ensure you are supported throughout this time along with a mentor being provided every step of the way at the school. \r\n\r\nThis provides a chance to experience a different setting and perfect your practice whilst working towards the teaching standards.  You will then return to your host school to complete your training.  \r\n\r\n",
+        "interview_process": "The Head of Department at the 'host' school will be interviewing you along with a member of the Senior Management Team.  A representative of the University will also be involved along with the Lead Phase Mentor.  You will also be asked to prepare a lesson or part of a lesson in your subject to deliver to a group of students in order to assess your interaction and communication skills with young people. You will also be asked to sit a brief literacy and numeracy task.  \r\n\r\nIn addition, you will need to bring your certificates and photo identification with you on the day. \r\n\r\nOne interview will take place at the school and then a further interview may take place with the university. \r\n",
+        "other_requirements": "\r\nYou must complete a satisfactory Enhanced DBS check, submit a health questionnaire and a suitability to teach declaration. \r\n ",
+        "personal_qualities": "Above all else we want to see that you like and can interact appropriately with children and young people. We want to see that you:\r\n\r\n*\texcellent communication skills\r\n*      have a desire to teach and make a difference\r\n*      like people and can interact with them appropriately\r\n*\tare determined, trustworthy and resilient\r\n*\tshow patience and kindness to others, and don’t harbour grudges\r\n*\tcan engage peoples’ attention, and adapt to situations as they unfold \r\n\r\n*     good time management and organisational skills in order to meet the  demands of the profession\r\n",
+        "required_qualifications": "A relevant honours degree from a British university with a minimum 2.2 or equivalent overseas degree supported by a recent NARIC certificate. \r\n\r\nMaths and English at Grade C or higher or equivalent (supported by a recent NARIC certificate for overseas students).  No Equivalency Tests are acceptable for Hertfordshire University. \r\n\r\n",
+        "salary_details": null
+      },
+      "relationships": {
+        "provider": {
+          "data": {
+            "type": "providers",
+            "id": "14881"
+          }
+        },
+        "accrediting_provider": {
+          "meta": {
+            "included": false
+          }
+        },
+        "site_statuses": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sites": {
+          "data": [
+            {
+              "type": "sites",
+              "id": "11216222"
+            }
+          ]
+        },
+        "subjects": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "meta": {
+        "edit_options": {
+          "entry_requirements": [
+            "must_have_qualification_at_application_time",
+            "expect_to_achieve_before_training_begins",
+            "equivalence_test"
+          ],
+          "qualifications": [
+            "qts",
+            "pgce_with_qts",
+            "pgde_with_qts"
+          ],
+          "age_range_in_years": [
+            "11_to_16",
+            "11_to_18",
+            "14_to_19"
+          ],
+          "start_dates": [
+            "October 2019",
+            "November 2019",
+            "December 2019",
+            "January 2020",
+            "February 2020",
+            "March 2020",
+            "April 2020",
+            "May 2020",
+            "June 2020",
+            "July 2020",
+            "August 2020",
+            "September 2020",
+            "October 2020",
+            "November 2020",
+            "December 2020",
+            "January 2021",
+            "February 2021",
+            "March 2021",
+            "April 2021",
+            "May 2021",
+            "June 2021",
+            "July 2021"
+          ],
+          "study_modes": [
+            "full_time",
+            "part_time",
+            "full_time_or_part_time"
+          ],
+          "show_is_send": false,
+          "show_start_date": false,
+          "show_applications_open": false,
+          "subjects": [
+            {
+              "id": "8",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Art and design",
+                "subject_code": "W1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "10",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Biology",
+                "subject_code": "C1",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "11",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Business studies",
+                "subject_code": "08",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "12",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Chemistry",
+                "subject_code": "F1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "13",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Citizenship",
+                "subject_code": "09",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "14",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Classics",
+                "subject_code": "Q8",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "15",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Communication and media studies",
+                "subject_code": "P3",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "16",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Computing",
+                "subject_code": "11",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "17",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Dance",
+                "subject_code": "12",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "18",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Design and technology",
+                "subject_code": "DT",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "19",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Drama",
+                "subject_code": "13",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "20",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Economics",
+                "subject_code": "L1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "21",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "English",
+                "subject_code": "Q3",
+                "bursary_amount": "12000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "22",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Geography",
+                "subject_code": "F8",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": "17000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "23",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Health and social care",
+                "subject_code": "L5",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "24",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "History",
+                "subject_code": "V1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "25",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Mathematics",
+                "subject_code": "G1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "33",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Modern Languages",
+                "subject_code": null,
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "26",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Music",
+                "subject_code": "W3",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "27",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Philosophy",
+                "subject_code": "P1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "28",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physical education",
+                "subject_code": "C6",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "29",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physics",
+                "subject_code": "F3",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "30",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Psychology",
+                "subject_code": "C8",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "31",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Religious education",
+                "subject_code": "V6",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "9",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Science",
+                "subject_code": "F0",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "32",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Social sciences",
+                "subject_code": "14",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            }
+          ],
+          "modern_languages": null
+        }
+      }
+    },
+    {
+      "id": "12933121",
+      "type": "courses",
+      "attributes": {
+        "findable?": true,
+        "open_for_applications?": true,
+        "has_vacancies?": true,
+        "course_code": "35X3",
+        "name": "Chemistry",
+        "study_mode": "full_time",
+        "qualification": "pgce_with_qts",
+        "description": "PGCE with QTS full time",
+        "content_status": "published",
+        "ucas_status": "running",
+        "funding_type": "fee",
+        "level": "secondary",
+        "is_send?": false,
+        "english": "must_have_qualification_at_application_time",
+        "maths": "must_have_qualification_at_application_time",
+        "science": null,
+        "gcse_subjects_required": [
+          "maths",
+          "english"
+        ],
+        "age_range_in_years": null,
+        "accrediting_provider": {
+          "id": 13753,
+          "address4": "London",
+          "provider_name": "Middlesex University",
+          "scheme_member": "is_a_UCAS_ITT_member",
+          "contact_name": "Admissions: Susie King",
+          "year_code": "2019",
+          "provider_code": "M80",
+          "provider_type": "university",
+          "postcode": "NW4 4BT",
+          "website": "http://www.mdx.ac.uk",
+          "address1": "Middlesex University",
+          "address2": "The Burroughs",
+          "address3": "Hendon",
+          "email": "enquiries@mdx.ac.uk",
+          "telephone": "020 8411 5555",
+          "region_code": null,
+          "created_at": "2019-07-19T08:26:19.175Z",
+          "updated_at": "2019-12-12T15:17:40.681Z",
+          "accrediting_provider": "accredited_body",
+          "changed_at": "2019-12-27T11:59:52.485Z",
+          "recruitment_cycle_id": 2,
+          "discarded_at": null,
+          "train_with_us": "The education department has been involved in teacher training since the 1950s and has a long-established reputation for the provision of high quality teacher training. The department is based at the Hendon campus in London. We are committed to developing excellence in all areas of teaching, learning and professional practice in a wide range of contexts. We have high expectations of all our training teachers and work tirelessly to ensure that each individual reaches their full potential and becomes confident and highly employable. As a result, rates of employment are high across the partnership and many of our trainees stay within the partnership for their first teaching post. Our trainees come form a diverse range of backgrounds and typically all complete their training as good or outstanding trainees. During the last Ofsted inspection, inspectors commended the strong support for current and former trainees and the skilful way in which tutors tailor their work to meet the individual needs of trainees, providing challenge and support as required. Trainees are encouraged to develop their own support networks with peers, sharing resources and ideas. As a result, trainees are confident and able to seek advice and help during and after they have completed training. \r\n\r\n\r\n\r\n\r\n",
+          "train_with_disability": "We aim to provide an inclusive teaching and learning environment which caters for all trainees. We work closely with the Middlesex University Dyslexia and Disability Service to ensure that we are able to provide the appropriate support.\r\n\r\nFor more information, see;\r\n[mdx.ac.uk](https://unihub.mdx.ac.uk/support/disability-and-dyslexia)\r\n\r\nWe endeavour to ensure that each trainee is supported on an individual basis, dependent on their needs. We strive to build resilience, and we  prepare trainees for the potential pressure points on the course with bespoke ‘well-being' sessions and provide individual personal support for trainees experiencing stress or anxiety. ",
+          "accrediting_provider_enrichments": [],
+          "latitude": 51.5901102,
+          "longitude": -0.228922
+        },
+        "accrediting_provider_code": "M80",
+        "start_date": "September 2020",
+        "applications_open_from": "2019-10-08",
+        "last_published_at": "2020-01-30T13:24:40Z",
+        "about_accrediting_body": "We have worked with Middlesex University for over 7 years delivering quality teacher training.  We always find the university responsive and supportive with any concerns or issues students have.  We are fortunate that the contacts at the University have remained the same for a number of years and therefore we have developed an excellent track record in working closely with them.  Our Lead Primary Mentor is the Chair of the School Direct Partnership group.",
+        "provider_code": "2FR",
+        "recruitment_cycle_year": "2020",
+        "about_course": "This is a PGCE Course in partnership with Middlesex University. \r\n\r\nWhether you are attending University or additional professional sessions within your host school, you will be working towards meeting the national Teaching Standards. Within the school setting, as your confidence and knowledge develops, you will be mentored and guided to work towards managing a trainees teaching timetable by the final term of your course.  You will then be prepared to teach a Newly Qualified Teachers timetable the following year.  We will fully support you and tailor the programme as much as possible to accommodate  your needs.  In addition, at Middlesex you will also benefit from access to the University's extensive resources, including those provided by the library and student support services.\r\n\r\nThe Middlesex School Direct programme provides you with a series of subject enhancement sessions, and a programme of professional studies which will be run at the University and at your host school. These may include sessions which:\r\n•Allow you to visit a variety of partnership schools and non-formal educational sites to enhance learning in specialist areas.\r\n•Provide you with opportunities to enhance your knowledge and pedagogy of your subject, or specialist area of the curriculum.\r\n•Develop your understanding of key contemporary issues within education, such as those around inclusion or EAL and SEND provision in schools.\r\n\r\nYou will critically evaluate the effectiveness of a wide range of resources and your own lesson plans. You will analyse research data and critically evaluate how research has contributed to the knowledge and understanding of how to teach effectively.\r\n\r\nIn addition to developing the knowledge and skills required to teach, you will also be able to identify and evaluate effective strategies for assessing children's learning through formative and summative assessment strategies. You will learn to critically evaluate the effectiveness of a wide range of resources for your subject and understand the importance of literacy, numeracy and ICT in delivering the curriculum.\r\n\r\nFor further information go to https://www.mdx.ac.uk/courses/postgraduate/science-with-chemistry\r\n\r\n",
+        "course_length": "OneYear",
+        "fee_details": "You will pay £9250 to the university however you may be entitled for a bursary. ",
+        "fee_international": null,
+        "fee_uk_eu": 9250,
+        "financial_support": null,
+        "how_school_placements_work": "\r\nWhen you are training with us you will train for the 1st and 3rd term within your 'host' school and then experience another school within the Alliance in the 2nd term.  \r\n\r\nOur lead mentor will visit you within your second setting to ensure you are supported throughout this time along with a mentor being provided every step of the way at the school. \r\n\r\nThis provides a chance to experience a different setting and perfect your practice whilst working towards the teaching standards.  You will then return to your host school to complete your training.  \r\n\r\n",
+        "interview_process": "The Head of Department at the 'host' school will be interviewing you along with a member of the Senior Management Team.  A representative of the University will also be involved along with the Lead Phase Mentor.  You will also be asked to prepare a lesson or part of a lesson in your subject to deliver to a group of students in order to assess your interaction and communication skills with young people. You will also be asked to sit a brief literacy and numeracy task.  In addition, you will need to bring your certificates and photo identification with you on the day. \r\n\r\nOne interview will take place at the school and then a further interview may take place with the university. \r\n",
+        "other_requirements": "You must complete a satisfactory Enhanced DBS check, submit a health questionnaire and a suitability to teach declaration. \r\n ",
+        "personal_qualities": "Above all else we want to see that you like and can interact appropriately with children and young people. We want to see that you:\r\n\r\n*\texcellent communication skills\r\n*      have a desire to teach and make a difference\r\n*      like people and can interact with them appropriately\r\n*\tare determined, trustworthy and resilient\r\n*\tshow patience and kindness to others, and don’t harbour grudges\r\n*\tcan engage peoples’ attention, and adapt to situations as they unfold \r\n*     good time management and organisational skills in order to meet the   demands of the profession\r\n",
+        "required_qualifications": "A relevant honours degree from a British university with a minimum 2.2 or equivalent overseas degree supported by a recent NARIC certificate. \r\n\r\nMaths and English at Grade C or higher or equivalent (supported by a recent NARIC certificate for overseas students)\r\n\r\nFor GCSEs, an equivalent qualification from Equivalency Testing Ltd is acceptable, but not any other provider. ",
+        "salary_details": null
+      },
+      "relationships": {
+        "provider": {
+          "data": {
+            "type": "providers",
+            "id": "14881"
+          }
+        },
+        "accrediting_provider": {
+          "meta": {
+            "included": false
+          }
+        },
+        "site_statuses": {
+          "meta": {
+            "included": false
+          }
+        },
+        "sites": {
+          "data": [
+            {
+              "type": "sites",
+              "id": "11216222"
+            },
+            {
+              "type": "sites",
+              "id": "11216223"
+            },
+            {
+              "type": "sites",
+              "id": "11216783"
+            }
+          ]
+        },
+        "subjects": {
+          "meta": {
+            "included": false
+          }
+        }
+      },
+      "meta": {
+        "edit_options": {
+          "entry_requirements": [
+            "must_have_qualification_at_application_time",
+            "expect_to_achieve_before_training_begins",
+            "equivalence_test"
+          ],
+          "qualifications": [
+            "qts",
+            "pgce_with_qts",
+            "pgde_with_qts"
+          ],
+          "age_range_in_years": [
+            "11_to_16",
+            "11_to_18",
+            "14_to_19"
+          ],
+          "start_dates": [
+            "October 2019",
+            "November 2019",
+            "December 2019",
+            "January 2020",
+            "February 2020",
+            "March 2020",
+            "April 2020",
+            "May 2020",
+            "June 2020",
+            "July 2020",
+            "August 2020",
+            "September 2020",
+            "October 2020",
+            "November 2020",
+            "December 2020",
+            "January 2021",
+            "February 2021",
+            "March 2021",
+            "April 2021",
+            "May 2021",
+            "June 2021",
+            "July 2021"
+          ],
+          "study_modes": [
+            "full_time",
+            "part_time",
+            "full_time_or_part_time"
+          ],
+          "show_is_send": false,
+          "show_start_date": false,
+          "show_applications_open": false,
+          "subjects": [
+            {
+              "id": "8",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Art and design",
+                "subject_code": "W1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "10",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Biology",
+                "subject_code": "C1",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "11",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Business studies",
+                "subject_code": "08",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "12",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Chemistry",
+                "subject_code": "F1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "13",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Citizenship",
+                "subject_code": "09",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "14",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Classics",
+                "subject_code": "Q8",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "15",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Communication and media studies",
+                "subject_code": "P3",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "16",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Computing",
+                "subject_code": "11",
+                "bursary_amount": "26000",
+                "early_career_payments": null,
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "17",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Dance",
+                "subject_code": "12",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "18",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Design and technology",
+                "subject_code": "DT",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "19",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Drama",
+                "subject_code": "13",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "20",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Economics",
+                "subject_code": "L1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "21",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "English",
+                "subject_code": "Q3",
+                "bursary_amount": "12000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "22",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Geography",
+                "subject_code": "F8",
+                "bursary_amount": "15000",
+                "early_career_payments": null,
+                "scholarship": "17000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "23",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Health and social care",
+                "subject_code": "L5",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "24",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "History",
+                "subject_code": "V1",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "25",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Mathematics",
+                "subject_code": "G1",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "33",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Modern Languages",
+                "subject_code": null,
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "26",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Music",
+                "subject_code": "W3",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": false
+              }
+            },
+            {
+              "id": "27",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Philosophy",
+                "subject_code": "P1",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "28",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physical education",
+                "subject_code": "C6",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "29",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Physics",
+                "subject_code": "F3",
+                "bursary_amount": "26000",
+                "early_career_payments": "2000",
+                "scholarship": "28000",
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "30",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Psychology",
+                "subject_code": "C8",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "31",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Religious education",
+                "subject_code": "V6",
+                "bursary_amount": "9000",
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": true
+              }
+            },
+            {
+              "id": "9",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Science",
+                "subject_code": "F0",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            },
+            {
+              "id": "32",
+              "type": "subjects",
+              "attributes": {
+                "subject_name": "Social sciences",
+                "subject_code": "14",
+                "bursary_amount": null,
+                "early_career_payments": null,
+                "scholarship": null,
+                "subject_knowledge_enhancement_course_available": null
+              }
+            }
+          ],
+          "modern_languages": null
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "14468",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "T92",
+        "provider_name": "2Schools Consortium",
+        "accredited_body?": true,
+        "can_add_more_sites?": true,
+        "accredited_bodies": [],
+        "train_with_us": "Ranked in the 10 best Teacher Training providers for Primary Teacher Training in 2015, 2Schools Consortium has been an accredited provider since 2002 and has a wealth of experience in mentoring trainees and in delivering training.\r\n\r\nThe 2Schools Consortium (Ofsted Outstanding, May 2014) consists of a lead school, Oakthorpe Primary School (Ofsted Outstanding, 2008), in Enfield, and approximately 30 partnership schools where trainees are placed.\r\n\r\n\r\n\r\nAll trainees on the 2Schools Consortium School Direct Salaried and SCITT Programme have the opportunity to work towards a PGCE award which will be validated by the University of East London.\r\n\r\nQuotes:\r\n'I’ve had so much fun this year and although it sounds crazy, I just wish I could do it all over again! '\r\nI feel that this year has changed me in so many different ways and made me so much more comfortable and confident in my teaching'.\r\nLorne-Rhys Jones, Qualified Teacher, Worcesters Primary School, School Direct Salaried 2017.18\r\n\r\n'Once again very pleased with this year’s trainee. I have been using school direct for 6 years and half my staff next year are from the programme. Without it would not be able to recruit. It has produced wonderful teacher. Thank you.'\r\nMaria Jay, Headteacher St Michael at Bowes Junior School, June 2018\r\n",
+        "train_with_disability": "At 2Schools we want to enable everyone to reach their full potential. After all teaching is the profession that unlocks potential in children.  If you do have and declare a disability we will do everything we reasonably can to make special arrangements. Please provide details on your application form so that we can ensure this happens. This will not affect your application.\r\n\r\nWe are committed to provide equality and fairness for all in our recruitment and employment practices and not to discriminate on grounds of age, disability, gender reassignment, marriage/civil partnership status, pregnancy and maternity, race, religion or belief, sex, or sexual orientation. We oppose all forms of unlawful and unfair discrimination.\r\n\r\nWe have regularly successfully supported a number of trainee with dyslexia, mental health conditions and learning difficulties and will continue to provide high level of support for any disability.",
+        "latitude": 51.6139314,
+        "longitude": -0.0935379,
+        "address1": "Oakthorpe Primary School",
+        "address2": "c/o Tile Kiln Lane",
+        "address3": "Palmers Green",
+        "address4": "London",
+        "postcode": "N13 6BY",
+        "region_code": "london",
+        "telephone": "02085203042",
+        "email": "training@henrymaynard.waltham.sch.uk",
+        "website": "",
+        "recruitment_cycle_year": "2020",
+        "admin_contact": null,
+        "utt_contact": null,
+        "web_link_contact": null,
+        "fraud_contact": null,
+        "finance_contact": null,
+        "gt12_contact": null,
+        "application_alert_contact": null,
+        "type_of_gt12": "no_response",
+        "send_application_alerts": "none"
+      },
+      "relationships": {
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "courses": {
+          "meta": {
+            "count": 1
+          }
+        }
+      }
+    },
+    {
+      "id": "11214484",
+      "type": "sites",
+      "attributes": {
+        "code": "O",
+        "location_name": "Oakthorpe Primary School",
+        "address1": "Tile Kiln Lane",
+        "address2": "",
+        "address3": "",
+        "address4": "",
+        "postcode": "N13 6BY",
+        "region_code": "london",
+        "latitude": 51.6139314,
+        "longitude": -0.0935379,
+        "recruitment_cycle_year": "2020"
+      }
+    },
+    {
+      "id": "14881",
+      "type": "providers",
+      "attributes": {
+        "provider_code": "2FR",
+        "provider_name": "AIM Alliance Schools",
+        "accredited_body?": false,
+        "can_add_more_sites?": true,
+        "accredited_bodies": [
+          {
+            "provider_name": "Middlesex University",
+            "provider_code": "M80",
+            "description": "We have worked with Middlesex University for over 7 years delivering quality teacher training.  We always find the university responsive and supportive with any concerns or issues students have.  We are fortunate that the contacts at the University have remained the same for a number of years and therefore we have developed an excellent track record in working closely with them.  Our Lead Primary Mentor is the Chair of the School Direct Partnership group."
+          },
+          {
+            "provider_name": "University of Hertfordshire",
+            "provider_code": "H36",
+            "description": "Hertfordshire University is a well established provider of quality teacher training.  They provide a strong support network within the University and have long established rigorous selection criteria both for Schools and Alliances entitled to train and candidates who will succeed on their courses.    Coupled with the Mentor network within the Alliance all candidates can be assured of a quality training programme."
+          }
+        ],
+        "train_with_us": "Aim Alliance Schools is a collaborative Alliance of 20 schools made up of both Primary and Secondary Schools. London Academy is the lead school for School Direct within the Alliance.  We train and develop teachers in north London, working in partnership with Middlesex University and Hertfordshire University. \r\n\r\nWe provide experienced mentors within the classroom and Lead Phase mentors provide additional support throughout the year.   We are small (a cohort of 25 this year) but concentrate on quality with 100% pass rate of our cohort last year.   Our schools work closely together in partnership with our universities to ensure you receive  a quality, tailored programme of learning and support.  \r\n\r\nYou can find out lots of information from our Aim Alliance Schools website (https://www.aimallianceschools.org).\r\n\r\n",
+        "train_with_disability": "Aim Alliance Schools is always willing to support applications from candidates with disabilities.  The Alliance will try to accommodate all trainees with disabilities and other needs.  Individual needs will be assessed on application and our lead phase mentors will discuss with individuals how their needs can be supported. ",
+        "latitude": 51.6227881,
+        "longitude": -0.2902603,
+        "address1": "Spur Road",
+        "address2": "",
+        "address3": "Edgware",
+        "address4": "London",
+        "postcode": "HA8 8DE",
+        "region_code": null,
+        "telephone": "0208 238 1100 x252",
+        "email": "a.phillips@londonacademy.org.uk",
+        "website": "www.aimallianceschools.org",
+        "recruitment_cycle_year": "2020",
+        "admin_contact": null,
+        "utt_contact": null,
+        "web_link_contact": null,
+        "fraud_contact": null,
+        "finance_contact": null,
+        "gt12_contact": null,
+        "application_alert_contact": null,
+        "type_of_gt12": "no_response",
+        "send_application_alerts": "all"
+      },
+      "relationships": {
+        "sites": {
+          "meta": {
+            "included": false
+          }
+        },
+        "courses": {
+          "meta": {
+            "count": 64
+          }
+        }
+      }
+    },
+    {
+      "id": "11216222",
+      "type": "sites",
+      "attributes": {
+        "code": "A",
+        "location_name": "London Academy",
+        "address1": "Spur Road",
+        "address2": "Edgware",
+        "address3": "London",
+        "address4": "",
+        "postcode": "HA8 8DE",
+        "region_code": "london",
+        "latitude": 51.6229616,
+        "longitude": -0.289853,
+        "recruitment_cycle_year": "2020"
+      }
+    },
+    {
+      "id": "11216783",
+      "type": "sites",
+      "attributes": {
+        "code": "3",
+        "location_name": "AIM North London",
+        "address1": "34 Turin Road",
+        "address2": "",
+        "address3": "Edmonton",
+        "address4": "London",
+        "postcode": "N9 8DQ",
+        "region_code": "london",
+        "latitude": 51.6349,
+        "longitude": -0.047247,
+        "recruitment_cycle_year": "2020"
+      }
+    },
+    {
+      "id": "11216223",
+      "type": "sites",
+      "attributes": {
+        "code": "B",
+        "location_name": "Mill Hill County High School",
+        "address1": "Worcester Crescent",
+        "address2": "Mill Hill",
+        "address3": "London",
+        "address4": "",
+        "postcode": "NW7 4LL",
+        "region_code": "london",
+        "latitude": 51.6271665,
+        "longitude": -0.2474848,
+        "recruitment_cycle_year": "2020"
+      }
+    }
+  ],
+  "links": {
+    "next": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=51.504524\u0026filter%5Blongitude%5D=-0.0961128\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=provider%2Csites\u0026page%5Bpage%5D=2\u0026page%5Bper_page%5D=10\u0026sort=provider.provider_name%2Cname",
+    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=51.504524\u0026filter%5Blongitude%5D=-0.0961128\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=provider%2Csites\u0026page%5Bpage%5D=420\u0026page%5Bper_page%5D=10\u0026sort=provider.provider_name%2Cname"
+  },
+  "meta": {
+    "count": 4207
+  },
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -16,6 +16,7 @@ module PageObjects
         element :funding_options, '[data-qa="course__funding_options"]'
         element :main_address, '[data-qa="course__main_address"]'
         elements :site_distance_to_location_query, '[data-qa="course__site_distance"]'
+        elements :nearest_address, '[data-qa="course__nearest_address"]'
       end
 
       class SubjectsSection < SitePrism::Section

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -15,6 +15,7 @@ module PageObjects
         element :accrediting_provider, '[data-qa="course__accrediting_provider"]'
         element :funding_options, '[data-qa="course__funding_options"]'
         element :main_address, '[data-qa="course__main_address"]'
+        elements :site_distance_to_location_query, '[data-qa="course__site_distance"]'
       end
 
       class SubjectsSection < SitePrism::Section

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -2,7 +2,7 @@ def results_page_parameters(parameters = {})
   {
     "filter[vacancies]" => "true",
     "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
-    "include" => "provider",
+    "include" => "provider,sites",
     "page[page]" => 1,
     "page[per_page]" => 10,
     "sort" => "provider.provider_name,name",

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -450,4 +450,34 @@ describe ResultsView do
       end
     end
   end
+
+  describe "#site_distance" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    context "greater than 1 mile" do
+      let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+      it "calculates the distance to the closest site, rounding to one decimal place" do
+        course = build(:course, sites: [
+          build(:site, latitude: 51.5079, longitude: 0.0877),
+          build(:site, latitude: 54.9783, longitude: 1.6178),
+        ])
+
+        expect(results_view.site_distance(course)).to eq(2)
+      end
+    end
+
+    context "less than 1 mile" do
+      let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+      it "calculates the distance to the closest site, rounding to one decimal place" do
+        course = build(:course, sites: [
+          build(:site, latitude: 51.4985, longitude: 0.1367),
+          build(:site, latitude: 54.9783, longitude: 1.6178),
+        ])
+
+        expect(results_view.site_distance(course)).to eq(0.1)
+      end
+    end
+  end
 end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -480,4 +480,25 @@ describe ResultsView do
       end
     end
   end
+
+  describe "#nearest_address" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+    let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+    it "returns the address to the nearest site" do
+      course = build(:course, sites: [
+        build(:site,
+              latitude: 51.4985,
+              longitude: 0.1367,
+              address1: "10 Windy Way",
+              address2: "Witham",
+              address3: "Essex",
+              address4: "UK",
+              postcode: "CM8 2SD"),
+        build(:site, latitude: 54.9783, longitude: 1.6178),
+      ])
+
+      expect(results_view.nearest_address(course)).to eq("10 Windy Way, Witham, Essex, UK, CM8 2SD")
+    end
+  end
 end


### PR DESCRIPTION
### Context
When querying courses by location we want course results listings to display the distance to the nearest site and the address of the nearest site.

When displaying the nearest distance the distance is rounded to 0 decimal places if it's less than 1 mile, else it is rounded to 1 decimal place.

### Changes proposed in this pull request
- Nearest site and site distance is displayed of user searches by location
- Main address is not displayed if user searches by location

<img width="764" alt="distance_2" src="https://user-images.githubusercontent.com/5256922/75665645-63def180-5c6c-11ea-9b6e-56da4806357d.png">

### Guidance to review

