### PR TITLE
[3064] - Add distance to sort by

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -23,7 +23,7 @@ module ResultFilters
         return
       end
 
-      form_params = strip(filter_params.clone)
+      form_params = strip(filter_params.clone).merge(sortby: ResultsView::DISTANCE)
       form_object = LocationFilterForm.new(form_params)
       if form_object.valid?
         all_params = form_params.merge!(form_object.params)

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -51,19 +51,14 @@
                   <%= form_with(url: results_path, method: "get", skip_enforcing_utf8: true, class: "govuk-form", data: {qa: "sort-form"}) do |form| %>
                     <%= render 'shared/hidden_fields',
                       form: form,
-                      exclude_keys: [:sortby]
+                      exclude_keys: ["sortby"]
                     %>
 
                     <div class="govuk-form-group">
                       <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-label--inline sortedby-label") %>
                       <%= form.select(
                         :sortby,
-                        options_for_select([
-                            ["Training provider (A-Z)", 0, { "data-qa": "sort-form__options__ascending" }],
-                            ["Training provider (Z-A)", 1, { "data-qa": "sort-form__options__descending" }]
-                          ],
-                          selected: params[:sortby]
-                        ),
+                        options_for_select(@results_view.sort_options, selected: params["sortby"].to_i || 0),
                         {},
                         {
                           class: "govuk-select trigger-result-update sortby-selector",

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -79,7 +79,8 @@ feature "Location filter", type: :feature do
         .with(
           query: base_parameters.merge("filter[longitude]" => "-0.1300436",
                                        "filter[latitude]" => "51.4980188",
-                                       "filter[radius]" => "20"),
+                                       "filter[radius]" => "20",
+                                       "sort" => "distance"),
         )
         .to_return(
           body: File.new("spec/fixtures/api_responses/two_courses_with_sites.json"),
@@ -228,6 +229,40 @@ feature "Location filter", type: :feature do
           "another_option" => "option",
         )
       end
+    end
+  end
+
+  describe "distance sorting" do
+    let(:distance_stub) do
+      stub_request(:get, courses_url)
+        .with(
+          query: base_parameters.merge("filter[longitude]" => "-0.1300436",
+                                       "filter[latitude]" => "51.4980188",
+                                       "filter[radius]" => "20",
+                                       "sort" => "distance"),
+          )
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/two_courses_with_sites.json"),
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
+    end
+
+    before do
+      distance_stub
+
+      filter_page.load
+
+      filter_page.by_postcode_town_or_city.click
+      filter_page.location_query.fill_in(with: "SW1P 3BT")
+      filter_page.find_courses.click
+    end
+
+    it "requests that the backend sorts the data" do
+      expect(distance_stub).to have_been_requested
+    end
+
+    it "is automatically selected" do
+      expect(results_page.sort_form.options.distance).to be_selected
     end
   end
 

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -70,6 +70,7 @@ module PageObjects
         section :options, '[data-qa="sort-form__options"]' do
           element :ascending, '[data-qa="sort-form__options__ascending"]'
           element :descending, '[data-qa="sort-form__options__descending"]'
+          element :distance, '[data-qa="sort-form__options__distance"]'
         end
         element :submit, '[data-qa="sort-form__submit"]'
       end

--- a/spec/site_prism/page_objects/page/start.rb
+++ b/spec/site_prism/page_objects/page/start.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module Page
+    class Start < PageObjects::Page::ResultFilters::Location
+      set_url "/"
+    end
+  end
+end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -501,4 +501,31 @@ describe ResultsView do
       expect(results_view.nearest_address(course)).to eq("10 Windy Way, Witham, Essex, UK, CM8 2SD")
     end
   end
+
+  describe "#sort_options" do
+    context "location query" do
+      subject { described_class.new(query_parameters: { "l" => "1" }).sort_options }
+      it {
+        is_expected.to eq(
+          [
+            ["Training provider (A-Z)", 0, { "data-qa": "sort-form__options__ascending" }],
+            ["Training provider (Z-A)", 1, { "data-qa": "sort-form__options__descending" }],
+            ["Distance", 2, { "data-qa": "sort-form__options__distance" }],
+          ],
+        )
+      }
+    end
+
+    context "all other queries" do
+      subject { described_class.new(query_parameters: {}).sort_options }
+      it {
+        is_expected.to eq(
+          [
+            ["Training provider (A-Z)", 0, { "data-qa": "sort-form__options__ascending" }],
+            ["Training provider (Z-A)", 1, { "data-qa": "sort-form__options__descending" }],
+          ],
+        )
+      }
+    end
+  end
 end


### PR DESCRIPTION
### Context

This PR adds a new 'distance' sort by option on the results page

- Distance sort by option only appears if user is searching by location
- Selecting sort by distance returns results ordered by distance to closest site

### Changes proposed in this pull request

- in addition to the above this pr also fixes a bug whereby sort params were being appended to the url rather than mutated

### Guidance to review
- Visit `/location/filter/results` and run a location query (option 1). Once you are on the results page you should see results are automatically sorted by distance. Select other sort options from the drop down and watch the magic show that appears before your eyes.

