### PR TITLE
[3066] Sitemap is now unpaginated

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,8 +1,10 @@
 class SitemapsController < ApplicationController
   def show
     @courses = Course
-      .includes(:provider)
       .where(recruitment_cycle_year: Settings.current_cycle)
+      .select("course_code", "provider_code", "changed_at")
+      .page(1)
+      .per(20000)
       .all
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,6 +10,7 @@ class Course < Base
   property :maths, type: :string
   property :english, type: :string
   property :science, type: :string
+  property :changed_at, type: :time
 
   self.primary_key = :course_code
 

--- a/app/views/sitemaps/show.xml.builder
+++ b/app/views/sitemaps/show.xml.builder
@@ -11,7 +11,7 @@ xml.urlset "xmlns" => "http://www.google.com/schemas/sitemap/0.9", "xmlns:xhtml"
   @courses.each do |course|
     xml.url do
       xml.loc course_url(course.provider_code, course.course_code)
-      xml.lastmod course.last_published_at.to_date.strftime("%Y-%m-%d")
+      xml.lastmod course.changed_at.to_date.strftime("%Y-%m-%d")
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -54,6 +54,7 @@ FactoryBot.define do
     meta { nil }
     age_range_in_years { "11_to_16" }
     program_type { "pg_teaching_apprenticeship" }
+    changed_at { Time.zone.now }
 
     after :build do |course, evaluator|
       # Necessary gubbins necessary to make JSONAPIClient's associations work.

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -3,12 +3,14 @@ require "rails_helper"
 describe "/sitemap.xml", type: :request do
   let(:provider) { build(:provider, provider_code: "T92") }
   let(:current_recruitment_cycle) { build :recruitment_cycle }
+  let(:changed_at) { Time.zone.now }
   let(:course) do
     build(:course,
           course_code: "X102",
           provider: provider,
           provider_code: provider.provider_code,
-          recruitment_cycle: current_recruitment_cycle)
+          recruitment_cycle: current_recruitment_cycle,
+          changed_at: changed_at)
   end
 
   before do
@@ -25,8 +27,14 @@ describe "/sitemap.xml", type: :request do
       params: {
         recruitment_cycle_year: Settings.current_cycle,
       },
+      pagination: {
+        page: 1,
+        per_page: 20_000,
+      },
       resources: course,
-      include: %w[provider],
+      fields: {
+        courses: %w[course_code provider_code changed_at],
+      },
     )
 
     get "/sitemap.xml"
@@ -46,7 +54,7 @@ describe "/sitemap.xml", type: :request do
           </url>
           <url>
             <loc>http://www.example.com/course/T92/X102</loc>
-            <lastmod>2019-01-01</lastmod>
+            <lastmod>#{changed_at.to_date.strftime('%Y-%m-%d')}</lastmod>
           </url>
         </urlset>
       XML


### PR DESCRIPTION
### Context

- https://trello.com/c/9oyEkcDp/3066-s-update-find-sitemapcontroller-to-call-the-api-with-the-correct-parameters-to-disable-pagination
- Previously only a subset of courses would show for sitemap as api call was paginated
- This makes the api call with very large pagination window to return full dataset
- This api endpoint has been optimised to only return the data needed to generate the sitemap 

### Changes proposed in this pull request

- Make call to optimised endpoint for unpaginated courses
- Changed `last_published_at` to `changed_at`

### Guidance to review

- `curl http://localhost:3002/sitemap.xml`
- this will make api call and only return needed data
- should return full dataset
- should take under 10 seconds