### PR TITLE
[3127] Fix qualification backlink after failed validation

### DIFF
--- a/app/controllers/result_filters/qualification_controller.rb
+++ b/app/controllers/result_filters/qualification_controller.rb
@@ -11,7 +11,7 @@ module ResultFilters
         redirect_to results_path(filter_params)
       else
         flash[:error] = "Please choose at least one qualification"
-        redirect_to qualification_path(filter_params.merge(qualifications: "none"))
+        redirect_to qualification_path(filter_params)
       end
     end
 

--- a/app/view_objects/result_filters/qualification_view.rb
+++ b/app/view_objects/result_filters/qualification_view.rb
@@ -1,7 +1,7 @@
 module ResultFilters
   class QualificationView
     def initialize(params:)
-      @qualifications_parameter = params[:qualifications]
+      @qualifications_parameter = params[:qualifications] || ""
     end
 
     def qts_only_checked?
@@ -25,11 +25,11 @@ module ResultFilters
     attr_reader :qualifications_parameter
 
     def parameter_array
-      qualifications_parameter.present? ? qualifications_parameter.split(",") : []
+      qualifications_parameter.split(",")
     end
 
     def checked?(param_value)
-      parameter_array.empty? || parameter_array.include?(param_value)
+      parameter_array.include?(param_value)
     end
   end
 end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -52,22 +52,9 @@ feature "Qualifications filter", type: :feature do
       end
     end
 
-    describe "pre-populating values" do
-      context "with no qualifications parameters" do
-        it "checks all boxes" do
-          expect(filter_page.qts_only).to be_checked
-          expect(filter_page.pgde_pgce_with_qts).to be_checked
-          expect(filter_page.other).to be_checked
-        end
-      end
-    end
-
     describe "validation" do
       context "when no qualification is selected" do
         it "shows an error message" do
-          filter_page.qts_only.click
-          filter_page.pgde_pgce_with_qts.click
-          filter_page.other.click
           filter_page.find_courses.click
 
           expect(filter_page).to have_error

--- a/spec/view_objects/result_filters/qualification_view_spec.rb
+++ b/spec/view_objects/result_filters/qualification_view_spec.rb
@@ -17,12 +17,12 @@ module ResultFilters
 
       context "when qualifications is empty" do
         let(:params) { { qualifications: "" } }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
 
-      context "when qualifications is not in the parameters" do
+      context "when qualifications" do
         let(:params) { {} }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
     end
 
@@ -41,12 +41,12 @@ module ResultFilters
 
       context "when qualifications is empty" do
         let(:params) { { qualifications: "" } }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
 
       context "when qualifications is nil" do
         let(:params) { {} }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
     end
 
@@ -65,12 +65,12 @@ module ResultFilters
 
       context "when qualifications is empty" do
         let(:params) { { qualifications: "" } }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
 
       context "when qualifications is nil" do
         let(:params) { {} }
-        it { is_expected.to eq(true) }
+        it { is_expected.to eq(false) }
       end
     end
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -181,7 +181,7 @@ describe ResultsView do
       let(:parameter_hash) { { "qualifications" => "QtsOnly,PgdePgceWithQts,Other" } }
 
       it "returns true" do
-        expect(results_view.all_qualifications?).to be_truthy
+        expect(results_view.all_qualifications?).to eq(true)
       end
     end
 
@@ -189,7 +189,7 @@ describe ResultsView do
       let(:parameter_hash) { { "qualifications" => "QtsOnly" } }
 
       it "returns false" do
-        expect(results_view.all_qualifications?).to be_falsy
+        expect(results_view.all_qualifications?).to eq(false)
       end
     end
   end


### PR DESCRIPTION
### Context

If the user deselects all qualifications in the qualifications filter, the query parameter is set to `none` and the user is shown a validation failure message. Unfortunately that parameter is also added to the back link on that page. If the user clicks that link, the filter on the results page is empty.

~~To fix this issue `all_qualifications?` returns `true` when the parameter is set to `none`. This is mildly hacky but it would be much more complex to track previous parameters and add logic to manage them so this seems to be a pragmatic approach to this edge case.~~

The parameter has been removed. The results page link passes all three qualifications in the link querystring so the behaviour from there is unaltered. If the user visits the filter directly without querystring params then all three checkboxes will now be unchecked. This is an edge case and the user would be presented with a validation message if they were to try and submit the empty form. I think this behaviour is more 'correct' but it does differ from the old version. 

### Changes proposed in this pull request

Remove the `qualifications=none` parameter that was used on failed validation.

### Guidance to review

* Go to the results page
* Click the qualifications filter
* Deselect everything
* Submit
* When you see the validation message, click the back link
* All qualifications should be visible in the filters

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
