### PR TITLE
[3092]  Show vacancies info when on results page

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -115,6 +115,10 @@ class CourseDecorator < Draper::Decorator
     "#{name} (#{course_code})"
   end
 
+  def has_vacancies?
+    object.has_vacancies? ? "Yes" : "No"
+  end
+
 private
 
   def find_max(attribute)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -108,6 +108,10 @@ class ResultsView
     query_parameters["l"] == "3"
   end
 
+  def vacancy_filter?
+    query_parameters["hasvacancies"] == "False"
+  end
+
   def sort_by_distance?
     sort_by == DISTANCE
   end

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -105,6 +105,12 @@
                   <%= course.provider.decorate.short_address %>
                 </dd>
               <% end %>
+              <% if @results_view.vacancy_filter?  %>
+                <dt class="govuk-list--description__label">Vacancies</dt>
+                <dd data-qa="course__has_vacancies">
+                  <%= course.decorate.has_vacancies? %>
+                </dd>
+              <% end %>
             </dl>
           </li>
         <% end %>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -27,7 +27,8 @@ describe CourseDecorator do
           subjects: subjects,
           open_for_applications?: true,
           last_published_at: "2019-03-05T14:42:34Z",
-          recruitment_cycle: current_recruitment_cycle
+          recruitment_cycle: current_recruitment_cycle,
+          has_vacancies?: true
   end
   let(:start_date) { Time.zone.local(2019) }
   let(:site) { build(:site) }
@@ -387,6 +388,12 @@ describe CourseDecorator do
   describe "#display_title" do
     it "returns the course name with the course code" do
       expect(decorated_course.display_title).to eq("Mathematics (A1)")
+    end
+  end
+
+  describe "has_vacancies?" do
+    it "returns if the course has vacancies" do
+      expect(decorated_course.has_vacancies?).to eq("Yes")
     end
   end
 end

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -58,6 +58,7 @@ feature "Search results", type: :feature do
         expect(first_course.accrediting_provider.text).to eq("e-Qualitas")
         expect(first_course.funding_options.text).to eq("Salary")
         expect(first_course.main_address.text).to eq("South East Learning Alliance, Riddlesdown Collegiate, Purley, South Croydon, Surrey, CR8 1EX")
+        expect(first_course).not_to have_show_vacanices
       end
 
       results_page.courses.second.then do |second_course|
@@ -67,6 +68,7 @@ feature "Search results", type: :feature do
         expect(second_course.funding_options.text).to eq("Salary")
         expect(second_course.accrediting_provider.text).to eq("Sheffield Hallam University")
         expect(second_course.main_address.text).to eq("Education House, Spawd Bone Lane, Knottingley, West Yorkshire, WF11 0EP")
+        expect(second_course).not_to have_show_vacanices
       end
     end
   end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -17,6 +17,7 @@ module PageObjects
         element :main_address, '[data-qa="course__main_address"]'
         elements :site_distance_to_location_query, '[data-qa="course__site_distance"]'
         elements :nearest_address, '[data-qa="course__nearest_address"]'
+        elements :show_vacanices, '[data-qa="course__has_vacancies"]'
       end
 
       class SubjectsSection < SitePrism::Section

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -386,6 +386,22 @@ describe ResultsView do
     end
   end
 
+  describe "#vacancy_filter?" do
+    subject { described_class.new(query_parameters: parameter_hash).vacancy_filter? }
+
+    context "when hasvacancies param is set to True" do
+      let(:parameter_hash) { { "hasvacancies" => "True" } }
+
+      it { is_expected.to be(false) }
+    end
+
+    context "when hasvacancies param is set to False" do
+      let(:parameter_hash) { { "hasvacancies" => "False" } }
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe "#course_count" do
     subject { described_class.new(query_parameters: {}).course_count }
 


### PR DESCRIPTION
### Context
When a candidate filters by courses with and without vacancies we should be showing that information for  each course

### Changes proposed in this pull request
Display vacancy info based on the vacancies filter in the params i.e. `hasvacancies=False`

### Guidance to review
Example - `/results?fulltime=False&hasvacancies=False&l=3&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&query=Berkshire+Teaching+Alliance&senCourses=False`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

### After
![localhost_3002_results_fulltime=False hasvacancies=False l=3 parttime=False qualifications=QtsOnly%2CPgdePgceWithQts%2COther query=Berkshire+Teaching+Alliance senCourses=False(iPad Pro)](https://user-images.githubusercontent.com/3071606/76064199-1969b780-5f81-11ea-85a7-34934ecc68d4.png)

