### PR TITLE
[3125] Backlink on location page returns no results after validation error

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -1,11 +1,7 @@
 module FilterParameters
-  def filter_params
-    if request.method == "GET"
-      parameters = request.query_parameters
-    elsif request.method == "POST"
-      parameters = request.request_parameters
-    end
+  PREVIOUS_PARAMETER_PREFIX = "prev_".freeze
 
+  def filter_params
     custom_params = parameters.reject do |param|
       param.in? %w(utf8 authenticity_token)
     end
@@ -25,7 +21,37 @@ module FilterParameters
     params[param].split(",") if params.key?(param)
   end
 
+  def filter_params_without_previous_parameters
+    remove_previous_parameters(filter_params)
+  end
+
+  def merge_previous_parameters(all_parameters)
+    previous_parameters.each do |key, value|
+      next if value == "none"
+
+      all_parameters[key.delete_prefix(PREVIOUS_PARAMETER_PREFIX)] = value
+    end
+
+    remove_previous_parameters(all_parameters)
+  end
+
+private
+
   def serialize_array_filter_param(value)
     value.join(",") if value.present?
+  end
+
+  def parameters
+    return request.query_parameters if request.method == "GET"
+
+    request.request_parameters
+  end
+
+  def previous_parameters
+    parameters.select { |key, _value| key.start_with? PREVIOUS_PARAMETER_PREFIX }
+  end
+
+  def remove_previous_parameters(all_parameters)
+    all_parameters.reject { |key, _value| key.start_with? PREVIOUS_PARAMETER_PREFIX }
   end
 end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -19,20 +19,22 @@ module ResultFilters
 
       form_params = strip(filter_params.clone).merge(sortby: ResultsView::DISTANCE)
       form_object = LocationFilterForm.new(form_params)
+
       if form_object.valid?
-        all_params = form_params.merge!(form_object.params)
-        redirect_to(next_step(all_params))
+        parameters_with_geocode_added_and_previous_removed = remove_previous_parameters(form_params.merge(form_object.params))
+        redirect_to(next_step(parameters_with_geocode_added_and_previous_removed))
       else
         flash[:error] = form_object.errors
-        back_to_current_page_if_error(form_params)
+        back_to_current_page_if_error(merge_previous_parameters(form_params))
       end
     end
 
   private
 
     def build_results_filter_query_parameters
-      @results_filter_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
-        .query_parameters_with_defaults
+      @results_filter_query_parameters = merge_previous_parameters(
+        ResultsView.new(query_parameters: request.query_parameters).query_parameters_with_defaults,
+      )
     end
 
     def location_option_selected?

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -18,7 +18,9 @@ module ResultFilters
         flash[:error] = [I18n.t("location_filter.fields.provider")]
         redirect_back
       elsif @provider_suggestions.count == 1
-        redirect_to results_path(filter_params.merge(query: @provider_suggestions.first.provider_name))
+        redirect_to results_path(
+          filter_params_without_previous_parameters.merge(query: @provider_suggestions.first.provider_name),
+        )
       end
     end
 

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -14,6 +14,7 @@
     } %>
     <%= form_with url: location_path, method: :post, data: { "ga-event-form" => "Location" } do |form| %>
       <%= render "shared/hidden_fields", exclude_keys: %w(l query rad), form: form %>
+      <%= render "shared/hidden_previous_fields", form: form %>
       <fieldset class="govuk-fieldset" role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -10,7 +10,10 @@
     <ul class="govuk-list govuk-list--bullet">
       <% @provider_suggestions.each do |provider| %>
         <li data-qa="provider_suggestion">
-          <%= govuk_link_to "#{provider.provider_name} (#{provider.provider_code})", results_path(filter_params.merge(query: provider.provider_name)), { class: "govuk-link", data: { qa: "provider_suggestion__link" } } %>
+          <%= govuk_link_to "#{provider.provider_name} (#{provider.provider_code})", 
+            results_path(filter_params_without_previous_parameters.merge(query: provider.provider_name)), 
+            { class: "govuk-link", data: { qa: "provider_suggestion__link" } } 
+          %>
         </li>
       <% end %>
     </ul>

--- a/app/views/shared/_hidden_previous_fields.html.erb
+++ b/app/views/shared/_hidden_previous_fields.html.erb
@@ -1,0 +1,7 @@
+<%= form.hidden_field("prev_l", value: params["prev_l"] || params["l"] || "none") %>
+<%= form.hidden_field("prev_loc", value: params["prev_loc"] || params["loc"] || "none") %>
+<%= form.hidden_field("prev_lng", value: params["prev_lng"] || params["lng"] || "none") %>
+<%= form.hidden_field("prev_lat", value: params["prev_lat"] || params["lat"] || "none") %>
+<%= form.hidden_field("prev_rad", value: params["prev_rad"] || params["rad"] || "none")  %>
+<%= form.hidden_field("prev_query", value: params["prev_query"] || params["query"] || "none") %>
+<%= form.hidden_field("prev_lq", value: params["prev_lq"] || params["lq"] || "none") %>

--- a/spec/controllers/concerns/filter_parameters_spec.rb
+++ b/spec/controllers/concerns/filter_parameters_spec.rb
@@ -1,0 +1,89 @@
+require_relative "../../../app/controllers/concerns/filter_parameters"
+require "active_support/core_ext"
+
+RSpec.describe FilterParameters do
+  class TestClass
+    include FilterParameters
+
+    attr_reader :request
+
+    def initialize(request:)
+      @request = request
+    end
+
+    def params
+      request.query_parameters
+    end
+  end
+
+  let(:request) do
+    double(method: verb, query_parameters: query_parameters, request_parameters: request_parameters)
+  end
+  let(:query_parameters) { {} }
+  let(:request_parameters) { {} }
+  let(:verb) { "GET" }
+
+  subject do
+    TestClass.new(request: request)
+  end
+
+  describe "#filter_params" do
+    context "GET" do
+      context "when rails parameters are present" do
+        let(:query_parameters) { { "utf8" => true, "authenticity_token" => "token", "test" => "test" } }
+
+        it "they are stripped" do
+          expect(subject.filter_params).to eq({ "test" => "test" })
+        end
+      end
+
+      context "when an array parameter is present" do
+        let(:query_parameters) { { "test" => [1, 2, 3] } }
+
+        it "serializes them to a comma separated string" do
+          expect(subject.filter_params["test"]).to eq("1,2,3")
+        end
+      end
+    end
+
+    context "POST" do
+      let(:verb) { "POST" }
+      let(:request_parameters) { { "test" => "request" } }
+      let(:query_parameters) { { "test" => "query" } }
+
+      it "uses request_parameters" do
+        expect(subject.filter_params["test"]).to eq("request")
+      end
+    end
+  end
+
+  describe "#deserialize_array_filter_param" do
+    let(:query_parameters) { { "test" => "1,2,3" } }
+    it "splits comma separated strings" do
+      expect(subject.deserialize_array_filter_param("test")).to match_array(%w(1 2 3))
+    end
+  end
+
+  describe "#filter_params_without_previous_parameters" do
+    let(:query_parameters) { { "l" => 0, "prev_l" => 1, "prev_query" => "query", "test" => "test" } }
+
+    it "removes the previous parameters" do
+      expect(subject.filter_params_without_previous_parameters).to eq({ "l" => 0, "test" => "test" })
+    end
+  end
+
+  describe "#merge_previous_parameters" do
+    let(:query_parameters) { { "l" => 0, "prev_l" => 1, "prev_query" => "query", "test" => "test" } }
+
+    it "sets the non prev equivalent and adds any that are not present" do
+      expect(subject.merge_previous_parameters(query_parameters)).to eq({ "l" => 1, "query" => "query", "test" => "test" })
+    end
+
+    context "where param is set to none" do
+      let(:query_parameters) { { "l" => 0, "prev_l" => 1, "prev_query" => "query", "test" => "test", "prev_lat" => "none" } }
+      it "ignores them" do
+        expect(subject.merge_previous_parameters(query_parameters)).to eq({ "l" => 1, "query" => "query", "test" => "test" })
+      end
+    end
+  end
+end

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -1,0 +1,171 @@
+require "rails_helper"
+
+feature "Location filter back link", type: :feature do
+  let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
+  let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:base_parameters) { results_page_parameters }
+  let(:courses_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  let(:subjects_url) do
+    "http://localhost:3001/api/v3/subject_areas?include=subjects"
+  end
+
+  before do
+    stub_results_page_request
+    stub_request(:get, subjects_url)
+  end
+
+  context "before the location filter form has been submitted" do
+    it "returns the user to their previous filtered results" do
+      load_results_page
+      open_the_location_filter
+      click_the_back_link
+      the_results_page_has_the_default_location_filter
+    end
+  end
+
+  context "after an invalid postcode search has been submitted" do
+    before do
+      stub_provider_request
+      stub_courses_request_with_acme
+    end
+
+    it "returns the user to their previous filtered results" do
+      load_results_page
+      open_the_location_filter
+      select_a_provider
+
+      open_the_change_provider_filter
+      submit_an_invalid_postcode_filter
+      click_the_back_link
+
+      the_results_page_still_has_the_original_provider_filter_applied
+    end
+  end
+
+  context "after an invalid provider search has been submitted" do
+    before do
+      stub_geocoder
+      stub_courses_request_with_location
+    end
+
+    it "returns the user to their previous filtered results" do
+      load_results_page
+      open_the_location_filter
+      select_a_location
+
+      open_the_location_filter
+      submit_an_invalid_provider_filter
+      click_the_back_link
+
+      the_results_page_still_has_the_original_location_filter_applied
+    end
+  end
+
+  def load_results_page
+    results_page.load
+  end
+
+  def open_the_location_filter
+    results_page.location_filter.link.click
+  end
+
+  def open_the_change_provider_filter
+    results_page.provider_filter.link.click
+  end
+
+  def select_a_provider
+    filter_page.by_provider.click
+    filter_page.provider_search.fill_in(with: "ACME")
+    filter_page.find_courses.click
+    provider_page.provider_suggestions[0].hyperlink.click
+  end
+
+  def submit_an_invalid_postcode_filter
+    filter_page.by_postcode_town_or_city.click
+    filter_page.find_courses.click
+  end
+
+  def click_the_back_link
+    filter_page.back_link.click
+  end
+
+  def the_results_page_still_has_the_original_provider_filter_applied
+    expect(results_page.provider_filter.name).to have_text("ACME SCITT 0")
+  end
+
+  def select_a_location
+    filter_page.by_postcode_town_or_city.click
+    filter_page.location_query.fill_in(with: "SW1P 3BT")
+    filter_page.find_courses.click
+  end
+
+  def submit_an_invalid_provider_filter
+    filter_page.by_provider.click
+    filter_page.find_courses.click
+  end
+
+  def the_results_page_still_has_the_original_location_filter_applied
+    expect(results_page.location_filter.name).to have_text("SW1P 3BT")
+  end
+
+  def the_results_page_has_the_default_location_filter
+    expect(results_page.location_filter.name).to have_text("Across England")
+  end
+
+  def stub_provider_request
+    stub_request(
+      :get,
+      "http://localhost:3001/api/v3/recruitment_cycles/2020/providers",
+    ).with(
+      query: {
+        "fields[providers]" => "provider_code,provider_name",
+        "search" => "ACME",
+      },
+      ).to_return(
+        body: File.new("spec/fixtures/api_responses/providers.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+  end
+
+  def stub_results_page_request
+    stub_request(:get, courses_url)
+      .with(any_parameters)
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/ten_courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
+  end
+
+  def stub_courses_request_with_acme
+    stub_request(:get, courses_url)
+      .with(
+        query: base_parameters.merge("filter[provider.provider_name]" => "ACME SCITT 0"),
+    )
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/four_courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
+  end
+
+  def stub_courses_request_with_location
+    stub_request(:get, courses_url)
+      .with(
+        query: base_parameters.merge("filter[longitude]" => "-0.1300436",
+                                     "filter[latitude]" => "51.4980188",
+                                     "filter[radius]" => "20",
+                                     "sort" => "distance"),
+    )
+      .to_return(
+        body: File.new("spec/fixtures/api_responses/ten_courses.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
+  end
+
+  def any_parameters
+    { query: hash_including({}) }
+  end
+end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -240,7 +240,7 @@ feature "Location filter", type: :feature do
       filter_page.find_courses.click
 
       expect(current_path).to eq(provider_page.url)
-      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to include(
         "l" => "3",
         "query" => "ACME",
       )
@@ -263,7 +263,7 @@ feature "Location filter", type: :feature do
         filter_page.find_courses.click
 
         expect(current_path).to eq(provider_page.url)
-        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to include(
           "l" => "3",
           "query" => "ACME",
           "another_option" => "option",

--- a/spec/views/shared/hidden_previous_fields_spec.rb
+++ b/spec/views/shared/hidden_previous_fields_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe "shared/hidden_previous_fields.html.erb", type: :view do
+  let(:form_builder) { double }
+
+  before do
+    allow(form_builder).to receive(:hidden_field)
+    render partial: "shared/hidden_previous_fields.html.erb", locals: { form: form_builder, params: params }
+  end
+
+  context "prev_ parameters are present in the params" do
+    let(:params) { { "prev_l" => "test-prev" } }
+
+    it "uses the previous value" do
+      expect(form_builder).to have_received(:hidden_field).with("prev_l", value: "test-prev")
+    end
+  end
+
+  context "prev_ parameters are not present in the params" do
+    let(:params) { { "loc" => "test-prev" } }
+
+    it "uses the current value" do
+      expect(form_builder).to have_received(:hidden_field).with("prev_loc", value: "test-prev")
+    end
+  end
+
+  context "neither prev_ nor current parameters present in the params" do
+    let(:params) { {} }
+
+    it "uses 'none'" do
+      expect(form_builder).to have_received(:hidden_field).with("prev_loc", value: "none")
+    end
+  end
+end


### PR DESCRIPTION
### Context

When selecting a 'location' filter (or provider filter as they are selected on the same page) there is a back link. We populate the backlink with the values from the original querystring that arrives with the filter page request. When an invalid form is submitted from that page the backlink is rebuilt with the now invalid parameters. If the backlink is clicked a variety of broken results pages are displayed depending on what combination of original and invalid filters are selected. This leads to either an incorrect filter being applied or in some cases no results at all and on '14xxx across England' link being displayed.

### Changes proposed in this pull request

Store the parameters from the last valid results page in a set of hidden fields prefixed with `prev_`. In the event of an invalid form being submitted from the location page, use these to build the back link.

Remove these parameters before the results page is rendered both from the back link and also from the provider links on the interstitial (non-javascript) provider list page.

### Guidance to review

**With JS:**

* Create a valid location filter
* Click 'Change location or choose a provider' and submit an empty provider filter form so as an error message is displayed. 
* Click the back link
* You should be returned to the original location filter

* Create a valid provider filter
* Click 'Change location or choose a provider' and submit an empty location filter form so as an error message is displayed. 
* Click the back link
* You should be returned to the original provider filter

**Without JS:**

Do those ^

also...

* Submit an incomplete provider search so as the provider list is displayed. 
* Check that the links for the provider work

In all cases the `prev_` parameters should have been removed by the time you return to the results page.

The start pages don't have a back link but will still get `prev_` parameters in their querystring if an invalid form is submitted. These should have been removed by the time the results page is reached and will have been set to `none` which is ignored.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
