### PR TITLE
Add encoding for autocomplete queries

### DIFF
--- a/app/controllers/provider_suggestions_controller.rb
+++ b/app/controllers/provider_suggestions_controller.rb
@@ -2,7 +2,8 @@ class ProviderSuggestionsController < ApplicationController
   def index
     return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
 
-    suggestions = ProviderSuggestion.suggest(params[:query])
+    sanitised_query = CGI.escape(params[:query])
+    suggestions = ProviderSuggestion.suggest(sanitised_query)
       .map { |provider| { code: provider.provider_code, name: provider.provider_name } }
     render json: suggestions
   end

--- a/app/models/provider_suggestion.rb
+++ b/app/models/provider_suggestion.rb
@@ -1,7 +1,7 @@
 class ProviderSuggestion < Base
   def self.suggest(query)
     self.requestor.__send__(
-      :request, :get, "/api/v3/provider-suggestions?query=#{CGI.escape(query)}"
+      :request, :get, "/api/v3/provider-suggestions?query=#{query}"
     )
   end
 end

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -1,5 +1,9 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
+export const getPath = (endpoint,query) => {
+  return `${endpoint}?query=${query}`;
+}
+
 export const request = endpoint => {
   let xhr = null; // Hoist this call so that we can abort previous requests.
 
@@ -7,9 +11,7 @@ export const request = endpoint => {
     if (xhr && xhr.readyState !== XMLHttpRequest.DONE) {
       xhr.abort();
     }
-
-    let encodedQuery = encodeURIComponent(query);
-    const path = `${endpoint}?query=${encodedQuery}`;
+    const path = getPath(endpoint, query);
 
     xhr = new XMLHttpRequest();
     xhr.addEventListener("load", evt => {

--- a/app/webpacker/scripts/autocomplete.spec.js
+++ b/app/webpacker/scripts/autocomplete.spec.js
@@ -1,4 +1,4 @@
-import initAutocomplete, { request } from "./autocomplete";
+import initAutocomplete, {getPath, request} from "./autocomplete";
 
 const abortMock = jest.fn();
 global.XMLHttpRequest = jest.fn(() => ({
@@ -32,6 +32,13 @@ describe("Autocomplete", () => {
     it("should instantiate an autocomplete", () => {
       expect(document.querySelector("#outer-container")).toMatchSnapshot();
     });
+  });
+
+  describe("getPath", () => {
+    it("should return a path", () => {
+      const path = getPath("/endpoint", "queryString");
+      expect(path).toBe("/endpoint?query=queryString")
+    })
   });
 
   describe("request", () => {

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -19,9 +19,9 @@ describe "/provider-suggestions", type: :request do
   end
   context "when provider suggestion query is valid" do
     query = "Str"
-    query_with_encoded_characters = "Str%E2%80%99"
+    query_with_unicode_character = "Str%E2%80%99"
 
-    [query, query_with_encoded_characters].each do |provider_query|
+    [query, query_with_unicode_character].each do |provider_query|
       it "returns success (200) for query: '#{provider_query}'" do
         provider_suggestions = stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=#{provider_query}")
                                  .to_return(


### PR DESCRIPTION
### Context

https://trello.com/c/4nSbRPzG/3276-s-publish-provider-autocomplete-not-encoding-request-correctly

### Changes proposed in this pull request

Modify autocomplete encoding to include tests

### Guidance to review
Linked to https://github.com/DFE-Digital/publish-teacher-training/issues/1025
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
