### PR TITLE
[2927] Add redirect for www2 and education to www service

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
-  constraints(host: /www2\.|\.education\./) do
+  constraints(host: /^www2\.|\.education\./) do
     match "/(*path)" => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" },
       via: %i[get post put]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,11 @@
 # rubocop:disable Metrics/BlockLength
 
 Rails.application.routes.draw do
+  constraints(host: /www2\.|\.education\./) do
+    match "/(*path)" => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" },
+      via: %i[get post put]
+  end
+
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,5 @@
 application_name: find-teacher-training
+base_url: http://localhost:3002
 teacher_training_api:
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,3 +1,4 @@
+base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
 search_and_compare_ui:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,3 +1,4 @@
+base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
 search_and_compare_ui:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,3 +1,4 @@
+base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
 search_and_compare_ui:


### PR DESCRIPTION
### Context
c# (www) is now dead so we need to promote  our new rails app to www instead of www2

### Changes proposed in this pull request
Add redirect for www2 and education.gov.uk to www. service

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
