### PR TITLE
[3155] Fix error styling and standardise behaviour across the service

### DIFF
--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -13,7 +13,7 @@
         end
     } %>
     <%= form_with url: location_path, method: :post, data: { "ga-event-form" => "Location" } do |form| %>
-      <%= render "shared/hidden_fields", exclude_keys: ["l"], form: form %>
+      <%= render "shared/hidden_fields", exclude_keys: %w(l query rad), form: form %>
       <fieldset class="govuk-fieldset" role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -18,7 +18,16 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
         </legend>
-        <div class="govuk-form-group" id="search-options">
+        <div class="govuk-form-group<%= " govuk-form-group--error" if flash[:error] %>" id="search-options">
+          <% if flash[:error] and location_error? === false and provider_error? === false%>
+            <p class="govuk-error-message">
+              <% if flash[:error].kind_of?(Array) %>
+                <%= flash[:error].first %>
+              <% else %>
+                <%= flash[:error] %>
+              <% end %>
+            </p>
+          <% end %>
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
               <%=
@@ -127,9 +136,7 @@
           </div>
         </div>
       </fieldset>
-      <div class="govuk-form-group">
-        <%= form.submit local_assigns[:submit_button_text], name: nil, class: "govuk-button", data: {qa: 'find-courses'} %>
-      </div>
+      <%= form.submit local_assigns[:submit_button_text], name: nil, class: "govuk-button", data: {qa: 'find-courses'} %>
     <% end %>
   </div>
 </div>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -118,13 +118,13 @@
               <div class="govuk-form-group <%= "govuk-form-group--error" if provider_error? %>" data-module="track-no-provider-results">
                 <%= form.label :query, class: "govuk-label" do %>
                   School, university or other training provider
+                  <span class="govuk-hint">Enter the name or provider code</span>
                   <% if provider_error? %>
                     <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
                     <span class="govuk-visually-hidden">Error: </span><%= I18n.t("location_filter.errors.missing_provider") %>
                   </span>
                   <% end %>
                 <% end %>
-                <span class="govuk-hint">Enter the name or provider code</span>
                 <%= form.text_field :query,
                                     id: "provider",
                                     value: params[:query],

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -46,7 +46,7 @@
               class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "1" %>"
               id="location-conditional" data-qa="location-conditional">
               <div class="govuk-form-group <%= "govuk-form-group--error" if location_error? %>">
-                <%= form.label :lq, "Postcode, town or city", class: "govuk-label" %>
+                <%= form.label :lq, "Postcode, town or city", { class: "govuk-label", for: "location"} %>
                 <% if location_error? %>
                   <div class="govuk-error-message" id="location-error" data-qa="location-error">
                     <span class="govuk-visually-hidden">Error: </span><%= flash[:error].last %>
@@ -116,7 +116,7 @@
             <div class="govuk-radios__conditional <%= "govuk-radios__conditional--hidden" unless params[:l] == "3" %>"
               id="query-container" data-qa="by-provider-conditional">
               <div class="govuk-form-group <%= "govuk-form-group--error" if provider_error? %>" data-module="track-no-provider-results">
-                <%= form.label :query, class: "govuk-label" do %>
+                <%= form.label :query, {class: "govuk-label", for: "provider" } do %>
                   School, university or other training provider
                   <span class="govuk-hint">Enter the name or provider code</span>
                   <% if provider_error? %>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -5,11 +5,11 @@
     <%= render partial: "shared/error_message", locals: {
       error_anchor_id:
         if no_option_selected?
-          "search-options"
+          "l_1"
         elsif location_error?
-          "location-error"
+          "location"
         elsif provider_error?
-          "provider-error"
+          "provider"
         end
     } %>
     <%= form_with url: location_path, method: :post, data: { "ga-event-form" => "Location" } do |form| %>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "shared/error_message", locals: { error_anchor_id: "qualification-error" } %>
+    <%= render partial: "shared/error_message", locals: { error_anchor_id: "qualifications_qtsonly" } %>
 
     <%= form_with url: qualification_path, method: :post, data: { "ga-event-form" => "Qualification" } do |form| %>
       <%= render "shared/hidden_fields", exclude_keys: ["qualifications"], form: form %>

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -21,7 +21,7 @@
             </span>
           <% end %>
           <div class="govuk-checkboxes">
-          <% default_to_true = (params[:fulltime] != "True" && params[:parttime] != "True")%>
+          <% default_to_true = (params[:fulltime] != "True" && params[:parttime] != "True") && flash[:error].nil? %>
             <div class="govuk-checkboxes__item">
               <%=
                 form.check_box(

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -6,7 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "shared/error_message", locals: { error_anchor_id: "study-type-error" } %>
+    <%= render partial: "shared/error_message", locals: { error_anchor_id: "fulltime" } %>
     <%= form_with url: studytype_path, method: :post do |form| %>
       <%= render "shared/hidden_fields", exclude_keys: ["fulltime", "parttime"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">


### PR DESCRIPTION
## Background
During migration from c# to Rails, a lot of different developers worked on various pages and were mostly trying to replicate what was done in c#. Unfortunately, this introduced some inconsistency in styling, error messages and interaction when the user clicked on the error summary link.

## Changes proposed in this pull request

**Home/Location page**
- Add missing error message when no type of location search is selected [e41e60a]
- reorder the hint/error message so that it matches [govuk-frontend guidelines](https://design-system.service.gov.uk/components/text-input/#error-messages) [40705f1]
- fixes malformed HTML where two elements on the page had the same id. This was done by excluding the keys in the hidden fields. (No visual difference)[d204866]
- fixes an accessibility issue with location/provider labels and text fields were not associated so screenreaders would not be able to provide the context of the input to the user. (No visual difference but users should be able to click on the labels)[e20d44e]
- Error summary link should set focus on the first radio/checkbox in a list or the invalid text field [d986e40]

**Study type filter page**
- Error summary link should set focus on the first radio/checkbox in a list or the invalid text field [d986e40]
- Does not set the default to both full time/parttime if there is an error. This fixes a usability issue where a user may untick full-time and part-time checkboxes, they get an error message saying they need to select at least one but both checkboxes are ticked already.[d8083f0]

**Qualification filter page**
- Error summary link should set focus on the first radio/checkbox in a list or the invalid text field (No visual difference)[04409e2]

### Screenshots

#### Before - Home/Location page (3 error states)

![image](https://user-images.githubusercontent.com/3441519/77511141-54685800-6e68-11ea-885f-4659d9e0b3c5.png)

![image](https://user-images.githubusercontent.com/3441519/77511405-ecfed800-6e68-11ea-92ab-adfb31276be9.png)
![image](https://user-images.githubusercontent.com/3441519/77511419-f25c2280-6e68-11ea-9351-b3340eff3233.png)

#### After - Home/Location page (3 error states)

![image](https://user-images.githubusercontent.com/3441519/77511342-cb9dec00-6e68-11ea-80ef-d97e5ba8fd14.png)

![image](https://user-images.githubusercontent.com/3441519/77511529-29323880-6e69-11ea-90db-39442d2d6e9e.png)

![image](https://user-images.githubusercontent.com/3441519/77511547-33eccd80-6e69-11ea-9191-168d50a3f804.png)
------
#### Before - Study type filter page 
![image](https://user-images.githubusercontent.com/3441519/77512724-84652a80-6e6b-11ea-93d0-987c4bfb561b.png)

#### After - Study type filter page
![image](https://user-images.githubusercontent.com/3441519/77512782-9515a080-6e6b-11ea-86a2-dd0c3d80b914.png)


## Outstanding issues not addressed in this PR
**Home/Location page**
- Accessibility autocomplete does not allow additional css classes to be added to the text field. https://github.com/alphagov/accessible-autocomplete/issues/428 

**Subject page**
- Error summary does not link to the first checkbox because accordion sections do not expand when expected. This is because accordion has a feature that stores the state of each section in session storage. The session storage overrides the state of the accordion that the server has sent.
- Checkboxes do not have error style i.e red left border and indent (I did try to apply it across the whole accordion but it didn't feel like it added much value to the accordion.

Generally, the subject page is complicated because we are using an accordion to group what would have been a large list of checkboxes into different groups.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
