### PR TITLE
[3028] Add search suggestions when searching with salary

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -201,19 +201,24 @@ class ResultsView
   end
 
   def suggested_search_links
-    @suggested_search_links ||= begin
-                                  all_links = []
-                                  radii_for_suggestions.each do |radius|
-                                    break if filter_links(all_links).count == 2
+    all_links = []
 
-                                    all_links << SuggestedSearchLink.new(
-                                      radius: radius,
-                                      count: course_counter(radius_to_check: radius),
-                                      parameters: query_parameters_with_defaults,
-                                    )
-                                  end
-                                  filter_links(all_links)
-                                end
+    if with_salaries?
+      first_link = suggested_search_link_including_unsalaried(current_radius: radius)
+      all_links << first_link if first_link.present?
+    end
+
+    radii_for_suggestions.each do |radius|
+      break if filter_links(all_links).count == 2
+
+      all_links << SuggestedSearchLink.new(
+        radius: radius,
+        count: course_counter(radius_to_check: radius),
+        parameters: query_parameters_with_defaults,
+      )
+    end
+
+    @suggested_search_links ||= filter_links(all_links)
   end
 
   def no_results_found?
@@ -358,18 +363,18 @@ private
     subject_parameters_array.any? ? subject_parameters_array.length : all_subjects.count
   end
 
-  def course_counter(radius_to_check: nil)
-    course_query(include_location: radius_to_check.present?, radius_to_query: radius_to_check).all.meta["count"]
+  def course_counter(radius_to_check: nil, include_salary: true)
+    course_query(include_location: radius_to_check.present?, radius_to_query: radius_to_check, include_salary: include_salary).all.meta["count"]
   end
 
-  def course_query(include_location:, radius_to_query: radius)
+  def course_query(include_location:, radius_to_query: radius, include_salary: true)
     base_query = Course.
       includes(site_statuses: [:site]).
       includes(:provider).
       includes(:subjects).
       where(recruitment_cycle_year: Settings.current_cycle)
 
-    base_query = base_query.where(funding: "salary") if with_salaries?
+    base_query = base_query.where(funding: "salary") if include_salary && with_salaries?
     base_query = base_query.where(has_vacancies: hasvacancies?)
     base_query = base_query.where(study_type: study_type) if study_type.present?
 
@@ -397,5 +402,28 @@ private
   def radii_for_suggestions
     radius_for_all_england = nil
     [10, 20, 50].reject { |rad| rad <= radius.to_i } << radius_for_all_england
+  end
+
+  def suggested_search_link_including_unsalaried(current_radius:)
+    suggested_search_link = nil
+
+    radii_including_current = [current_radius] + radii_for_suggestions
+
+    radii_including_current.each do |radius|
+      break if suggested_search_link.present?
+
+      count = course_counter(radius_to_check: radius, include_salary: false)
+
+      if count > course_count
+        suggested_search_link = SuggestedSearchLink.new(
+          radius: radius,
+          count: count,
+          parameters: query_parameters_with_defaults.except("funding"),
+          including_non_salaried: true,
+        )
+      end
+    end
+
+    suggested_search_link
   end
 end

--- a/app/view_objects/suggested_search_link.rb
+++ b/app/view_objects/suggested_search_link.rb
@@ -1,14 +1,16 @@
 class SuggestedSearchLink
-  attr_reader :radius, :count, :parameters
+  include ActionView::Helpers::TextHelper
+  attr_reader :radius, :count, :parameters, :including_non_salaried
 
-  def initialize(radius:, count:, parameters:)
+  def initialize(radius:, count:, parameters:, including_non_salaried: false)
     @radius = radius
     @count = count
     @parameters = parameters
+    @including_non_salaried = including_non_salaried
   end
 
   def text
-    count_prefix = "#{count} course#{'s' if count != 1} "
+    count_prefix = "#{pluralize(count, 'course')} #{'with or without a salary ' if including_non_salaried}"
     count_prefix + (all_england? ? "across England" : "within #{radius} miles")
   end
 

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -1,0 +1,295 @@
+describe "Suggested salary searches" do
+  let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:courses_url) do
+    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  end
+
+  def default_query_for_location_search(radius:)
+    { l: 1, loc: "Cat Town", lq: "Cat Town", lat: 51.4980188, lng: -0.1300436, rad: radius }
+  end
+
+  def stub_subjects
+    stub_request(:get, "http://localhost:3001/api/v3/subject_areas?include=subjects")
+  end
+
+  def course_fixture_for(results:)
+    file_name = case results
+                when 0
+                  "empty_courses.json"
+                when 2
+                  "two_courses.json"
+                when 4
+                  "four_courses.json"
+                when 10
+                  "ten_courses.json"
+                end
+
+    File.new("spec/fixtures/api_responses/#{file_name}")
+  end
+
+  def suggested_search_count_parameters
+    results_page_parameters.reject do |k, _v|
+      ["page[page]", "page[per_page]", "sort"].include?(k)
+    end
+  end
+
+  def stub_courses(number_of_results:, query:)
+    stub_request(:get, courses_url)
+      .with(query: query)
+      .to_return(
+        body: course_fixture_for(results: number_of_results),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+    )
+  end
+
+  def stub_suggested_across_england_with_salary_filter(number_of_results:)
+    stub_courses(
+      number_of_results: number_of_results,
+      query: suggested_search_count_parameters.merge("filter[funding]" => "salary"),
+    )
+  end
+
+  def stub_suggested_across_england_without_salary_filter(number_of_results:)
+    stub_courses(
+      number_of_results: number_of_results,
+      query: suggested_search_count_parameters,
+    )
+  end
+
+  def stub_results_with_salary_filter(radius:, number_of_results:)
+    stub_courses(
+      number_of_results: number_of_results,
+      query: results_page_parameters.merge(
+        "filter[funding]" => "salary",
+        "filter[latitude]" => 51.4980188,
+        "filter[longitude]" => -0.1300436,
+        "filter[radius]" => radius,
+      ),
+    )
+  end
+
+  def stub_suggested_with_salary_filter(radius:, number_of_results:)
+    stub_courses(
+      number_of_results: number_of_results,
+      query: suggested_search_count_parameters.merge(
+        "filter[funding]" => "salary",
+        "filter[latitude]" => 51.4980188,
+        "filter[longitude]" => -0.1300436,
+        "filter[radius]" => radius,
+      ),
+    )
+  end
+
+  def stub_suggested_without_salary_filter(radius:, number_of_results:)
+    stub_courses(
+      number_of_results: number_of_results,
+      query: suggested_search_count_parameters.merge(
+        "filter[latitude]" => 51.4980188,
+        "filter[longitude]" => -0.1300436,
+        "filter[radius]" => radius,
+      ),
+    )
+  end
+
+  def search_for_salaried_courses_with_query_params(query)
+    filter_page.load(query: query)
+    filter_page.salary_courses.click
+    filter_page.find_courses.click
+  end
+
+  before do
+    stub_subjects
+  end
+
+  context "with 0 results" do
+    context "and the initial search was filtered to a 5 mile radius" do
+      before do
+        stub_results_with_salary_filter(radius: 5, number_of_results: 0)
+      end
+
+      context "with courses available that are non-salaried with the same radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 5, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 10, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the same radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 5))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 5 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles")
+        end
+      end
+
+      context "with courses available that are non-salaried with a larger radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 5, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 10, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 10, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the larger radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 5))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 10 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles")
+        end
+      end
+
+      context "no courses are found in the suggested searches" do
+        before do
+          stub_suggested_without_salary_filter(radius: 5, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 10, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 20, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 50, number_of_results: 0)
+          stub_suggested_across_england_without_salary_filter(number_of_results: 0)
+
+          stub_suggested_with_salary_filter(radius: 5, number_of_results: 0)
+          stub_suggested_with_salary_filter(radius: 10, number_of_results: 0)
+          stub_suggested_with_salary_filter(radius: 20, number_of_results: 0)
+          stub_suggested_with_salary_filter(radius: 50, number_of_results: 0)
+          stub_suggested_across_england_with_salary_filter(number_of_results: 0)
+        end
+
+        it "doesn't show the link if" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 5))
+
+          expect(results_page).not_to have_suggested_search_links
+        end
+      end
+    end
+
+    context "and the initial search was filtered to a 10 mile radius" do
+      before do
+        stub_results_with_salary_filter(radius: 10, number_of_results: 0)
+      end
+
+      context "with courses available that are non-salaried with the same radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 10, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 20, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the same radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 10))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 10 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles")
+        end
+      end
+
+      context "with courses available that are non-salaried with a larger radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 10, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 20, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 20, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the larger radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 10))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles")
+        end
+      end
+    end
+
+    context "and the initial search was filtered to a 20 mile radius" do
+      before do
+        stub_results_with_salary_filter(radius: 20, number_of_results: 0)
+      end
+
+      context "with courses available that are non-salaried with the same radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 20, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 50, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the same radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 20))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles")
+        end
+      end
+
+      context "with courses available that are non-salaried with a larger radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 20, number_of_results: 0)
+          stub_suggested_without_salary_filter(radius: 50, number_of_results: 4)
+          stub_suggested_with_salary_filter(radius: 50, number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the larger radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 20))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles")
+        end
+      end
+    end
+
+    context "and the initial search was filtered to a 50 mile radius" do
+      before do
+        stub_results_with_salary_filter(radius: 50, number_of_results: 0)
+      end
+
+      context "with courses available that are non-salaried with the same radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 50, number_of_results: 4)
+          stub_suggested_across_england_with_salary_filter(number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the same radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 50))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England")
+        end
+      end
+
+      context "with courses available that are non-salaried with a larger radius and salaried in a larger radius" do
+        before do
+          stub_suggested_without_salary_filter(radius: 50, number_of_results: 0)
+          stub_suggested_across_england_without_salary_filter(number_of_results: 4)
+          stub_suggested_across_england_with_salary_filter(number_of_results: 10)
+        end
+
+        it "displays a suggested search for the non-salaried courses with the larger radius first followed with salaried in a larger radius" do
+          search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 50))
+
+          expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
+          expect(results_page.suggested_search_description.text).to eq("You can find:")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary across England")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England")
+        end
+      end
+    end
+  end
+
+  context "with more than 2 results" do
+    before do
+      stub_results_with_salary_filter(radius: 5, number_of_results: 10)
+    end
+
+    it "does not show the suggested searches" do
+      search_for_salaried_courses_with_query_params(default_query_for_location_search(radius: 5))
+      expect(results_page).not_to have_suggested_search_links
+    end
+  end
+end


### PR DESCRIPTION
### Context

Search suggestions need to appear when searching with salary and getting < 3 results

### Changes proposed in this pull request

- Extend current search suggesion logic to encompass salaried searches

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
