### PR TITLE
[3202] Convert to non-existent subject codes to and from C# codes

### DIFF
--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -21,7 +21,13 @@ module CsharpRailsSubjectConversionHelper
       entry[:csharp_id] == id
     end
 
-    raise "An unregistered subject id was specified: #{id}" if rails_data.nil?
+    # A user may somehow end up with a subject that doesn't exist.
+    # If we weren't converting subject IDs, this wouldn't be an issue
+    # but since we are, we will just return a subject id that will never exist.
+    # This workaround means that removing this entire module will be easier in
+    # future because we don't need to do any extra work to ensure a subject
+    # exists.
+    return "[non-existent subject code]" if rails_data.nil?
 
     rails_data[:subject_code]
   end
@@ -31,7 +37,7 @@ module CsharpRailsSubjectConversionHelper
       entry[:subject_code] == id
     end
 
-    raise "An unregistered subject id was specified: #{id}" if csharp_data.nil?
+    return "[non-existent subject id]" if csharp_data.nil?
 
     csharp_data[:csharp_id]
   end


### PR DESCRIPTION
### Context
When a non-existent C# subject was specified we raised an error in order to highlight any bugs with the C# conversion. This has ceased to be useful as C# conversion moves towards complete removal.

### Changes proposed in this pull request
When trying to convert a C# subject that doesn't exist, return a subject code that cannot exist.

### Guidance to review
This fix is not nice, this is intentional. It avoids the need for a fix to be implemented outside, which would further embed this code in the system and complicated removing it, because the code outside of this file is correct.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
