### PR TITLE
[3136] Encode query in javascript for autocomplete

### DIFF
--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -7,7 +7,9 @@ export const request = endpoint => {
     if (xhr && xhr.readyState !== XMLHttpRequest.DONE) {
       xhr.abort();
     }
-    const path = `${endpoint}?query=${query}`;
+
+    let encodedQuery = encodeURIComponent(query);
+    const path = `${endpoint}?query=${encodedQuery}`;
 
     xhr = new XMLHttpRequest();
     xhr.addEventListener("load", evt => {


### PR DESCRIPTION
### Context

Sentry errors are being thrown when people include characters which require escaping due to Rack not accepting the request.

### Changes proposed in this pull request

- Encode the query in javascript before sending it to the endpoint

### Guidance to review

- Select "By school, university or other training provider"
- Enter something like "2A%"
  - Bonus: We can do wild card queries, and you'll see results that return containing the text "2A" 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
