### PR TITLE
[3296] Redirect start#location to root

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
     get "subject", to: "subject#start", as: "start_subject"
   end
 
+  # There is no need for a seperate path for start#location but this was the
+  # root path in the legacy c# app so we're redirecting to root
+  get "/start/location", to: redirect("/", status: "301")
+
   get "/terms-conditions", to: "pages#terms", as: "terms"
   get "/accessibility", to: "pages#accessibility", as: "accessibility"
   get "/privacy-policy", to: "pages#privacy", as: "privacy"

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+describe "/start", type: :request do
+  context "when a suser requests /location" do
+    it "redirects to root path" do
+      get "/start/location"
+      expect(response).to redirect_to("/")
+    end
+  end
+end


### PR DESCRIPTION
### Context
This is leftover from c# world, for context there used to be an information page before the location search, that was removed so the homepage became the location search.

### Changes proposed in this pull request
Redirect `/start/location` to root

### Guidance to review
`https://s121d02-3296-find-as.azurewebsites.net/start/location`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
