### PR TITLE
[3212] Handle subjects as comma delimited string

### DIFF
--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -1,7 +1,13 @@
 #These functions are barely tested and temporary, they should be removed when the results page is filtering in Rails
 module CsharpRailsSubjectConversionHelper
   def convert_csharp_subject_id_params_to_subject_code
-    params["subjects"]&.map do |subject|
+    subjects = if params["subjects"].is_a?(String)
+                 params["subjects"].split(",")
+               else
+                 params["subjects"]
+               end
+
+    subjects&.map do |subject|
       csharp_to_subject_code(id: subject)
     end
   end

--- a/spec/controllers/result_filters/subject_controller_spec.rb
+++ b/spec/controllers/result_filters/subject_controller_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe ResultFilters::SubjectController do
+  describe "#new" do
+    context "when subjects is a comma delimited string" do
+      it "returns a 200" do
+        stub_request(:get, "http://localhost:3001/api/v3/subject_areas?include=subjects").
+           with(
+             headers: {
+              "Accept" => "application/vnd.api+json",
+              "Accept-Encoding" => "gzip,deflate",
+              "Content-Type" => "application/vnd.api+json",
+              "User-Agent" => "Faraday v0.17.3",
+             },
+           ).to_return(status: 200, body: "", headers: {})
+
+        get :new, params: { subjects: "38,29" }
+        expect(response).to be_successful
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/QJ6cXQZU/3212-sentry-error-when-subjects-is-a-string-eg-12
- There fixes an error where users are accessing results with subjects as comma delimited string
- They may be an old style from csharp world

### Changes proposed in this pull request

- Handle conversion of comma delimited string of subjects

### Guidance to review

- visit url seen in sentry. see trello ticket
- previously would throw an error. should now no longer seen an error and see filter page
- can now submit filter page to see results

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
