### PR TITLE
[3157] Remove C# style parameterisation

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -2,23 +2,9 @@ module FilterParameters
   PREVIOUS_PARAMETER_PREFIX = "prev_".freeze
 
   def filter_params
-    custom_params = parameters.reject do |param|
+    parameters.reject do |param|
       param.in? %w(utf8 authenticity_token)
     end
-
-    custom_params_with_formatted_arrays = custom_params.to_h do |key, value|
-      if value.is_a? Array
-        [key, serialize_array_filter_param(value)]
-      else
-        [key, value]
-      end
-    end
-
-    custom_params_with_formatted_arrays.with_indifferent_access
-  end
-
-  def deserialize_array_filter_param(param)
-    params[param].split(",") if params.key?(param)
   end
 
   def filter_params_without_previous_parameters
@@ -33,12 +19,6 @@ module FilterParameters
     end
 
     remove_previous_parameters(all_parameters)
-  end
-
-private
-
-  def serialize_array_filter_param(value)
-    value.join(",") if value.present?
   end
 
   def parameters

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,5 +1,10 @@
 class ResultsController < ApplicationController
   def index
+    parameter_converter = ConvertDeprecatedCsharpParametersService.new.call(parameters: request.query_parameters)
+    if parameter_converter[:deprecated]
+      return redirect_to results_path(parameter_converter[:parameters])
+    end
+
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
   end
 end

--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -1,21 +1,19 @@
 #These functions are barely tested and temporary, they should be removed when the results page is filtering in Rails
 module CsharpRailsSubjectConversionHelper
   def convert_csharp_subject_id_params_to_subject_code
-    deserialize_array_filter_param("subjects")&.map do |subject|
+    params["subjects"]&.map do |subject|
       csharp_to_subject_code(id: subject)
     end
   end
 
   def convert_subject_code_params_to_csharp
-    new_subjects = params["subjects"]&.map do |subject|
+    params["subjects"]&.map do |subject|
       subject_code_to_csharp_subject_id(id: subject)
     end
-
-    serialize_array_filter_param(new_subjects)
   end
 
   def csharp_array_to_subject_codes(csharp_id_array)
-    csharp_id_array.map { |csharp_id| csharp_to_subject_code(id: csharp_id) }
+    csharp_id_array&.map { |csharp_id| csharp_to_subject_code(id: csharp_id) }
   end
 
   def csharp_to_subject_code(id:)

--- a/app/services/convert_deprecated_csharp_parameters_service.rb
+++ b/app/services/convert_deprecated_csharp_parameters_service.rb
@@ -1,0 +1,48 @@
+class ConvertDeprecatedCsharpParametersService
+  def call(parameters:)
+    boolean_parameter_names = %w[fulltime hasvacancies parttime senCourses]
+    array_parameter_names = %w[qualifications subjects]
+
+    have_legacy_params = false
+    params_hash = parameters
+
+    boolean_parameter_names.each do |parameter_name|
+      if is_legacy_boolean?(parameters[parameter_name])
+        have_legacy_params = true
+        params_hash = params_hash.merge(parameter_name => legacy_to_rails_boolean(parameters[parameter_name]))
+      end
+    end
+
+    array_parameter_names.each do |parameter_name|
+      if is_legacy_array?(parameters[parameter_name])
+        params_hash = params_hash.merge(parameter_name => legacy_to_rails_array(parameters[parameter_name]))
+        have_legacy_params = true
+      end
+    end
+
+    if have_legacy_params
+      warn "The user navigated to the results page using the deprecated C# parameterisation scheme" if Rails.env.production?
+      return { deprecated: true, parameters: params_hash }
+    end
+
+    { deprecated: false, parameters: params_hash }
+  end
+
+private
+
+  def is_legacy_boolean?(parameter)
+    parameter.in?(%w[True False])
+  end
+
+  def is_legacy_array?(parameter)
+    parameter.present? && !parameter.instance_of?(Array)
+  end
+
+  def legacy_to_rails_array(array)
+    array.split(",")
+  end
+
+  def legacy_to_rails_boolean(boolean)
+    boolean == "True"
+  end
+end

--- a/app/services/unescaped_query_string_service.rb
+++ b/app/services/unescaped_query_string_service.rb
@@ -11,7 +11,7 @@ class UnescapedQueryStringService
   end
 
   def call
-    "#{base_path}?#{URI.encode_www_form(parameters)}".gsub("%2C", ",")
+    "#{base_path}?#{parameters.to_param}".gsub("%2C", ",")
   end
 
   private_class_method :new

--- a/app/view_objects/result_filters/qualification_view.rb
+++ b/app/view_objects/result_filters/qualification_view.rb
@@ -1,7 +1,7 @@
 module ResultFilters
   class QualificationView
     def initialize(params:)
-      @qualifications_parameter = params[:qualifications] || ""
+      @qualifications_parameter = params[:qualifications]
     end
 
     def qts_only_checked?
@@ -17,19 +17,19 @@ module ResultFilters
     end
 
     def qualification_selected?
-      parameter_array.any?
+      return false if qualifications_parameter.nil?
+
+      qualifications_parameter.any?
     end
 
   private
 
     attr_reader :qualifications_parameter
 
-    def parameter_array
-      qualifications_parameter.split(",")
-    end
-
     def checked?(param_value)
-      parameter_array.include?(param_value)
+      return false if qualifications_parameter.nil?
+
+      param_value.in?(qualifications_parameter)
     end
   end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -30,27 +30,37 @@ class ResultsView
   end
 
   def fulltime?
-    query_parameters["fulltime"].present? && query_parameters["fulltime"].downcase == "true"
+    return false if query_parameters["fulltime"].nil?
+
+    query_parameters["fulltime"] == "true"
   end
 
   def parttime?
-    query_parameters["parttime"].present? && query_parameters["parttime"].downcase == "true"
+    return false if query_parameters["parttime"].nil?
+
+    query_parameters["parttime"] == "true"
   end
 
   def hasvacancies?
-    query_parameters["hasvacancies"].blank? || query_parameters["hasvacancies"].downcase == "true"
+    return true if query_parameters["hasvacancies"].nil?
+
+    query_parameters["hasvacancies"] == "true"
+  end
+
+  def sen_courses?
+    query_parameters["senCourses"] == "true"
   end
 
   def qts_only?
-    qualifications_parameters_array.include?("QtsOnly")
+    qualifications.include?("QtsOnly")
   end
 
   def pgce_or_pgde_with_qts?
-    qualifications_parameters_array.include?("PgdePgceWithQts")
+    qualifications.include?("PgdePgceWithQts")
   end
 
   def other_qualifications?
-    qualifications_parameters_array.include?("Other")
+    qualifications.include?("Other")
   end
 
   def all_qualifications?
@@ -242,6 +252,7 @@ private
     qualification |= %w[qts] if qts_only?
     qualification |= %w[pgce_with_qts pgde_with_qts] if pgce_or_pgde_with_qts?
     qualification |= %w[pgce pgde] if other_qualifications?
+
     qualification
   end
 
@@ -274,27 +285,23 @@ private
   end
 
   def qualifications_parameters
-    { "qualifications" => query_parameters["qualifications"].presence || "QtsOnly,PgdePgceWithQts,Other" }
+    { "qualifications" => query_parameters["qualifications"].presence || %w[QtsOnly PgdePgceWithQts Other] }
   end
 
   def fulltime_parameters
-    { "fulltime" => fulltime?.to_s.humanize }
+    { "fulltime" => fulltime? }
   end
 
   def parttime_parameters
-    { "parttime" => parttime?.to_s.humanize }
+    { "parttime" => parttime? }
   end
 
   def hasvacancies_parameters
-    { "hasvacancies" => hasvacancies?.to_s.humanize }
+    { "hasvacancies" => hasvacancies? }
   end
 
   def sen_courses_parameters
-    { "senCourses" => query_parameters["senCourses"].presence || "False" }
-  end
-
-  def qualifications_parameters_array
-    qualifications_parameters["qualifications"].split(",")
+    { "senCourses" => sen_courses? }
   end
 
   def subject_parameters
@@ -302,7 +309,7 @@ private
   end
 
   def subject_parameters_array
-    (subject_parameters["subjects"] || "").split(",")
+    query_parameters["subjects"] || []
   end
 
   def subject_codes
@@ -341,7 +348,7 @@ private
   end
 
   def qualifications
-    query_parameters["qualifications"] || "QtsOnly,PgdePgceWithQts,Other"
+    query_parameters["qualifications"] || %w[QtsOnly PgdePgceWithQts Other]
   end
 
   def filtered_subjects

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -21,14 +21,14 @@
             </span>
           <% end %>
           <div class="govuk-checkboxes">
-          <% default_to_true = (params[:fulltime] != "True" && params[:parttime] != "True") && flash[:error].nil? %>
+          <% default_to_true = (params[:fulltime] != "true" && params[:parttime] != "true") && flash[:error].nil? %>
             <div class="govuk-checkboxes__item">
               <%=
                 form.check_box(
                   :fulltime,
-                  { class: "govuk-checkboxes__input", data: { qa: 'full_time'}, checked: params[:fulltime] == "True" || default_to_true },
-                  "True",
-                  "False"
+                  { class: "govuk-checkboxes__input", data: { qa: 'full_time'}, checked: params[:fulltime] == "true" || default_to_true },
+                  "true",
+                  "false"
                 )
               %>
               <%= form.label :fulltime, class: "govuk-label govuk-checkboxes__label" do %>
@@ -43,9 +43,9 @@
               <%=
                 form.check_box(
                   :parttime,
-                  { class: "govuk-checkboxes__input", data: { qa: 'part_time'}, checked: params[:parttime] == "True" || default_to_true },
-                  "True",
-                  "False"
+                  { class: "govuk-checkboxes__input", data: { qa: 'part_time'}, checked: params[:parttime] == "true" || default_to_true },
+                  "true",
+                  "false"
                 )
               %>
               <%= form.label :parttime, class: "govuk-label govuk-checkboxes__label" do %>

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -22,7 +22,7 @@
                   "True",
                   class: "govuk-radios__input",
                   data: { qa: "with_vacancies" },
-                  checked: params[:hasvacancies] == "True" || params[:hasvacancies].blank?
+                  checked: params[:hasvacancies] == "true" || params[:hasvacancies].blank?
                 )
               %>
               <%= form.label :hasvacancies_true, "Only courses with vacancies", class: "govuk-label govuk-radios__label" %>
@@ -35,7 +35,7 @@
                   "False",
                   class: "govuk-radios__input",
                   data: { qa: "with_and_without_vacancies" },
-                  checked: params[:hasvacancies] == "False"
+                  checked: params[:hasvacancies] == "false"
                 )
               %>
               <%= form.label :hasvacancies_false, "Courses with and without vacancies", class: "govuk-label govuk-radios__label" %>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "copy-webpack-plugin": "^5.1.1",
     "govuk-frontend": "^3.6.0",
     "lodash.throttle": "^4.1.1",
-    "set-value": "^3.0.1"
+    "set-value": "^3.0.1",
+    "yarn": "^1.22.4"
   },
   "devDependencies": {
     "jest": "^25.2.3",

--- a/spec/controllers/concerns/filter_parameters_spec.rb
+++ b/spec/controllers/concerns/filter_parameters_spec.rb
@@ -28,24 +28,6 @@ RSpec.describe FilterParameters do
   end
 
   describe "#filter_params" do
-    context "GET" do
-      context "when rails parameters are present" do
-        let(:query_parameters) { { "utf8" => true, "authenticity_token" => "token", "test" => "test" } }
-
-        it "they are stripped" do
-          expect(subject.filter_params).to eq({ "test" => "test" })
-        end
-      end
-
-      context "when an array parameter is present" do
-        let(:query_parameters) { { "test" => [1, 2, 3] } }
-
-        it "serializes them to a comma separated string" do
-          expect(subject.filter_params["test"]).to eq("1,2,3")
-        end
-      end
-    end
-
     context "POST" do
       let(:verb) { "POST" }
       let(:request_parameters) { { "test" => "request" } }
@@ -63,13 +45,6 @@ RSpec.describe FilterParameters do
       it "returns the query parameters" do
         expect(subject.filter_params).to eq({ "test" => "test" })
       end
-    end
-  end
-
-  describe "#deserialize_array_filter_param" do
-    let(:query_parameters) { { "test" => "1,2,3" } }
-    it "splits comma separated strings" do
-      expect(subject.deserialize_array_filter_param("test")).to match_array(%w(1 2 3))
     end
   end
 

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -44,11 +44,11 @@ feature "Funding filter", type: :feature do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
+            "fulltime" => "false",
+            "hasvacancies" => "true",
+            "parttime" => "false",
+            "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+            "senCourses" => "false",
             "test" => "params",
           },
         )

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -150,11 +150,11 @@ feature "Location filter", type: :feature do
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          "fulltime" => "False",
-          "hasvacancies" => "True",
-          "parttime" => "False",
-          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-          "senCourses" => "False",
+          "fulltime" => "false",
+          "hasvacancies" => "true",
+          "parttime" => "false",
+          "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+          "senCourses" => "false",
           "test" => "params",
         },
       )
@@ -389,7 +389,7 @@ feature "Location filter", type: :feature do
         page: results_page,
         expected_query_params: {
           "l" => "2",
-          "test" => "1,2",
+          "test" => %w[1 2],
         },
       )
     end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -41,11 +41,11 @@ feature "Qualifications filter", type: :feature do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
+            "fulltime" => "false",
+            "hasvacancies" => "true",
+            "parttime" => "false",
+            "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+            "senCourses" => "false",
             "test" => "params",
           },
         )

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -24,6 +24,26 @@ feature "Study type filter", type: :feature do
       expect(page).to have_content("Study type")
     end
 
+    describe "Navigating to the page with currently selected filters" do
+      it "Preselects with fulltime" do
+        filter_page.load(query: { fulltime: "true" })
+        expect(filter_page.full_time.checked?).to eq(true)
+        expect(filter_page.part_time.checked?).to eq(false)
+      end
+
+      it "Preselects with parttime" do
+        filter_page.load(query: { parttime: "true" })
+        expect(filter_page.full_time.checked?).to eq(false)
+        expect(filter_page.part_time.checked?).to eq(true)
+      end
+
+      it "Preselects all" do
+        filter_page.load
+        expect(filter_page.full_time.checked?).to eq(true)
+        expect(filter_page.part_time.checked?).to eq(true)
+      end
+    end
+
     describe "back link" do
       before do
         stub_request(:get, courses_url)
@@ -41,11 +61,11 @@ feature "Study type filter", type: :feature do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
+            "fulltime" => "false",
+            "hasvacancies" => "true",
+            "parttime" => "false",
+            "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+            "senCourses" => "false",
             "test" => "params",
           },
         )
@@ -54,12 +74,12 @@ feature "Study type filter", type: :feature do
 
     describe "Navigating to the page with currently selected filters" do
       it "Allows the full time param to be pre-selected" do
-        filter_page.load(query: { fulltime: "True" })
+        filter_page.load(query: { fulltime: "true" })
         expect(filter_page.full_time.checked?).to eq(true)
       end
 
       it "Allows the part time param to be pre-selected" do
-        filter_page.load(query: { parttime: "True" })
+        filter_page.load(query: { parttime: "true" })
         expect(filter_page.part_time.checked?).to eq(true)
       end
     end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -63,7 +63,6 @@ feature "Subject filter", type: :feature do
 
         filter_page.continue.click
 
-
         expect(results_page.heading.text).to eq("Teacher training courses")
         expect(results_page.subjects_filter.subjects.map(&:text))
           .to eq(
@@ -208,11 +207,11 @@ feature "Subject filter", type: :feature do
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params:  {
-          "fulltime" => "False",
-          "hasvacancies" => "True",
-          "parttime" => "False",
-          "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-          "senCourses" => "False",
+          "fulltime" => "false",
+          "hasvacancies" => "true",
+          "parttime" => "false",
+          "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+          "senCourses" => "false",
           "test" => "params",
         },
       )
@@ -308,7 +307,7 @@ feature "Subject filter", type: :feature do
 
   context "with previously selected subjects" do
     it "automatically selects the given checkboxes" do
-      filter_page.load(query: { subjects: "31", senCourses: "true" })
+      visit subject_path(subjects: %w[31], senCourses: "true")
       expect(filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
       expect(filter_page.send_area.subjects.first.checkbox).to be_checked
     end
@@ -327,7 +326,8 @@ feature "Subject filter", type: :feature do
             body: File.new("spec/fixtures/api_responses/ten_courses.json"),
             headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
               )
-      filter_page.load(query: { subjects: "31", senCourses: "true" })
+
+      visit subject_path(subjects: %w[31], senCourses: "true")
       filter_page.subject_areas.first.subjects[0].checkbox.click # unselect
       filter_page.subject_areas.first.subjects[1].checkbox.click # select a different one
       filter_page.send_area.subjects.first.checkbox.click # unselect
@@ -358,12 +358,12 @@ feature "Subject filter", type: :feature do
     end
 
     it "only changes the subjects params" do
-      filter_page.load(query: { subjects: "32,31", other_param: "param_value" })
+      visit subject_path(subjects: %w[32 31], other_param: "param_value")
       filter_page.continue.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          "subjects" => "31,32",
+          "subjects" => %w[31 32],
           "other_param" => "param_value",
         },
       )

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -41,11 +41,11 @@ feature "Vacancy filter", type: :feature do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            "fulltime" => "False",
-            "hasvacancies" => "True",
-            "parttime" => "False",
-            "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
-            "senCourses" => "False",
+            "fulltime" => "false",
+            "hasvacancies" => "true",
+            "parttime" => "false",
+            "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+            "senCourses" => "false",
             "test" => "params",
           },
         )
@@ -54,12 +54,12 @@ feature "Vacancy filter", type: :feature do
 
     describe "Navigating to the page with currently selected filters" do
       it "Preselects with vacancies" do
-        filter_page.load(query: { hasvacancies: "True" })
+        filter_page.load(query: { hasvacancies: "true" })
         expect(filter_page.with_vacancies.checked?).to eq(true)
       end
 
       it "Preselects with and without vacancies" do
-        filter_page.load(query: { hasvacancies: "False" })
+        filter_page.load(query: { hasvacancies: "false" })
         expect(filter_page.with_and_without_vacancies.checked?).to eq(true)
       end
     end

--- a/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
+++ b/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
@@ -1,0 +1,53 @@
+describe ConvertDeprecatedCsharpParametersService do
+  let(:service) { described_class.new }
+  let(:service_call) { service.call(parameters: input_parameters) }
+
+  context "given deprecated parameters" do
+    let(:input_parameters) do
+      {
+        "fulltime" => "True",
+        "hasvacancies" => "True",
+        "parttime" => "True",
+        "senCourses" => "True",
+        "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+        "subjects" => "1,2,3",
+      }
+    end
+
+    it "flags that the parameters are deprecated" do
+      expect(service_call[:deprecated]).to eq(true)
+    end
+
+    it "returns the correct parameters" do
+      expect(service_call[:parameters]).to eq({
+        "fulltime" => true,
+        "hasvacancies" => true,
+        "parttime" => true,
+        "senCourses" => true,
+        "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+        "subjects" => %w[1 2 3],
+      })
+    end
+  end
+
+  context "given supported parameters" do
+    let(:input_parameters) do
+      {
+        "fulltime" => "true",
+        "hasvacancies" => "true",
+        "parttime" => "true",
+        "senCourses" => "true",
+        "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+        "subjects" => %w[1 2 3],
+      }
+    end
+
+    it "does not flag that the parameters are deprecated" do
+      expect(service_call[:deprecated]).to eq(false)
+    end
+
+    it "returns the same parameters" do
+      expect(service_call[:parameters]).to eq(input_parameters)
+    end
+  end
+end

--- a/spec/services/unescaped_query_string_service_spec.rb
+++ b/spec/services/unescaped_query_string_service_spec.rb
@@ -1,6 +1,13 @@
 require_relative "../../app/services/unescaped_query_string_service"
 
-RSpec.describe UnescapedQueryStringService do
-  subject { described_class.call(base_path: "/test", parameters: { test: "1,2,3" }) }
-  it { is_expected.to eq("/test?test=1,2,3") }
+describe UnescapedQueryStringService do
+  context "with C# style parameters" do
+    subject { described_class.call(base_path: "/test", parameters: { test: "1,2,3" }) }
+    it { is_expected.to eq("/test?test=1,2,3") }
+  end
+
+  context "with Rails style parameters" do
+    subject { described_class.call(base_path: "/test", parameters: { test: [1, 2, 3] }) }
+    it { is_expected.to eq("/test?test%5B%5D=1&test%5B%5D=2&test%5B%5D=3") }
+  end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -100,7 +100,6 @@ module PageObjects
       element :salary_link, '[data-qa="filters__salary_link"]'
       element :vacancies_link, '[data-qa="filters__vacancies_link"]'
 
-
       element :suggested_searches, '[data-qa="suggested_searches"]'
       element :suggested_search_heading, '[data-qa="suggested_search_heading"]'
       element :suggested_search_description, '[data-qa="suggested_search_description"]'

--- a/spec/view_objects/result_filters/qualification_view_spec.rb
+++ b/spec/view_objects/result_filters/qualification_view_spec.rb
@@ -1,26 +1,26 @@
 require_relative "../../../app/view_objects/result_filters/qualification_view"
 
 module ResultFilters
-  RSpec.describe QualificationView do
+  describe QualificationView do
     describe "qts_only_checked?" do
       subject { described_class.new(params: params).qts_only_checked? }
 
       context "when QtsOnly param not present" do
-        let(:params) { { qualifications: "Other,PgdePgceWithQts" } }
+        let(:params) { { qualifications: %w[Other PgdePgceWithQts] } }
         it { is_expected.to eq(false) }
       end
 
       context "when QtsOnly param is present" do
-        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
         it { is_expected.to eq(true) }
       end
 
       context "when qualifications is empty" do
-        let(:params) { { qualifications: "" } }
+        let(:params) { { qualifications: [] } }
         it { is_expected.to eq(false) }
       end
 
-      context "when qualifications" do
+      context "when parameters are empty" do
         let(:params) { {} }
         it { is_expected.to eq(false) }
       end
@@ -30,17 +30,22 @@ module ResultFilters
       subject { described_class.new(params: params).pgde_pgce_with_qts_checked? }
 
       context "when PgdePgceWithQts param not present" do
-        let(:params) { { qualifications: "Other,QtsOnly" } }
+        let(:params) { { qualifications: %w[Other QtsOnly] } }
         it { is_expected.to eq(false) }
       end
 
       context "when PgdePgceWithQts param is present" do
-        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
         it { is_expected.to eq(true) }
       end
 
       context "when qualifications is empty" do
-        let(:params) { { qualifications: "" } }
+        let(:params) { { qualifications: [] } }
+        it { is_expected.to eq(false) }
+      end
+
+      context "when parameters are empty" do
+        let(:params) { {} }
         it { is_expected.to eq(false) }
       end
 
@@ -50,25 +55,25 @@ module ResultFilters
       end
     end
 
-    describe "pgde_pgce_with_qts_checked" do
+    describe "#other_checked?" do
       subject { described_class.new(params: params).other_checked? }
 
       context "when Other param not present" do
-        let(:params) { { qualifications: "QtsOnly,PgdePgceWithQts" } }
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
         it { is_expected.to eq(false) }
       end
 
       context "when Other param is present" do
-        let(:params) { { qualifications: "QtsOnly,Other" } }
+        let(:params) { { qualifications: %w[QtsOnly Other] } }
         it { is_expected.to eq(true) }
       end
 
       context "when qualifications is empty" do
-        let(:params) { { qualifications: "" } }
+        let(:params) { { qualifications: [] } }
         it { is_expected.to eq(false) }
       end
 
-      context "when qualifications is nil" do
+      context "when parameters are empty" do
         let(:params) { {} }
         it { is_expected.to eq(false) }
       end
@@ -77,17 +82,17 @@ module ResultFilters
     describe "qualification_selected?" do
       subject { described_class.new(params: params).qualification_selected? }
       context "when a parameter is selected" do
-        let(:params) { { qualifications: "Other" } }
+        let(:params) { { qualifications: %w[Other] } }
         it { is_expected.to eq(true) }
       end
 
       context "when multiple parameters are selected" do
-        let(:params) { { qualifications: "Other,QtsOnly" } }
+        let(:params) { { qualifications: %w[Other QtsOnly] } }
         it { is_expected.to eq(true) }
       end
 
       context "when no parameter is selected" do
-        let(:params) { { qualifications: "" } }
+        let(:params) { {} }
         it { is_expected.to eq(false) }
       end
 

--- a/spec/view_objects/suggested_search_link_spec.rb
+++ b/spec/view_objects/suggested_search_link_spec.rb
@@ -26,8 +26,17 @@ describe SuggestedSearchLink do
     end
 
     describe "#url" do
-      subject { super().url }
-      it { is_expected.to eq("/results?lat=5&lng=-5&rad=10&loc=Shetlands&lq=2") }
+      it "produces the correct URL" do
+        uri = URI(subject.url)
+        expect(uri.path).to eq("/results")
+        expect(Rack::Utils.parse_nested_query(uri.query)).to eq({
+          "lat" => "5",
+          "lng" => "-5",
+          "rad" => "10",
+          "loc" => "Shetlands",
+          "lq" => "2",
+        })
+      end
     end
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -9710,3 +9710,8 @@ yargs@^7.0.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^5.0.0"
+
+yarn@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
+  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==


### PR DESCRIPTION
### Context
We previously inserted a conversion layer between C# parameters and Rails parameters so that we  would be able to seamlessly redirect between Rails and C# Find. As C# Find has now been retired this functionality is no longer needed.

### Changes proposed in this pull request
 - Add a conversion and redirection service for C# style parameters in order to avoid breaking bookmarks, and log when C# style parameters are used.  
 - Modify existing code to use Rails style parameters. (`parameter_a=True&parameter_b=x,y` to `parameter_a=true&parameter_b[]=x&parameter_b[]=y`)  
 - Add some missing tests.  

The following are out of scope for this PR:
 - Renaming parameters to use Rails conventions  
 - Removing the subject ID/code conversion

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
