### PR TITLE
[3304] Course apply goes thru a redirect

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -14,4 +14,17 @@ class CoursesController < ApplicationController
   rescue JsonApiClient::Errors::NotFound
     render file: "errors/not_found", status: :not_found
   end
+
+  def apply
+    course = Course
+      .includes(:provider)
+      .where(recruitment_cycle_year: Settings.current_cycle)
+      .where(provider_code: params[:provider_code])
+      .find(params[:course_code])
+      .first
+
+    Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
+
+    redirect_to "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
+  end
 end

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -7,8 +7,7 @@
 
   <% if @course.has_vacancies? %>
     <p class="govuk-body">
-      <%= link_to "Apply for this course",
-                  "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}",
+      <%= link_to "Apply for this course", apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
                   class: "govuk-button govuk-button--start",
                   data: { qa: 'course__apply_link' } %>
     </p>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "55a5b98fb69b00ad7b8d2fadb6de6cdd39d66193cd74505cecc4e78d6d400610",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/courses_controller.rb",
+      "line": 28,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(\"https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CoursesController",
+        "method": "apply"
+      },
+      "user_input": "Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code",
+      "confidence": "High",
+      "note": ""
+    }
+  ],
+  "updated": "2020-05-11 12:27:41 +0100",
+  "brakeman_version": "4.8.1"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
 
   resource :sitemap, only: :show
 
+  get "/course/:provider_code/:course_code/apply", to: "courses#apply", as: :apply
   get "/course/:provider_code/:course_code", to: "courses#show", as: "course"
   get "/results", to: "results#index", as: "results"
 

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe CoursesController do
+  let(:provider) { build(:provider) }
+  let(:course) { build(:course, provider: provider) }
+
+  before do
+    stub_api_v3_resource(
+      type: Course,
+      params: {
+        recruitment_cycle_year: Settings.current_cycle,
+        provider_code: course.provider_code,
+        course_code: course.course_code,
+      },
+      resources: course,
+      include: %w[provider],
+    )
+  end
+
+  describe "#apply" do
+    let(:logger) { double(:logger) }
+
+    it "redirects to correct apply destination" do
+      get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+      expect(response).to redirect_to("https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
+    end
+
+    it "writes to log" do
+      allow(Rails).to receive(:logger).and_return(logger)
+      expect(logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
+
+      get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+    end
+  end
+end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -234,7 +234,7 @@ feature "Course show", type: :feature do
 
       expect(course_page.apply_link.text).to eq("Apply for this course")
 
-      expect(course_page.apply_link[:href]).to eq("https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
+      expect(course_page.apply_link[:href]).to eq("/course/T92/X130/apply")
 
       expect(course_page).not_to have_content("When you apply you’ll need these codes for the Choices section of your application form")
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/wZJSXUte/3304-redirect-pages-for-tracking-usage-of-apply-button
- We want to add reporting for conversions when applying for a course

### Changes proposed in this pull request

- Course `Apply` goes thru a redirect
- The additional hop writes to the log for later reporting

### Guidance to review

- Find any course with a vacancy and visit the course page
- Locate the `Apply` button
- Mouse over it or inspect the element
- Url should remain on the same domain
- Clicking on it should take you to the Apply service and on the correct page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
