### PR TITLE
[3145] Remove apply section if no courses

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
 
-  <% if course.has_vacancies? %>
+  <% if @course.has_vacancies? %>
     <p class="govuk-body">
       <%= link_to "Apply for this course",
                   "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}",


### PR DESCRIPTION
### Context
If a course has no vacancies the "Apply" CTA should not be present

### Changes proposed in this pull request
Remove Apply CTA when no vacancies.

`course.has_vanancies` is a decorator method and returns "No" instead of `false`

### After
<img width="724" alt="Screenshot 2020-03-17 at 14 06 37" src="https://user-images.githubusercontent.com/3071606/76864156-89691f00-6858-11ea-8868-a9ee6bd64f2f.png">

### Guidance to review
e.g. http://localhost:3002/course/1HE/368Y#section-apply

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
