### PR TITLE
[3397] Add rel nofollow to apply links

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -9,7 +9,8 @@
     <p class="govuk-body">
       <%= link_to "Apply for this course", apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
                   class: "govuk-button govuk-button--start",
-                  data: { qa: 'course__apply_link' } %>
+                  data: { qa: 'course__apply_link' },
+                  rel: "nofollow" %>
     </p>
 
     <h3 class="govuk-heading-m">Choose a training location</h3>


### PR DESCRIPTION

### Context

- https://trello.com/c/nMi5yG7c/3397-adding-nofollow-to-apply-for-this-course-redirect-link
- We want to reduct false positives on conversion reporting

### Changes proposed in this pull request

- Add `rel="nofollow"` to apply links

### Guidance to review

- Find a course with an apply button
- Link should have `rel` attribute with `nofollow`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
