### PR TITLE
[3134] Fix pagination not showing

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -9,6 +9,7 @@ class ResultsView
   DISTANCE = "2".freeze
   SUGGESTED_SEARCH_THRESHOLD = 3
   MAXIMUM_NUMBER_OF_SUGGESTED_LINKS = 2
+  RESULTS_PER_PAGE = 10
 
   def initialize(query_parameters:)
     @query_parameters = query_parameters
@@ -147,12 +148,16 @@ class ResultsView
 
                    base_query
                      .page(query_parameters[:page] || 1)
-                     .per(10)
+                     .per(results_per_page)
                  end
   end
 
   def course_count
     courses.meta["count"]
+  end
+
+  def total_pages
+    (course_count.to_f / results_per_page).ceil
   end
 
   def site_distance(course)
@@ -227,6 +232,10 @@ class ResultsView
   end
 
 private
+
+  def results_per_page
+    RESULTS_PER_PAGE
+  end
 
   def qualification
     qualification = []

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -33,6 +33,7 @@
         </div>
       </div>
     </div>
+
     <div class="govuk-grid-column-two-thirds">
       <% if @results_view.no_results_found?%>
         <div class="govuk-grid-row">
@@ -85,6 +86,7 @@
             </div>
         <% end %>
       <% end %>
+
       <% if @results_view.suggested_search_visible? %>
         <div class="govuk-grid-row" data-qa="suggested_searches">
           <h3 class="govuk-heading-m" data-qa="suggested_search_heading">Suggested searches</h3>
@@ -141,7 +143,7 @@
           </li>
         <% end %>
       </ul>
-      <%= paginate @results_view.courses %>
+      <%= paginate(@results_view.courses, total_pages: @results_view.total_pages) %>
     </div>
   </div>
 </div>

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -24,7 +24,7 @@ describe "heartbeat requests" do
       end
 
       it "returns JSON" do
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
       end
 
       it "returns the expected response report" do

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -741,4 +741,49 @@ describe ResultsView do
       it { is_expected.to eq("No courses") }
     end
   end
+
+  describe "#total_pages" do
+    let(:parameter_hash) { {} }
+
+    subject { described_class.new(query_parameters: query_parameters) }
+
+    def stub_request_with_meta_count(count)
+      stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        .with(query: results_page_parameters)
+        .to_return(
+          body: { meta: { count: count } }.to_json,
+          headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+          )
+    end
+
+    context "where there are no results" do
+      before do
+        stub_request_with_meta_count(0)
+      end
+
+      it "should return 0 pages" do
+        expect(subject.total_pages).to eql(0)
+      end
+    end
+
+    context "where there are 10 results" do
+      before do
+        stub_request_with_meta_count(10)
+      end
+
+      it "should return 1 page" do
+        expect(subject.total_pages).to eql(1)
+      end
+    end
+
+    context "where there are 20 results" do
+      before do
+        stub_request_with_meta_count(20)
+      end
+
+      it "should return 2 pages" do
+        expect(subject.total_pages).to eql(2)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

- Pagination options are missing from results pages under certain conditions

### Changes proposed in this pull request

- This add pagination buttons (next/previous) to bottom of results
- The root cause of this regression is not yet known
- This is fixed by explicity calculating total pages and passing to
kaminari view helper
- Fixed deprecation warning

### Guidance to review

- visit http://localhost:3002/results?fulltime=False&hasvacancies=False&l=3&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&query=Essex+and+Thames+Primary+SCITT&senCourses=False
- there are more than 10 courses so should seen pagination options and able to paginate to second page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [x] Product review
