### PR TITLE
[3109] Fix inability to de-select SEND subject

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: "shared/error_message", locals: { error_anchor_id: "subject1" } %>
 
     <%= form_with(url: subject_path, method: :post, data: { "ga-event-form" => "Subject" }) do |f| %>
-      <%= render "shared/hidden_fields", exclude_keys: ["subjects"], form: f %>
+      <%= render "shared/hidden_fields", exclude_keys: %w(subjects senCourses), form: f %>
       <h1 class="govuk-heading-xl" data-qa="heading">Find courses by subject</h1>
 
       <p class="govuk-body">Select the subjects you want to teach.</p>

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -317,6 +317,32 @@ feature "Subject filter", type: :feature do
       filter_page.load(query: { senCourses: "True" })
       expect(filter_page.send_area.subjects.first.checkbox).to be_checked
     end
+
+    it "lets you unselect SEND and other subjects" do
+      stub_request(:get, courses_url)
+          .with(query: base_parameters.merge(
+            "filter[subjects]" => "01",
+              ))
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/ten_courses.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+              )
+      filter_page.load(query: { subjects: "31", senCourses: "true" })
+      filter_page.subject_areas.first.subjects[0].checkbox.click # unselect
+      filter_page.subject_areas.first.subjects[1].checkbox.click # select a different one
+      filter_page.send_area.subjects.first.checkbox.click # unselect
+
+      filter_page.continue.click
+
+      expect(results_page.subjects_filter).not_to have_send_courses
+      expect(results_page.subjects_filter.subjects.map(&:text))
+          .to eq(
+            [
+                "Primary with English",
+            ],
+                  )
+      expect(results_page.subjects_filter).not_to have_extra_subjects
+    end
   end
 
   context "with existing parameters" do


### PR DESCRIPTION
### Context

*repro steps*

* selected send from subject list
* visit results page
* then deselect send from subject list
* SEND filter should be removed but was not

https://youtu.be/LAc9KnCSxyU

### Changes proposed in this pull request

[3109] Fix inability to de-select SEND subject

### Guidance to review

:eyes:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review