### PR TITLE
Add --frozen-lockfile to docker image yarn install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --update --no-cache --virtual build-dependances \
 
 ADD package.json $APP_HOME/package.json
 ADD yarn.lock $APP_HOME/yarn.lock
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 ADD . $APP_HOME/
 


### PR DESCRIPTION
Webpacker 5.1.0 removed yarn integrity checker. This commit ensures that
we also use the yarn.lock we generated while developing rather than updating
it. It should also fail if package.json & yarn.lock are out of sync.

Yarn's own maintainer discourages its use:
https://github.com/yarnpkg/yarn/issues/6427#issuecomment-434499073
and suggests the following solution:
Solution
Remove the integrity initializer and the configuration options. Encourage
developers to ensure yarn install in local environments and
yarn install --frozen-lockfile as part of deployment.

Other references:
https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile
https://github.com/rails/webpacker/pull/2518