### PR TITLE
[3067] Replace chrome/selenium with webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,9 +102,7 @@ group :test do
   # Adds support for Capybara system testing and selenium driver
   gem "capybara", ">= 2.15"
 
-  gem "selenium-webdriver"
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem "chromedriver-helper"
+  gem "webdrivers", "~> 4.0"
 
   # Get us some fake!
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,8 +62,6 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    archive-zip (0.12.0)
-      io-like (~> 0.3.0)
     ast (2.4.0)
     better_errors (2.6.0)
       coderay (>= 1.0.0)
@@ -88,9 +86,6 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
-    chromedriver-helper (2.1.1)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     config (2.2.1)
@@ -171,7 +166,6 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.4)
     json_api_client (1.16.1)
       activemodel (>= 3.2.0)
@@ -321,7 +315,7 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     scss_lint-govuk (0.2.0)
       scss_lint
-    selenium-webdriver (3.142.6)
+    selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     sentry-raven (2.13.0)
@@ -358,6 +352,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (4.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -384,7 +382,6 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (>= 2.15)
-  chromedriver-helper
   config
   draper
   factory_bot_rails
@@ -407,7 +404,6 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   scss_lint-govuk
-  selenium-webdriver
   sentry-raven
   simplecov
   site_prism
@@ -417,6 +413,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webdrivers (~> 4.0)
   webmock
   webpacker
 


### PR DESCRIPTION

### Context
When running tests the following warning was being logged:

`
 WARN Selenium [DEPRECATION] Selenium::WebDriver::Chrome#driver_path= is
deprecated. Use Selenium::WebDriver::Chrome::Service#driver_path= instead.
`

The reason is that chrome-drivers has been deprecated since 2019-03-31.
It is recommended to use `webdrivers` gem (Selenium tests more easily
with automatic installation and updates for all supported webdrivers)

Other references:
stackoverflow.com/questions/55970418/capyabra-selenium-chrome-driver-settings

### Changes proposed in this pull request

### Guidance to review
Replicates this PR https://github.com/DFE-Digital/govuk-rails-boilerplate/pull/197
