### PR TITLE
[3095] Fix accrediting body in results

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -95,9 +95,9 @@
               <% end %>
               <dt class="govuk-list--description__label">Financial support</dt>
               <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
-              <% if course.accrediting_provider.present? %>
+              <% if course['accrediting_provider'].present? %>
                 <dt>Accredited body</dt>
-                <dd data-qa="course__accrediting_provider"><%= course.accrediting_provider.provider_name %></dd>
+                <dd data-qa="course__accrediting_provider"><%= course['accrediting_provider']['provider_name'] %></dd>
               <% end %>
               <% unless @results_view.location_filter?  %>
                 <dt class="govuk-list--description__label">Main address</dt>

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -55,7 +55,7 @@ feature "Search results", type: :feature do
         expect(first_course.name.text).to eq("Mathematics (2VMB)")
         expect(first_course.provider_name.text).to eq("South East Learning Alliance")
         expect(first_course.description.text).to eq("QTS full time with salary")
-        expect(first_course).not_to have_accrediting_provider
+        expect(first_course.accrediting_provider.text).to eq("e-Qualitas")
         expect(first_course.funding_options.text).to eq("Salary")
         expect(first_course.main_address.text).to eq("South East Learning Alliance, Riddlesdown Collegiate, Purley, South Croydon, Surrey, CR8 1EX")
       end
@@ -65,7 +65,7 @@ feature "Search results", type: :feature do
         expect(second_course.provider_name.text).to eq("Delta Teaching School Alliance")
         expect(second_course.description.text).to eq("PGCE with QTS full time with salary")
         expect(second_course.funding_options.text).to eq("Salary")
-        expect(second_course).not_to have_accrediting_provider
+        expect(second_course.accrediting_provider.text).to eq("Sheffield Hallam University")
         expect(second_course.main_address.text).to eq("Education House, Spawd Bone Lane, Knottingley, West Yorkshire, WF11 0EP")
       end
     end


### PR DESCRIPTION
### Context
The accrediting body on not rendered on the results listing

### Changes proposed in this pull request
Fix accrediting body 

### Guidance to review
/results

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### After
![localhost_3002_results_fulltime=False hasvacancies=True l=3 parttime=False qualifications=QtsOnly%2CPgdePgceWithQts%2COther query=BHSSA senCourses=false subjects=24(iPad Pro)](https://user-images.githubusercontent.com/3071606/76028241-155e7b00-5f2a-11ea-80b3-2a730b688c46.png)