### PR TITLE
[3189] FilterParameters supports HEAD requests

### DIFF
--- a/app/controllers/concerns/filter_parameters.rb
+++ b/app/controllers/concerns/filter_parameters.rb
@@ -42,7 +42,7 @@ private
   end
 
   def parameters
-    return request.query_parameters if request.method == "GET"
+    return request.query_parameters if %w(GET HEAD).include?(request.method)
 
     request.request_parameters
   end

--- a/spec/controllers/concerns/filter_parameters_spec.rb
+++ b/spec/controllers/concerns/filter_parameters_spec.rb
@@ -55,6 +55,15 @@ RSpec.describe FilterParameters do
         expect(subject.filter_params["test"]).to eq("request")
       end
     end
+
+    context "HEAD" do
+      let(:verb) { "HEAD" }
+      let(:query_parameters) { { "utf8" => true, "authenticity_token" => "token", "test" => "test" } }
+
+      it "returns the query parameters" do
+        expect(subject.filter_params).to eq({ "test" => "test" })
+      end
+    end
   end
 
   describe "#deserialize_array_filter_param" do


### PR DESCRIPTION
### Context

HEAD requests were causing errors as `parameters` was returning `nil`. They should be treated as GET requests in this context.

### Changes proposed in this pull request

Treat HEAD requests as GET requests in `FilterParameters`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
