### PR TITLE
[3170] don't include HTTParty in heartbeat controller

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -1,6 +1,4 @@
 class HeartbeatController < ActionController::API
-  include HTTParty
-
   def ping
     render body: "PONG"
   end
@@ -18,7 +16,7 @@ class HeartbeatController < ActionController::API
 private
 
   def api_alive?
-    response = HeartbeatController.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+    response = HTTParty.get("#{Settings.teacher_training_api.base_url}/healthcheck")
     response.success?
   rescue StandardError
     false


### PR DESCRIPTION
### Context

We are getting very voluminous errors being logged to Logit and also into local logs. This is a result of using the gems `rails_semantic_logger` and `httparty`: it seems when `HTTParty` is included into a class/module it defines the method `logger` differently from `ActionController::Base#logger`. SemanticLogger uses this method and as a result an error is raised, and sent to logit with a massive backtrace. (see comment below for a sample)

### Changes proposed in this pull request

Don't include `HTTParty` into `HeartbeatController`, use `HTTParty.get` directly instead.

### Guidance to review

Couldn't find a way to test this, even though we can see this error being logged in `log/test.log` when we run the tests. You might want to truncate that log file on your dev system.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
