### PR TITLE
[3178] remove blank provider redirect

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,18 +1,5 @@
 class ResultsController < ApplicationController
   def index
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
-
-    if filtering_by_blank_provider?
-      params_hash = request.query_parameters.merge(l: 2)
-      params_hash.delete("query")
-
-      redirect_to results_path(params_hash)
-    end
-  end
-
-private
-
-  def filtering_by_blank_provider?
-    @results_view.provider_filter? && @results_view.provider.blank?
   end
 end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -219,26 +219,4 @@ feature "results", type: :feature do
       end
     end
   end
-
-  describe "location filter" do
-    context "location with blank provider name" do
-      let(:params) do
-        {
-          l: 3,
-          query: "",
-          qualifications: "QtsOnly,PgdePgceWithQts,Other",
-          fulltime: "False",
-          parttime: "False",
-          hasvacancies: "True",
-          senCourses: "False",
-        }
-      end
-
-      it "falls back to l2 (Across England)" do
-        location_filter_uri = URI(current_url)
-        expect(location_filter_uri.path).to eq("/results")
-        expect(location_filter_uri.query).to eq("fulltime=False&hasvacancies=True&l=2&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&senCourses=False")
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Context

- Previously the removed redirect logic was added as there was no validation on the filter form
- Therefore users were able to enter invalid states which would have to be handled in the results page
- As there is now validation on the filter form there is no longer a need to handle these invalid states on the results page

### Changes proposed in this pull request

- When provider is blank this previously redirected to `Across England`
- This is no longer needed as filter form now has validation to prevent user from entering this odd invalid state
- Should the user enter this invalid state we still search `Across England` by default

### Guidance to review

- perform search with blank provider in the form
- should not be able to reach removed redirect logic as form validation prevents user from entering this invalid state
- should be validation that informs you to enter a provider
- this should work for both javascript and non-javascript versions

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
