### PR TITLE
[3160] Exclude pagination params from filter_parameters

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -3,7 +3,7 @@ module FilterParameters
 
   def filter_params
     parameters.reject do |param|
-      param.in? %w(utf8 authenticity_token)
+      param.in? %w(utf8 authenticity_token page)
     end
   end
 
@@ -20,6 +20,8 @@ module FilterParameters
 
     remove_previous_parameters(all_parameters)
   end
+
+private
 
   def parameters
     return request.query_parameters if %w(GET HEAD).include?(request.method)

--- a/spec/controllers/concerns/filter_parameters_spec.rb
+++ b/spec/controllers/concerns/filter_parameters_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe FilterParameters do
   end
 
   describe "#filter_params" do
+    context "GET" do
+      context "when rails parameters are present" do
+        let(:query_parameters) { { "utf8" => true, "authenticity_token" => "token", "test" => "test" } }
+
+        it "they are stripped" do
+          expect(subject.filter_params).to eq({ "test" => "test" })
+        end
+      end
+
+      context "when pagination parameters are present" do
+        let(:query_parameters) { { "page" => 3, "test" => "test" }.with_indifferent_access }
+
+        it "they are stripped" do
+          expect(subject.filter_params).to eq({ "test" => "test" })
+        end
+      end
+    end
+
     context "POST" do
       let(:verb) { "POST" }
       let(:request_parameters) { { "test" => "request" } }
@@ -35,6 +53,14 @@ RSpec.describe FilterParameters do
 
       it "uses request_parameters" do
         expect(subject.filter_params["test"]).to eq("request")
+      end
+
+      context "when pagination parameters are present" do
+        let(:request_parameters) { { "page" => 3, "test" => "test" } }
+
+        it "they are stripped" do
+          expect(subject.filter_params).to eq({ "test" => "test" })
+        end
       end
     end
 


### PR DESCRIPTION
### Context
This resolves the following bug:

Theres a large result set shown on the results page and the user has
used pagination to look through the results. They decide to edit some
filters. After changes to the filter the result set is narrowed down but
the results page tries to take them back to the last set pagination.
This is likely to cause confusion for users or raise errors for us to
investigate. For example the result set is only has 3 courses and the
user was on the 6th page of results.
### Changes proposed in this pull request


### Guidance to review

Search for courses "Across England". Use the pagination and then edit each filter and test the following each time:

1. Try the back link - It should take you back to the page you were last on
2. Update a filter and click "Continue" to go back to the results page - You should be taken to the first page of results.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
