### PR TITLE
[3332] - Add bad query encoding middleware

### DIFF
--- a/app/controllers/location_suggestions_controller.rb
+++ b/app/controllers/location_suggestions_controller.rb
@@ -1,6 +1,14 @@
 class LocationSuggestionsController < ApplicationController
   def index
+    return render(json: { error: "Bad request" }, status: :bad_request) if params_invalid?
+
     suggestions = LocationSuggestion.suggest(params[:query])
     render json: suggestions
+  end
+
+private
+
+  def params_invalid?
+    params[:query].nil?
   end
 end

--- a/config/initializers/handle_bad_encoding.rb
+++ b/config/initializers/handle_bad_encoding.rb
@@ -1,0 +1,3 @@
+require "rack/handle_bad_encoding"
+
+Rails.application.config.middleware.use Rack::HandleBadEncoding

--- a/lib/rack/handle_bad_encoding.rb
+++ b/lib/rack/handle_bad_encoding.rb
@@ -1,0 +1,19 @@
+module Rack
+  class HandleBadEncoding
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      if env["REQUEST_PATH"] == "/location-suggestions"
+        begin
+          Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
+        rescue Rack::Utils::InvalidParameterError
+          env["QUERY_STRING"] = ""
+        end
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/spec/fixtures/api_responses/location-suggestions.json
+++ b/spec/fixtures/api_responses/location-suggestions.json
@@ -1,0 +1,163 @@
+{
+  "predictions": [
+    {
+      "description": "London, UK",
+      "id": "b1a8b96daab5065cf4a08f953e577c34cdf769c0",
+      "matched_substrings": [
+        {
+          "length": 6,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJdd4hrwug2EcRmSrV3Vo6llI",
+      "reference": "ChIJdd4hrwug2EcRmSrV3Vo6llI",
+      "structured_formatting": {
+        "main_text": "London",
+        "main_text_matched_substrings": [
+          {
+            "length": 6,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "UK"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "London"
+        },
+        {
+          "offset": 8,
+          "value": "UK"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "London Bridge Station, London, UK",
+      "id": "e186a3a32c7bb65a52a3ff926ac2f4745413f374",
+      "matched_substrings": [
+        {
+          "length": 6,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJZQtYnFADdkgRkj1_diDEvLY",
+      "reference": "ChIJZQtYnFADdkgRkj1_diDEvLY",
+      "structured_formatting": {
+        "main_text": "London Bridge Station",
+        "main_text_matched_substrings": [
+          {
+            "length": 6,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "London, UK"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "London Bridge Station"
+        },
+        {
+          "offset": 23,
+          "value": "London"
+        },
+        {
+          "offset": 31,
+          "value": "UK"
+        }
+      ],
+      "types": [
+        "premise",
+        "geocode"
+      ]
+    },
+    {
+      "description": "Londonderry, UK",
+      "id": "aede3ce2eed4c02e3eaaa4fb737ceccedc654fc6",
+      "matched_substrings": [
+        {
+          "length": 6,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJY5PQNOTdX0gRL_NVxyr6Ib0",
+      "reference": "ChIJY5PQNOTdX0gRL_NVxyr6Ib0",
+      "structured_formatting": {
+        "main_text": "Londonderry",
+        "main_text_matched_substrings": [
+          {
+            "length": 6,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "UK"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "Londonderry"
+        },
+        {
+          "offset": 13,
+          "value": "UK"
+        }
+      ],
+      "types": [
+        "locality",
+        "political",
+        "geocode"
+      ]
+    },
+    {
+      "description": "London Heathrow Terminal 2 - The Queen's Terminal, Inner Ring East, Hounslow, UK",
+      "id": "ae0ee93f39c36d61bcf9ee1c4040cfc62bbc91cd",
+      "matched_substrings": [
+        {
+          "length": 6,
+          "offset": 0
+        }
+      ],
+      "place_id": "ChIJAc88dMtzdkgR4YgFxhmidOo",
+      "reference": "ChIJAc88dMtzdkgR4YgFxhmidOo",
+      "structured_formatting": {
+        "main_text": "London Heathrow Terminal 2 - The Queen's Terminal",
+        "main_text_matched_substrings": [
+          {
+            "length": 6,
+            "offset": 0
+          }
+        ],
+        "secondary_text": "Inner Ring East, Hounslow, UK"
+      },
+      "terms": [
+        {
+          "offset": 0,
+          "value": "London Heathrow Terminal 2 - The Queen's Terminal"
+        },
+        {
+          "offset": 51,
+          "value": "Inner Ring East"
+        },
+        {
+          "offset": 68,
+          "value": "Hounslow"
+        },
+        {
+          "offset": 78,
+          "value": "UK"
+        }
+      ],
+      "types": [
+        "premise",
+        "geocode"
+      ]
+    }
+  ],
+  "status": "OK"
+}

--- a/spec/lib/rack/handle_bad_encoding_spec.rb
+++ b/spec/lib/rack/handle_bad_encoding_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe Rack::HandleBadEncoding do
+  let(:app) { double }
+  let(:middleware) { described_class.new(app) }
+
+  context "request path is '/location-suggestions'" do
+    context "query does not contain invalid encodings" do
+      it "does not modify the query" do
+        expect(app).to receive(:call).with("REQUEST_PATH" => "/location-suggestions", "QUERY_STRING" => "query=london")
+        middleware.call(
+          "REQUEST_PATH" => "/location-suggestions",
+          "QUERY_STRING" => "query=london",
+        )
+      end
+    end
+
+    context "query is absent" do
+      it "does not modify the query" do
+        expect(app).to receive(:call).with("REQUEST_PATH" => "/location-suggestions")
+        middleware.call("REQUEST_PATH" => "/location-suggestions")
+      end
+    end
+
+    context "query contains invalid encodings" do
+      it "modifies the query" do
+        expect(app).to receive(:call).with(
+          "QUERY_STRING" => "",
+          "REQUEST_PATH" => "/location-suggestions",
+        )
+        middleware.call(
+          "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+          "REQUEST_PATH" => "/location-suggestions",
+        )
+      end
+    end
+  end
+
+  context "request path is not 'location-suggestions'" do
+    it "does not modify the query" do
+      expect(app).to receive(:call).with(
+        "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+        "REQUEST_PATH" => "/foo/bar",
+      )
+      middleware.call(
+        "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+        "REQUEST_PATH" => "/foo/bar",
+      )
+    end
+  end
+end

--- a/spec/requests/location_suggestions_spec.rb
+++ b/spec/requests/location_suggestions_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "/location-suggestions", type: :request do
+  context "when provider suggestion is blank" do
+    it "returns bad request (400)" do
+      get "/location-suggestions"
+
+      expect(response.status).to eq(400)
+      expect(JSON.parse(response.body)).to eq("error" => "Bad request")
+    end
+  end
+
+  context "when location suggestion query is valid" do
+    it "returns success (200)" do
+      query = "london"
+      location_suggestions = stub_request(
+        :get,
+        "#{Settings.google.places_api_host}/maps/api/place/autocomplete/json?components=country:uk&input=#{query}&key=replace_me&language=en&types=geocode",
+      ).to_return(body: File.new("spec/fixtures/api_responses/location-suggestions.json"))
+
+      get "/location-suggestions?query=#{query}"
+
+      expect(location_suggestions).to have_been_requested
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
### Context
- Fix for Sentry issue: https://sentry.io/organizations/dfe-bat/issues/?project=1780060&referrer=slack
- Some requests are being made to the 'location-suggestions' endpoint containing invalid encodings. Rails does not handle this natively and exceptions bubble up


### Changes proposed in this pull request
- This new middleware intercepts the request **if** the request path == `/location-suggestions` and drops the query if it contains invalid encodings
- Inspired by: https://jamescrisp.org/2018/05/28/fixing-invalid-query-parameters-invalid-encoding-in-a-rails-app/

### Guidance to review
- To view the error locally, comment out the `bad_query_encoding` initialiser, and make a request to `/location-suggestions` with a query containing invalid encodings e.g. `BLAH%%fjf%%BLAH` 
- To view the fix, uncomment the initialiser, restart the app, and send the same request.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
