### PR TITLE
[3070] - fix user journey when using the wizard

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -13,7 +13,7 @@ module ResultFilters
     def create
       # if searching for specific provider go to results page
       if provider_option_selected?
-        redirect_to(provider_path(params_for_provider_search))
+        redirect_to(provider_path(get_params_for_selected_option({})))
         return
       end
 
@@ -21,14 +21,7 @@ module ResultFilters
       form_object = LocationFilterForm.new(form_params)
       if form_object.valid?
         all_params = form_params.merge!(form_object.params)
-
-        if location_option_selected?
-          submitted_params = params_for_location_search(all_params)
-        elsif across_england_option_selected?
-          submitted_params = params_for_across_england_search(all_params)
-        end
-
-        redirect_to(next_step(submitted_params))
+        redirect_to(next_step(all_params))
       else
         flash[:error] = form_object.errors
         back_to_current_page_if_error(form_params)
@@ -54,23 +47,22 @@ module ResultFilters
       filter_params[:l] == "3"
     end
 
-    def params_for_location_search(params)
-      params.except(:query)
-    end
-
-    def params_for_across_england_search(params)
-      params.except(:lat, :lng, :rad, :loc, :lq, :query, :sortby)
-    end
-
-    def params_for_provider_search
-      filter_params.except(:lat, :lng, :rad, :loc, :lq)
+    def get_params_for_selected_option(all_params)
+      if location_option_selected?
+        all_params.except(:query)
+      elsif across_england_option_selected?
+        all_params.except(:lat, :lng, :rad, :loc, :lq, :query, :sortby)
+      elsif provider_option_selected?
+        filter_params.except(:lat, :lng, :rad, :loc, :lq)
+      end
     end
 
     def strip(params)
       params.reject { |_, v| v == "" }
     end
 
-    def next_step(submitted_params)
+    def next_step(all_params)
+      submitted_params = get_params_for_selected_option(all_params)
       if flash[:start_wizard]
         start_subject_path(submitted_params)
       else

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -11,15 +11,9 @@ module ResultFilters
     end
 
     def create
+      # if searching for specific provider go to results page
       if provider_option_selected?
         redirect_to(provider_path(params_for_provider_search))
-        return
-      elsif across_england_option_selected?
-        if flash[:start_wizard]
-          redirect_to(start_subject_path(params_for_across_england_search))
-        else
-          redirect_to(results_path(params_for_across_england_search))
-        end
         return
       end
 
@@ -27,14 +21,17 @@ module ResultFilters
       form_object = LocationFilterForm.new(form_params)
       if form_object.valid?
         all_params = form_params.merge!(form_object.params)
-        redirect_to results_path(all_params)
+
+        if location_option_selected?
+          submitted_params = params_for_location_search(all_params)
+        elsif across_england_option_selected?
+          submitted_params = params_for_across_england_search(all_params)
+        end
+
+        redirect_to(next_step(submitted_params))
       else
         flash[:error] = form_object.errors
-        if flash[:start_wizard]
-          redirect_to root_path(form_params)
-        else
-          redirect_to location_path(form_params)
-        end
+        back_to_current_page_if_error(form_params)
       end
     end
 
@@ -45,6 +42,10 @@ module ResultFilters
         .query_parameters_with_defaults
     end
 
+    def location_option_selected?
+      filter_params[:l] == "1"
+    end
+
     def across_england_option_selected?
       filter_params[:l] == "2"
     end
@@ -53,16 +54,36 @@ module ResultFilters
       filter_params[:l] == "3"
     end
 
+    def params_for_location_search(params)
+      params.except(:query)
+    end
+
+    def params_for_across_england_search(params)
+      params.except(:lat, :lng, :rad, :loc, :lq, :query, :sortby)
+    end
+
     def params_for_provider_search
       filter_params.except(:lat, :lng, :rad, :loc, :lq)
     end
 
-    def params_for_across_england_search
-      filter_params.except(:lat, :lng, :rad, :loc, :lq, :query)
-    end
-
     def strip(params)
       params.reject { |_, v| v == "" }
+    end
+
+    def next_step(submitted_params)
+      if flash[:start_wizard]
+        start_subject_path(submitted_params)
+      else
+        results_path(submitted_params)
+      end
+    end
+
+    def back_to_current_page_if_error(form_params)
+      if flash[:start_wizard]
+        redirect_to root_path(form_params)
+      else
+        redirect_to location_path(form_params)
+      end
     end
   end
 end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "Location filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
+  let(:start_page) { PageObjects::Page::Start.new }
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
@@ -104,6 +105,21 @@ feature "Location filter", type: :feature do
       expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
       expect(results_page.location_filter.map).to be_present
       expect(results_page.courses.count).to eq(2)
+    end
+
+    describe "when using the wizard" do
+      it "progresses to next step instead of going straight to results" do
+        start_page.load
+        start_page.by_postcode_town_or_city.click
+        start_page.location_query.fill_in(with: "SW1P 3BT")
+        start_page.find_courses.click
+
+        URI(current_url).then do |uri|
+          expect(uri.path).to eq("/start/subject")
+          expect(uri.query)
+            .to eq("l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=20&sortby=2")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

This fixes a bug where users starting out from the start page
(i.e location page) would be taken straight to the results page if they
search by postcode,town or city. The preferred route was supposed to be
that all location-based search (i.e "search by postcode, town or city"
or "Across the whole of England") should always take the user to the
subjects page to select specific subjects they are interested in.

Provider searches, on the other hand, should take users straight to the
results page.

As the location page (ie "Start page") has a dual purpose if the user
has already searched for some courses but decided to edit the location
then they should not have to go back to the subject page before returning
to the results page.

I found LocationController create method very hard to read because of
all the redirecting and various params being passed around. I understand
that the reason the params are so complicated is that we have to support
a c# version of the service. We should look to review this in more detail
once we are using rails completely.

I made a start at refactoring the method to attempt to make it easier to
read and understand by moving some of the logic out into private methods.

### Changes proposed in this pull request


### Guidance to review

