### PR TITLE
[3085] Fix funding option on results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -128,7 +128,7 @@ class ResultsView
   def courses
     @courses ||= begin
                    base_query = Course
-                     .includes(:provider).includes(:sites)
+                     .includes(:provider).includes(:sites).includes(:subjects)
                      .where(recruitment_cycle_year: Settings.current_cycle)
 
                    base_query = base_query.where(funding: "salary") if with_salaries?

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -2,7 +2,7 @@ def results_page_parameters(parameters = {})
   {
     "filter[vacancies]" => "true",
     "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
-    "include" => "provider,sites",
+    "include" => "provider,sites,subjects",
     "page[page]" => 1,
     "page[per_page]" => 10,
     "sort" => "provider.provider_name,name",


### PR DESCRIPTION
### Context
The funding option was incorrect on the results by always showing "Student finance if you’re eligible" because we weren't including `subjects` in the API response so each of the `has_scholarship_and_bursary?` and `has_bursary?` was returning false

### Changes proposed in this pull request
Include `subjects` in the API response

### Guidance to review
/results

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### After
![localhost_3002_results_fulltime=False hasvacancies=True l=3 parttime=False qualifications=QtsOnly query=BHSSA senCourses=false subjects=24(iPad Pro)](https://user-images.githubusercontent.com/3071606/76031792-535e9d80-5f30-11ea-8000-569a40352966.png)

