### PR TITLE
[3110] Correct error page styling

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,8 @@
 module ViewHelper
+  def govuk_mail_to(email, name = nil, html_options = {}, &block)
+    mail_to(email, name, html_options.merge(class: "govuk-link"), &block)
+  end
+
   def govuk_link_to(body, url = body, html_options = { class: "govuk-link" })
     link_to body, url, html_options
   end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,16 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<%= content_for :page_title, "Sorry, something went wrong" %>
+
+<div class="govuk-width-container">
   <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-xl">Sorry, something went wrong</h1>
+    </div>
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We're sorry, but something went wrong.</h1>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
+      <p class="govuk-body">Sorry, we're experiencing technical difficulties.</p>
+      <p class="govuk-body">
+        <%= govuk_mail_to(Settings.service_support.contact_email_address, "Contact the Becoming a Teacher team")%>
+        if you continue to see this error.
+      </p>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,9 +1,14 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<%= content_for :page_title, "Page not found" %>
+
+<div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">The page you were looking for doesn't exist.</h1>
-      <p class="govuk-body">You may have mistyped the address or the page may have moved.</p>
-      <p class="govuk-body">If you are the application owner check the logs for more information.</p>
+      <h1 class="govuk-heading-xl">Page not found</h1>
+      <p class="govuk-body">If you entered a web address please check it was correct.</p>
+      <p class="govuk-body">
+        <%= govuk_mail_to(Settings.service_support.contact_email_address, "Contact the Becoming a Teacher team")%>
+        if you believe you are seeing this message in error.
+      </p>
     </div>
   </div>
-</main>
+</div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,4 +1,6 @@
-<main role="main" class="govuk-main-wrapper" id="main-content">
+<%= content_for :page_title, "The change you wanted was rejected" %>
+
+<div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">The change you wanted was rejected.</h1>
@@ -6,4 +8,4 @@
       <p class="govuk-body">If you are the application owner check the logs for more information.</p>
     </div>
   </div>
-</main>
+</div>


### PR DESCRIPTION
### Context
The error page did not have the correct styling or content, it should have looked like: https://www.find-postgraduate-teacher-training.service.gov.uk/xxx

### Changes proposed in this pull request
Correct the styling

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
