### PR TITLE
3088 logit integration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,12 @@ gem "draper"
 # http client
 gem "httparty"
 
+# Offshore logging
+gem "logstash-logger"
+
+# Semantic Logger makes logs pretty
+gem "rails_semantic_logger"
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.0.2"
 

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem "rails_semantic_logger"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 6.0.2"
 
+# Thread-safe global state
+gem "request_store"
+
 # Use Puma as the app server
 gem "puma", "~> 4.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,9 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logstash-event (1.2.02)
+    logstash-logger (0.26.1)
+      logstash-event (~> 1.2)
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -254,6 +257,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_semantic_logger (4.4.3)
+      rack
+      railties (>= 3.2)
+      semantic_logger (~> 4.4)
     railties (6.0.2.1)
       actionpack (= 6.0.2.1)
       activesupport (= 6.0.2.1)
@@ -321,6 +328,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    semantic_logger (4.6.0)
+      concurrent-ruby (~> 1.0)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.18.5)
@@ -400,9 +409,11 @@ DEPENDENCIES
   kaminari
   launchy
   listen (>= 3.0.5, < 3.3)
+  logstash-logger
   pry-byebug
   puma (~> 4.3)
   rails (~> 6.0.2)
+  rails_semantic_logger
   redcarpet
   rspec-rails (~> 4.0.0.beta4)
   rspec_junit_formatter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -415,6 +415,7 @@ DEPENDENCIES
   rails (~> 6.0.2)
   rails_semantic_logger
   redcarpet
+  request_store
   rspec-rails (~> 4.0.0.beta4)
   rspec_junit_formatter
   rubocop-govuk

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,19 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :store_request_id
+
+  def store_request_id
+    RequestStore.store[:request_id] = request.uuid
+  end
+
+  def assign_sentry_contexts
+    Raven.extra_context(request_id: RequestStore.store[:request_id])
+  end
+
+  def append_info_to_payload(payload)
+    super
+
+    payload[:request_id] = RequestStore.store[:request_id]
+  end
 end

--- a/app/controllers/application_controller_spec.rb
+++ b/app/controllers/application_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe ApplicationController, type: :controller do
+  let(:request_uuid) { SecureRandom.uuid }
+
+  before do
+    allow(request).to receive(:uuid).and_return(request_uuid)
+  end
+
+  describe "#store_request_id" do
+    it "stores the request id" do
+      allow(RequestStore).to receive(:store).and_return({})
+
+      controller.__send__(:store_request_id)
+
+      expect(RequestStore.store).to eq(request_id: request_uuid)
+    end
+  end
+
+  describe "#append_info_to_payload" do
+    it "sets the request_id in the payload to the request uuid" do
+      payload = {}
+
+      allow(RequestStore).to receive(:store).and_return({ request_id: request_uuid })
+
+      controller.__send__(:append_info_to_payload, payload)
+
+      expect(payload[:request_id]).to eq request_uuid
+    end
+  end
+end

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -1,6 +1,18 @@
 class Base < JsonApiClient::Resource
   include Draper::Decoratable
 
+  def run(request_method, path, params: nil, headers: {}, body: nil)
+    super(
+      request_method,
+      path,
+      params: params,
+      headers: headers.update(
+        "X-Request-Id" => RequestStore.store[:request_id],
+        ),
+      body: body
+    )
+  end
+
   self.site = "#{Settings.teacher_training_api.base_url}/api/v3/"
   self.paginator = JsonApiClient::Paginating::NestedParamPaginator
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,4 +50,9 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # logging
+  config.log_level = Settings.log_level
+
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,16 +60,14 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # Logging
+  config.log_tags = [:request_id] # Prepend all log lines with the following tags.
+  config.log_level = Settings.log_level
 
-  # Use a different logger for distributed setups.
-  # require 'syslog/logger'
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+  if Settings.logstash.host && Settings.logstash.port
+    config.logger = LogStashLogger.new(Settings.logstash.to_h)
+  else
+    config.logger = ActiveSupport::Logger.new(STDOUT)
+    config.logger.warn("logstash not configured, falling back to standard Rails logging")
   end
 end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,0 +1,6 @@
+LogStashLogger.configure do |config|
+  config.customize_event do |event|
+    event["application"] = Settings.application_name
+    event["environment"] = Rails.env
+  end
+end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,0 +1,18 @@
+if Settings.logstash.host && Settings.logstash.port
+  logstash_formatter = Proc.new do |event|
+    # The value here appears to break logging to logstash / elasticsearch
+    event["duration"] = event["duration_ms"]
+    event["duration_ms"] = nil
+
+    # For some reason logstash / elasticsearch drops events where the payload
+    # is a hash. These are more conveniently accessed at the top level of the
+    # event, anyway, so we move it there.
+    if event["payload"].present?
+      event.append(event["payload"])
+      event["payload"] = nil
+    end
+  end
+
+  log_stash = LogStashLogger.new(Settings.logstash.to_h.merge(customize_event: logstash_formatter))
+  SemanticLogger.add_appender(logger: log_stash, level: :info, formatter: :json)
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,4 @@
+application_name: find-teacher-training
 teacher_training_api:
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
@@ -11,3 +12,9 @@ google:
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 redirect_results_to_c_sharp: true
+logstash:
+  type: tcp
+  host: # Our hostname here
+  port: # Our port here
+  ssl_enable: true
+log_level: info

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -5,3 +5,4 @@ search_and_compare_ui:
   base_url: http://localhost:5000
 valid_referers:
   - http://localhost:5000
+log_level: debug

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -21,7 +21,7 @@ describe ApplicationController, type: :controller do
     it "sets the request_id in the payload to the request uuid" do
       payload = {}
 
-      allow(RequestStore).to receive(:store).and_return({ request_id: request_uuid })
+      allow(RequestStore).to receive(:store).and_return(request_id: request_uuid)
 
       controller.__send__(:append_info_to_payload, payload)
 


### PR DESCRIPTION
### Context
We want to make events log-able and easy to find on Kibana

### Changes proposed in this pull request
- Adds `logstash logger` and `rails semantic logger` and configures per environment
- request id logged and sent to V3 API
- Setup 'borrowed' from Publish Teacher Training repo

### Find Teacher Training logs
Note request id logged

<img width="1269" alt="log_log_log" src="https://user-images.githubusercontent.com/5256922/76323184-49e08700-62dc-11ea-87e3-7975eef7d000.png">

Azure config appears to be in place already - https://github.com/DFE-Digital/find-teacher-training/blob/4eb3936c82ad1a12a9be0a61430f01d7f08f528c/azure/template.json#L117

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
