### PR TITLE
Add default radius to location search

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -10,6 +10,7 @@ class ResultsView
   SUGGESTED_SEARCH_THRESHOLD = 3
   MAXIMUM_NUMBER_OF_SUGGESTED_LINKS = 2
   RESULTS_PER_PAGE = 10
+  ALL_RADII = %w[5 10 20 50 100].freeze
 
   def initialize(query_parameters:)
     @query_parameters = query_parameters
@@ -86,7 +87,7 @@ class ResultsView
   end
 
   def radius
-    query_parameters["rad"]
+    ALL_RADII.include?(query_parameters["rad"]) ? query_parameters["rad"] : "20"
   end
 
   def sort_by

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -263,6 +263,17 @@ describe ResultsView do
 
       it { is_expected.to eq("10") }
     end
+
+    context "when an unapproved rad is passed" do
+      let(:parameter_hash) { { "rad" => "11" } }
+
+      it { is_expected.to eq("20") }
+    end
+
+    context "when rad is not passed" do
+      let(:parameter_hash) { {} }
+      it { is_expected.to eq("20") }
+    end
   end
 
   describe "#show_map?" do


### PR DESCRIPTION
### Context

https://trello.com/c/tWLPyVWv/3260-sset-default-search-radius-if-none-provided
https://sentry.io/organizations/dfe-bat/issues/1590006301/?project=1377944&referrer=slack

### Changes proposed in this pull request

* Add default of 20 miles to search radius if it's not included in the query parameters

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
