### PR TITLE
[3115] Ignore un-geocoded sites for nearest site

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -1,4 +1,5 @@
 require "geokit"
+
 class ResultsView
   include CsharpRailsSubjectConversionHelper
   include ActionView::Helpers::NumberHelper
@@ -155,8 +156,9 @@ class ResultsView
   end
 
   def site_distance(course)
-    distances = new_or_running_sites_for(course).
-      map { |site| lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}") }
+    distances = new_or_running_sites_for(course).map do |site|
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
+    end
 
     min_distance = distances.min
 
@@ -168,8 +170,9 @@ class ResultsView
   end
 
   def nearest_address(course)
-    nearest_address = new_or_running_sites_for(course).
-      min_by { |site| lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}") }
+    nearest_address = new_or_running_sites_for(course).min_by do |site|
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
+    end
 
     [
       nearest_address.address1,
@@ -234,7 +237,7 @@ private
   end
 
   def new_or_running_sites_for(course)
-    course.
+    sites = course.
       site_statuses.
       select(&:new_or_running?).
       map(&:site).
@@ -243,6 +246,10 @@ private
       # when calculating '#nearest_address' or '#site_distance'
         [site.address1, site.address2, site.address3, site.address4, site.postcode].all?(&:blank?)
       end
+
+    sites.reject do |site|
+      site.latitude.blank? || site.longitude.blank?
+    end
   end
 
   def lat_long

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -607,6 +607,7 @@ describe ResultsView do
   describe "#nearest_address" do
     let(:results_view) { described_class.new(query_parameters: parameter_hash) }
     let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+    let(:geocoder) { double("geocoder") }
 
     it "returns the address to the nearest site" do
       site1 = build(:site,
@@ -618,11 +619,24 @@ describe ResultsView do
                     address4: "UK",
                     postcode: "CM8 2SD")
       site2 = build(:site, latitude: 54.9783, longitude: 1.6178)
+      site3 = build(:site,
+                    latitude: nil,
+                    longitude: nil,
+                    address1: "10 Windy Way",
+                    address2: "Witham",
+                    address3: "Essex",
+                    address4: "UK",
+                    postcode: "CM8 2SD")
 
       course = build(:course, site_statuses: [
         build(:site_status, :full_time_and_part_time, site: site1),
         build(:site_status, :full_time_and_part_time, site: site2),
+        build(:site_status, :full_time_and_part_time, site: site3),
       ])
+
+      allow(Geokit::LatLng).to receive(:new).and_return(geocoder)
+      allow(geocoder).to receive(:distance_to).with("51.4985,0.1367")
+      allow(geocoder).to receive(:distance_to).with(",").and_raise(Geokit::Geocoders::GeocodeError)
 
       expect(results_view.nearest_address(course)).to eq("10 Windy Way, Witham, Essex, UK, CM8 2SD")
     end


### PR DESCRIPTION
### Context

- Backend returns all sites including un-geocoded sites for courses
- When calculating nearest site if there is no lat/lng provided it throws an exception

### Changes proposed in this pull request

- When working out nearest site for a course
- Ignore any sites that are not geocoded
- These are sites that do not have lat/lng
- Otherwise an exception is thrown

### Guidance to review

- visit http://localhost:3002/results?fulltime=False&hasvacancies=True&l=1&lat=53.9588365&lng=-1.0794777&loc=York+YO1%2C+UK&lq=York+YO1%2C+UK&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&rad=20&senCourses=False&sortby=2&subjects=31%2C32
- No exception should be thrown and can see results page
- Ordering will be incorrect but will be fixed later by https://github.com/DFE-Digital/teacher-training-api/pull/1240

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
