### PR TITLE
[3120] - Bugfix: Strip out non-ASCII characters

### DIFF
--- a/app/controllers/concerns/query_sanitizer.rb
+++ b/app/controllers/concerns/query_sanitizer.rb
@@ -1,0 +1,5 @@
+module QuerySanitizer
+  def strip_non_ascii(query)
+    query.encode("ASCII", invalid: :replace, undef: :replace, replace: "")
+  end
+end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -1,6 +1,7 @@
 module ResultFilters
   class ProviderController < ApplicationController
     include FilterParameters
+    include QuerySanitizer
 
     def new
       if params[:query].blank?
@@ -11,22 +12,27 @@ module ResultFilters
       @provider_suggestions = Provider
         .select(:provider_code, :provider_name)
         .where(recruitment_cycle_year: Settings.current_cycle)
-        .with_params(search: params[:query])
+        .with_params(search: sanitized_params["query"])
         .all
 
       if @provider_suggestions.count.zero?
         flash[:error] = [I18n.t("location_filter.fields.provider")]
         redirect_back
       elsif @provider_suggestions.count == 1
-        redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))
+        redirect_to results_path(sanitized_params.merge(query: @provider_suggestions.first.provider_name))
       end
     end
 
     def redirect_back
-      redirect_params = filter_params
+      redirect_params = sanitized_params
       redirect_params = redirect_params.except(:query) if params[:query].blank?
 
       redirect_to location_path(redirect_params)
+    end
+
+    def sanitized_params
+      query = filter_params["query"]
+      @sanitized_params ||= filter_params.clone.merge("query" => strip_non_ascii(query))
     end
   end
 end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -132,26 +132,51 @@ feature "Provider filter", type: :feature do
   end
 
   context "Searching" do
-    let(:search_term) { "ACME SCITT" }
-    before do
-      stub_request(:get, providers_url)
-        .to_return(
-          body: File.new("spec/fixtures/api_responses/providers.json"),
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-      )
+    context "valid search term" do
+      let(:search_term) { "ACME SCITT" }
+      before do
+        stub_request(:get, providers_url)
+          .to_return(
+            body: File.new("spec/fixtures/api_responses/providers.json"),
+            headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+            )
 
-      provider_filter_page.load(query: query_params)
-    end
-    it "has a form with which to search again" do
-      provider_filter_page.search.expand.click
-      provider_filter_page.search.input.fill_in(with: "ACME SCITT")
-      provider_filter_page.search.submit.click
+        provider_filter_page.load(query: query_params)
+      end
+      it "has a form with which to search again" do
+        provider_filter_page.search.expand.click
+        provider_filter_page.search.input.fill_in(with: "ACME SCITT")
+        provider_filter_page.search.submit.click
 
-      expect(current_path).to eq(provider_filter_page.url)
-      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-        "query" => "ACME SCITT",
-        "utf8" => "✓",
-      )
+        expect(current_path).to eq(provider_filter_page.url)
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          "query" => "ACME SCITT",
+          "utf8" => "✓",
+                                                                            )
+      end
+      context "search term containing ASCII characters" do
+        let(:search_term) { "Kings" }
+        before do
+          stub_request(:get, providers_url)
+            .to_return(
+              body: File.new("spec/fixtures/api_responses/providers.json"),
+              headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+              )
+
+          provider_filter_page.load(query: query_params)
+        end
+        it "has a form with which to search again" do
+          provider_filter_page.search.expand.click
+          provider_filter_page.search.input.fill_in(with: "King’s")
+          provider_filter_page.search.submit.click
+
+          expect(current_path).to eq(provider_filter_page.url)
+          expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+            "query" => "King’s",
+            "utf8" => "✓",
+                                                                              )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
When a user visits the `/results/filter/location` or `/results/filter/provider` forms we want to make sure we strip out user any input containing non-ASCII characters before the query is sent to the V3 API.

### Changes proposed in this pull request
Creation and use of a new controller concern which strips out non-ASCII characters

### Guidance to review
Not sure if it should be part of this PR but this LocationsController is in need of some refactoring methinks.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
