### PR TITLE
[3120] - Encode the provider suggestion query

### DIFF
--- a/app/models/provider_suggestion.rb
+++ b/app/models/provider_suggestion.rb
@@ -1,7 +1,7 @@
 class ProviderSuggestion < Base
   def self.suggest(query)
     self.requestor.__send__(
-      :request, :get, "/api/v3/provider-suggestions?query=#{query}"
+      :request, :get, "/api/v3/provider-suggestions?query=#{CGI.escape(query)}"
     )
   end
 end

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -17,36 +17,35 @@ describe "/provider-suggestions", type: :request do
       expect(JSON.parse(response.body)).to eq("error" => "Bad request")
     end
   end
-  context "when provider suggestion ids valid" do
-    let(:provider_suggestions) {
-      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=Str")
-        .to_return(
-          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-          body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
-        )
-    }
+  context "when provider suggestion query is valid" do
+    query = "Str"
+    query_with_encoded_characters = "Str%E2%80%99"
 
-    before do
-      provider_suggestions
-    end
+    [query, query_with_encoded_characters].each do |provider_query|
+      it "returns success (200) for query: '#{provider_query}'" do
+        provider_suggestions = stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=#{provider_query}")
+                                 .to_return(
+                                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+                                   body: File.new("spec/fixtures/api_responses/provider-suggestions.json"),
+                                 )
 
-    it "returns success (200)" do
-      get "/provider-suggestions?query=Str"
+        get "/provider-suggestions?query=#{provider_query}"
 
-      expect(provider_suggestions).to have_been_requested
-      expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)).to eq(
-        [
-           {
-             "code" => "A0",
-             "name" => "ACME SCITT 0",
-           },
-           {
-             "code" => "A01",
-             "name" => "Acme SCITT",
-           },
-         ],
-       )
+        expect(provider_suggestions).to have_been_requested
+        expect(response.status).to eq(200)
+        expect(JSON.parse(response.body)).to eq(
+          [
+            {
+              "code" => "A0",
+              "name" => "ACME SCITT 0",
+            },
+            {
+              "code" => "A01",
+              "name" => "Acme SCITT",
+            },
+          ],
+         )
+      end
     end
   end
 end


### PR DESCRIPTION
NB: this PR depends on https://github.com/DFE-Digital/teacher-training-api/pull/1243

### Context
Passing non-ASCII characters into '/provider-suggestions' query params causes the JSONApiClient to throw an `URI::InvalidURIError`:

### Changes proposed in this pull request
- Encoding the provider suggestion query prevents the JSONApiClient raising a 'URI::InvalidURIError' if the query contains non-ASCII characters

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
