### PR TITLE
[3291] Show vacancies in results view

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -124,7 +124,7 @@ class ResultsView
   end
 
   def vacancy_filter?
-    query_parameters["hasvacancies"] == "False"
+    query_parameters["hasvacancies"] == "false"
   end
 
   def sort_by_distance?

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -388,14 +388,14 @@ describe ResultsView do
   describe "#vacancy_filter?" do
     subject { described_class.new(query_parameters: parameter_hash).vacancy_filter? }
 
-    context "when hasvacancies param is set to True" do
-      let(:parameter_hash) { { "hasvacancies" => "True" } }
+    context "when hasvacancies param is set to true" do
+      let(:parameter_hash) { { "hasvacancies" => "true" } }
 
       it { is_expected.to be(false) }
     end
 
-    context "when hasvacancies param is set to False" do
-      let(:parameter_hash) { { "hasvacancies" => "False" } }
+    context "when hasvacancies param is set to false" do
+      let(:parameter_hash) { { "hasvacancies" => "false" } }
 
       it { is_expected.to be(true) }
     end


### PR DESCRIPTION
### Context
Vacancies not being shown when user filters by all courses

### Changes proposed in this pull request
Fix case of `hasvacancies` param

### Guidance to review
`https://s121d02-3291-find-as.azurewebsites.net/results?fulltime=false&hasvacancies=false&l=3&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&query=West+Essex+SCITT&senCourses=false`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
