### PR TITLE
[3332] - Add '/provider-suggestions' path to HandleBadEncoding middleware

### DIFF
--- a/lib/rack/handle_bad_encoding.rb
+++ b/lib/rack/handle_bad_encoding.rb
@@ -5,7 +5,7 @@ module Rack
     end
 
     def call(env)
-      if env["REQUEST_PATH"] == "/location-suggestions"
+      if %w[/location-suggestions /provider-suggestions].include?(env["REQUEST_PATH"])
         begin
           Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
         rescue Rack::Utils::InvalidParameterError

--- a/spec/lib/rack/handle_bad_encoding_spec.rb
+++ b/spec/lib/rack/handle_bad_encoding_spec.rb
@@ -4,39 +4,41 @@ describe Rack::HandleBadEncoding do
   let(:app) { double }
   let(:middleware) { described_class.new(app) }
 
-  context "request path is '/location-suggestions'" do
-    context "query does not contain invalid encodings" do
-      it "does not modify the query" do
-        expect(app).to receive(:call).with("REQUEST_PATH" => "/location-suggestions", "QUERY_STRING" => "query=london")
-        middleware.call(
-          "REQUEST_PATH" => "/location-suggestions",
-          "QUERY_STRING" => "query=london",
-        )
+  %w[/location-suggestions /provider-suggestions].each do |path|
+    context "request path is #{path}" do
+      context "query does not contain invalid encodings" do
+        it "does not modify the query" do
+          expect(app).to receive(:call).with("REQUEST_PATH" => path, "QUERY_STRING" => "query=london")
+          middleware.call(
+            "REQUEST_PATH" => path,
+            "QUERY_STRING" => "query=london",
+          )
+        end
       end
-    end
 
-    context "query is absent" do
-      it "does not modify the query" do
-        expect(app).to receive(:call).with("REQUEST_PATH" => "/location-suggestions")
-        middleware.call("REQUEST_PATH" => "/location-suggestions")
+      context "query is absent" do
+        it "does not modify the query" do
+          expect(app).to receive(:call).with("REQUEST_PATH" => path)
+          middleware.call("REQUEST_PATH" => path)
+        end
       end
-    end
 
-    context "query contains invalid encodings" do
-      it "modifies the query" do
-        expect(app).to receive(:call).with(
-          "QUERY_STRING" => "",
-          "REQUEST_PATH" => "/location-suggestions",
-        )
-        middleware.call(
-          "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
-          "REQUEST_PATH" => "/location-suggestions",
-        )
+      context "query contains invalid encodings" do
+        it "modifies the query" do
+          expect(app).to receive(:call).with(
+            "QUERY_STRING" => "",
+            "REQUEST_PATH" => path,
+          )
+          middleware.call(
+            "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
+            "REQUEST_PATH" => path,
+          )
+        end
       end
     end
   end
 
-  context "request path is not 'location-suggestions'" do
+  context "request path is not 'location-suggestions' or '/provider-suggestions'" do
     it "does not modify the query" do
       expect(app).to receive(:call).with(
         "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",


### PR DESCRIPTION
### Context
Sentry: https://sentry.io/organizations/dfe-bat/issues/1671504823/?referrer=slack

### Changes proposed in this pull request
Add '/provider-suggestions' path to HandleBadEncoding middleware

### Guidance to review
Curl `/provider-suggestions` endpoint with query containing bad encodings (e.g. `M20%C2%A3@%`). App now returns Bad Request.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
