### PR TITLE
[3029] copy update search suggestion when searching for a salaried course when there are 3 salaried courses

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -225,6 +225,7 @@ class ResultsView
         radius: radius,
         count: course_counter(radius_to_check: radius),
         parameters: query_parameters_with_defaults,
+        explicit_salary_filter: with_salaries?,
       )
     end
 

--- a/app/view_objects/suggested_search_link.rb
+++ b/app/view_objects/suggested_search_link.rb
@@ -1,16 +1,17 @@
 class SuggestedSearchLink
   include ActionView::Helpers::TextHelper
-  attr_reader :radius, :count, :parameters, :including_non_salaried
+  attr_reader :radius, :count, :parameters, :including_non_salaried, :explicit_salary_filter
 
-  def initialize(radius:, count:, parameters:, including_non_salaried: false)
+  def initialize(radius:, count:, parameters:, including_non_salaried: false, explicit_salary_filter: false)
     @radius = radius
     @count = count
     @parameters = parameters
     @including_non_salaried = including_non_salaried
+    @explicit_salary_filter = explicit_salary_filter
   end
 
   def text
-    count_prefix = "#{pluralize(count, 'course')} #{'with or without a salary ' if including_non_salaried}"
+    count_prefix = "#{pluralize(count, text_course_text)} "
     count_prefix + (all_england? ? "across England" : "within #{radius} miles")
   end
 
@@ -33,5 +34,12 @@ private
     parameters
       .reject { |k, _v| %w(lat lng rad loc lq).include?(k) }
       .merge("l" => 2)
+  end
+
+  def text_course_text
+    return "non-salaried course" if including_non_salaried
+    return "salaried course" if explicit_salary_filter
+
+    "course"
   end
 end

--- a/app/view_objects/suggested_search_link.rb
+++ b/app/view_objects/suggested_search_link.rb
@@ -11,8 +11,9 @@ class SuggestedSearchLink
   end
 
   def text
-    count_prefix = "#{pluralize(count, text_course_text)} "
-    count_prefix + (all_england? ? "across England" : "within #{radius} miles")
+    count_prefix = "#{pluralize(count, 'course')} "
+    count_prefix << (all_england? ? "across England" : "within #{radius} miles")
+    count_prefix << (text_course_text.presence || "")
   end
 
   def url
@@ -20,6 +21,12 @@ class SuggestedSearchLink
       base_path: Rails.application.routes.url_helpers.results_path,
       parameters: suggested_search_link_parameters(radius: radius),
     )
+  end
+
+  def suffix
+    return " - including both salaried courses and ones without a salary" if including_non_salaried
+
+    ""
   end
 
 private
@@ -37,9 +44,8 @@ private
   end
 
   def text_course_text
-    return "non-salaried course" if including_non_salaried
-    return "salaried course" if explicit_salary_filter
+    return " with a salary" if explicit_salary_filter
 
-    "course"
+    ""
   end
 end

--- a/app/views/results/_try_another_search_text.html.erb
+++ b/app/views/results/_try_another_search_text.html.erb
@@ -1,0 +1,7 @@
+<p class="govuk-body">
+You can <%= link_to "try another search", root_path, class: "govuk-link" %>, for example by changing subject or location 
+<% if @results_view.with_salaries? %>
+or searching for courses that don't offer a salary
+<% end %>
+.
+</p>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -40,9 +40,7 @@
           <h2 class="govuk-heading-l">
             There are no courses matching your&nbsp;search
           </h2>
-          <p class="govuk-body">
-            You can <%= link_to "try another search", root_path, class: "govuk-link" %>, for example by changing subject or location.
-          </p>
+          <%= render partial: "try_another_search_text" %>
         </div>
       <% else %>
         <div class="govuk-grid-row">
@@ -93,10 +91,10 @@
           <p class="govuk-body" data-qa="suggested_search_description">You can find:</p>
           <ul class="govuk-list govuk-list--bullet">
             <%- @results_view.suggested_search_links.each do |link| %>
-            <li data-qa="suggested_search_link">
-              <a href="<%=link.url%>" class="govuk-link" data-qa="link"><%=link.text%></a>
-            </li>
-          <%- end -%>
+              <li data-qa="suggested_search_link">
+                <a href="<%=link.url%>" class="govuk-link" data-qa="link"><%=link.text%></a><%=link.suffix%>
+              </li>
+            <%- end -%>
           </ul>
         </div>
       <% end %>

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -127,8 +127,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 5 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 10 miles")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 5 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 5 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles with a salary")
         end
       end
 
@@ -144,8 +145,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 10 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 10 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 10 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 10 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles with a salary")
         end
       end
 
@@ -188,8 +190,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 10 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 20 miles")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 10 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 10 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles with a salary")
         end
       end
 
@@ -205,8 +208,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 20 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 20 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 20 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles with a salary")
         end
       end
     end
@@ -227,8 +231,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 20 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 50 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 20 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles with a salary")
         end
       end
 
@@ -244,8 +249,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 50 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 50 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 50 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles with a salary")
         end
       end
     end
@@ -266,8 +272,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 50 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses across England")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses within 50 miles - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England with a salary")
         end
       end
 
@@ -283,8 +290,9 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses across England")
-          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses across England")
+          expect(results_page.suggested_search_links.first.text).to eq("4 courses across England - including both salaried courses and ones without a salary")
+          expect(results_page.suggested_search_links.first.link.text).to eq("4 courses across England")
+          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England with a salary")
         end
       end
     end

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe "Suggested salary searches" do
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -125,8 +127,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 5 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 5 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 10 miles")
         end
       end
 
@@ -142,8 +144,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 10 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 10 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 10 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 10 miles")
         end
       end
 
@@ -186,8 +188,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 10 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 10 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 20 miles")
         end
       end
 
@@ -203,8 +205,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 20 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 20 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 20 miles")
         end
       end
     end
@@ -225,8 +227,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 20 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 20 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 50 miles")
         end
       end
 
@@ -242,8 +244,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 50 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses within 50 miles")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses within 50 miles")
         end
       end
     end
@@ -264,8 +266,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary within 50 miles")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses within 50 miles")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses across England")
         end
       end
 
@@ -281,8 +283,8 @@ describe "Suggested salary searches" do
 
           expect(results_page.suggested_search_heading.text).to eq("Suggested searches")
           expect(results_page.suggested_search_description.text).to eq("You can find:")
-          expect(results_page.suggested_search_links.first.text).to eq("4 courses with or without a salary across England")
-          expect(results_page.suggested_search_links.last.text).to eq("10 courses across England")
+          expect(results_page.suggested_search_links.first.text).to eq("4 non-salaried courses across England")
+          expect(results_page.suggested_search_links.last.text).to eq("10 salaried courses across England")
         end
       end
     end

--- a/spec/view_objects/suggested_search_link_spec.rb
+++ b/spec/view_objects/suggested_search_link_spec.rb
@@ -10,6 +10,11 @@ describe SuggestedSearchLink do
       it { is_expected.to eq("5 courses across England") }
     end
 
+    describe "#suffix" do
+      subject { super().suffix }
+      it { is_expected.to eq("") }
+    end
+
     describe "#url" do
       subject { super().url }
       it { is_expected.to eq("/results?l=2") }
@@ -23,6 +28,12 @@ describe SuggestedSearchLink do
     describe "#text" do
       subject { super().text }
       it { is_expected.to eq("5 courses within 10 miles") }
+    end
+
+    describe "#suffix" do
+      subject { super().suffix }
+
+      it { is_expected.to eq("") }
     end
 
     describe "#url" do
@@ -42,15 +53,32 @@ describe SuggestedSearchLink do
 
   context "including_non_salaried is true" do
     let(:parameters) { { "lat" => "5", "lng" => "-5", "rad" => "10", "loc" => "Shetlands", "lq" => "2" } }
-    subject { described_class.new(radius: nil, count: "5", parameters: parameters, including_non_salaried: true).text }
+    subject { described_class.new(radius: nil, count: "5", parameters: parameters, including_non_salaried: true) }
 
-    it { is_expected.to eq("5 non-salaried courses across England") }
+    describe "#text" do
+      subject { super().text }
+
+      it { is_expected.to eq("5 courses across England") }
+    end
+
+    describe "#suffix" do
+      subject { super().suffix }
+
+      it { is_expected.to eq(" - including both salaried courses and ones without a salary") }
+    end
   end
 
   context "explicit_salary_filter is true" do
     let(:parameters) { { "lat" => "5", "lng" => "-5", "rad" => "10", "loc" => "Shetlands", "lq" => "2" } }
-    subject { described_class.new(radius: nil, count: "5", parameters: parameters, explicit_salary_filter: true).text }
 
-    it { is_expected.to eq("5 salaried courses across England") }
+    describe "#text" do
+      subject { described_class.new(radius: nil, count: "5", parameters: parameters, explicit_salary_filter: true).text }
+      it { is_expected.to eq("5 courses across England with a salary") }
+    end
+
+    describe "#text" do
+      subject { described_class.new(radius: nil, count: "5", parameters: parameters, explicit_salary_filter: true).suffix }
+      it { is_expected.to eq("") }
+    end
   end
 end

--- a/spec/view_objects/suggested_search_link_spec.rb
+++ b/spec/view_objects/suggested_search_link_spec.rb
@@ -39,4 +39,18 @@ describe SuggestedSearchLink do
       end
     end
   end
+
+  context "including_non_salaried is true" do
+    let(:parameters) { { "lat" => "5", "lng" => "-5", "rad" => "10", "loc" => "Shetlands", "lq" => "2" } }
+    subject { described_class.new(radius: nil, count: "5", parameters: parameters, including_non_salaried: true).text }
+
+    it { is_expected.to eq("5 non-salaried courses across England") }
+  end
+
+  context "explicit_salary_filter is true" do
+    let(:parameters) { { "lat" => "5", "lng" => "-5", "rad" => "10", "loc" => "Shetlands", "lq" => "2" } }
+    subject { described_class.new(radius: nil, count: "5", parameters: parameters, explicit_salary_filter: true).text }
+
+    it { is_expected.to eq("5 salaried courses across England") }
+  end
 end

--- a/spec/views/results/try_another_search_text_spec.rb
+++ b/spec/views/results/try_another_search_text_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "results/try_another_search_text.html.erb", type: :view do
+  let(:html) { render partial: "results/try_another_search_text.html.erb" }
+  let(:salary_suffix) { "or searching for courses that don't offer a salary" }
+
+  before do
+    assign(:results_view, double(with_salaries?: with_salaries))
+  end
+
+  context "with_salaries is true" do
+    let(:with_salaries) { true }
+
+    it "renders the salary suffix " do
+      expect(html).to match(salary_suffix)
+    end
+  end
+
+  context "with_salaries is false" do
+    let(:with_salaries) { false }
+
+    it "does't render the salary suffix " do
+      expect(html).not_to match(salary_suffix)
+    end
+  end
+end


### PR DESCRIPTION
### Context

If a user search for salaried courses returns 3 or less results we show them suggested search links. The first link should include salaried and non-salaried courses at a radius that returns more courses than the original search. If widening the radius further returns more results we should show a link to that too. The subsequent links should respect the original filter and only include salaried courses.

If an increment of the radius only returns the same number of courses as the previous radius we don't show the link.

### Changes proposed in this pull request

Update the text of the links to better describe the searches that they link to.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
