### PR TITLE
[2933] remove results redirect

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,6 +1,4 @@
 class ResultsController < ApplicationController
-  before_action :redirect_to_c_sharp
-
   def index
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
 
@@ -16,22 +14,5 @@ private
 
   def filtering_by_blank_provider?
     @results_view.provider_filter? && @results_view.provider.blank?
-  end
-
-  def redirect_to_c_sharp
-    return unless Settings.redirect_results_to_c_sharp
-
-    query_string = request.query_string
-    base_url = Settings.search_and_compare_ui.base_url
-
-    redirect_uri = URI(base_url)
-    redirect_uri.path = "/results"
-    redirect_uri.query = query_string.gsub("%2C", ",") if query_string.present?
-
-    redirect_to redirect_uri.to_s
-  end
-
-  def subjects_params_array
-    params["subjects"].split(",")
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,7 +42,7 @@
           <% end %>
         </div>
         <div class="govuk-header__content">
-          <%= link_to "Find postgraduate teacher training", Settings.search_and_compare_ui.base_url, class: "govuk-header__link govuk-header__link--service-name" %>
+          <%= link_to "Find postgraduate teacher training", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
         </div>
       </div>
     </header>
@@ -67,7 +67,7 @@
             </div>
           </div>
         <% end %>
-        
+
         <%= yield %>
       </main>
     </div>

--- a/azure/template.json
+++ b/azure/template.json
@@ -145,13 +145,6 @@
         "description": "API Key for Google Geocode"
       }
     },
-    "settingsRedirectResultsToCSharp": {
-      "type": "bool",
-      "defaultValue": true,
-      "metadata": {
-        "description": "Redirect Results page To CSharp"
-      }
-    }
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
@@ -294,10 +287,6 @@
                 "name": "SETTINGS__GOOGLE__GCP_API_KEY",
                 "value": "[parameters('settingsGoogleGeocodeAPIKey')]"
               },
-              {
-                "name": "SETTINGS__REDIRECT_RESULTS_TO_C_SHARP",
-                "value": "[parameters('settingsRedirectResultsToCSharp')]"
-              }
             ]
           },
           "customHostName": {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,7 +11,6 @@ google:
   places_api_path: "/maps/api/place/autocomplete/json"
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
-redirect_results_to_c_sharp: true
 logstash:
   type: tcp
   host: # Our hostname here

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,6 +1,5 @@
 teacher_training_api:
   base_url: http://localhost:3001
-redirect_results_to_c_sharp: false
 search_and_compare_ui:
   base_url: http://localhost:5000
 valid_referers:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,5 @@
 teacher_training_api:
   base_url: http://localhost:3001
-redirect_results_to_c_sharp: false
 search_and_compare_ui:
   base_url: http://localhost:5000
 valid_referers:

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -4,8 +4,6 @@ describe "/results", type: :request do
   before do
     default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
 
-    allow(Settings).to receive(:redirect_results_to_c_sharp).and_return(true)
-
     stub_api_v3_resource(
       type: SubjectArea,
       resources: nil,
@@ -20,18 +18,8 @@ describe "/results", type: :request do
         )
   end
 
-  it "redirects to c sharp version" do
+  it "returns success (200)" do
     get "/results"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results")
-  end
-
-  it "forwards querystring params" do
-    get "/results?test=one&test_two=%26booyah"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=%26booyah")
-  end
-
-  it "decodes querystring commas" do
-    get "/results?test=one&test_two=booyah%2Ckasha"
-    expect(response).to redirect_to(Settings.search_and_compare_ui.base_url + "/results?test=one&test_two=booyah,kasha")
+    expect(response).to have_http_status(200)
   end
 end


### PR DESCRIPTION
### Context
Being able to manually view and test the results page

### Changes proposed in this pull request
- Remove redirect to c# results page

### Guidance to review
`/results`
