### PR TITLE
[3122] Fixed location page validation failure redirects

### DIFF
--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -26,7 +26,11 @@ module ResultFilters
       redirect_params = filter_params
       redirect_params = redirect_params.except(:query) if params[:query].blank?
 
-      redirect_to location_path(redirect_params)
+      if flash[:start_wizard]
+        redirect_to root_path(redirect_params)
+      else
+        redirect_to location_path(redirect_params)
+      end
     end
   end
 end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -190,6 +190,18 @@ feature "Location filter", type: :feature do
         expect(filter_page).to have_error
         expect(page).to have_current_path(root_path, ignore_query: true)
       end
+
+      context "selecting 'By school, university or other training provider'" do
+        it "stays on start page after validations" do
+          visit root_path
+
+          filter_page.by_provider.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_error
+          expect(page).to have_current_path(root_path, ignore_query: true)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context
Locations page taking users to results page instead of subject page

### Changes proposed in this pull request
Ensure the validation does not redirect user away from the url they was submit for

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
