### PR TITLE
[3009] Fixed qualification filter due to mismatch

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -138,7 +138,8 @@ class ResultsView
                    base_query = base_query.where(funding: "salary") if with_salaries?
                    base_query = base_query.where(vacancies: hasvacancies?)
                    base_query = base_query.where(study_type: study_type) if study_type.present?
-                   base_query = base_query.where(qualifications: qualifications)
+
+                   base_query = base_query.where(qualification: qualification.join(",")) unless all_qualifications?
                    base_query = base_query.where(subjects: subject_codes.join(",")) if subject_codes.any?
                    base_query = base_query.where(send_courses: true) if send_courses?
 
@@ -205,6 +206,14 @@ class ResultsView
   end
 
 private
+
+  def qualification
+    qualification = []
+    qualification |= %w[qts] if qts_only?
+    qualification |= %w[pgce_with_qts pgde_with_qts] if pgce_or_pgde_with_qts?
+    qualification |= %w[pgce pgde] if other_qualifications?
+    qualification
+  end
 
   def lat_long
     Geokit::LatLng.new(latitude.to_f, longitude.to_f)

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -110,7 +110,7 @@ feature "Qualifications filter", type: :feature do
     context "deselecting courses with 'qts only' qualification" do
       before do
         stub_request(:get, courses_url)
-          .with(query: base_parameters.merge("filter[qualifications]" => "PgdePgceWithQts,Other"))
+          .with(query: base_parameters.merge("filter[qualification]" => "pgce_with_qts,pgde_with_qts,pgce,pgde"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -137,7 +137,7 @@ feature "Qualifications filter", type: :feature do
     context "deselecting courses that with 'pgde with qts' qualification" do
       before do
         stub_request(:get, courses_url)
-          .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,Other"))
+          .with(query: base_parameters.merge("filter[qualification]" => "qts,pgce,pgde"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -164,7 +164,7 @@ feature "Qualifications filter", type: :feature do
     context "deselecting courses with 'further education' qualification" do
       before do
         stub_request(:get, courses_url)
-          .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts"))
+          .with(query: base_parameters.merge("filter[qualification]" => "qts,pgce_with_qts,pgde_with_qts"))
           .to_return(
             body: File.new("spec/fixtures/api_responses/courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -215,7 +215,7 @@ feature "Qualifications filter", type: :feature do
       )
 
       stub_request(:get, courses_url)
-        .with(query: base_parameters.merge("filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other"))
+        .with(query: base_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -1,7 +1,6 @@
 def results_page_parameters(parameters = {})
   {
     "filter[vacancies]" => "true",
-    "filter[qualifications]" => "QtsOnly,PgdePgceWithQts,Other",
     "include" => "provider,sites,subjects",
     "page[page]" => 1,
     "page[per_page]" => 10,


### PR DESCRIPTION
### Context
qualification filter due to mismatch

### Changes proposed in this pull request
 Fixed qualification filter due to mismatch

`qualifications` vs `qualification`
`QtsOnly` vs `qts`
`PgdePgceWithQts` vs `pgce_with_qts,pgde_with_qts`
`Other` vs `pgce,pgde`

The key & value sent to the `api` was just wrong

### Guidance to review
Fiddle the qualification filter and look at the rails page
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
