### PR TITLE
[3384] Remove search and compare url

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -14,8 +14,7 @@ module ViewHelper
   def permitted_referrer?
     return false if request.referer.blank?
 
-    request.referer.start_with?(Settings.search_and_compare_ui.base_url) ||
-      request.referer.include?(request.host_with_port) ||
+    request.referer.include?(request.host_with_port) ||
       Settings.valid_referers.any? { |url| request.referer.start_with?(url) }
   end
 

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,7 +1,5 @@
 teacher_training_api:
   base_url: http://localhost:3001
-search_and_compare_ui:
-  base_url: http://localhost:5000
 valid_referers:
   - http://localhost:5000
 log_level: debug

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,7 +1,5 @@
 base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
-search_and_compare_ui:
-  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 valid_referers:
   - https://www.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,7 +1,5 @@
 base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
-search_and_compare_ui:
-  base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 valid_referers:
   - https://www.qa.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,7 +1,5 @@
 base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
-search_and_compare_ui:
-  base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 valid_referers:
   - https://www.staging.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,6 +1,4 @@
 teacher_training_api:
   base_url: http://localhost:3001
-search_and_compare_ui:
-  base_url: http://localhost:5000
 valid_referers:
   - http://localhost:9000

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -251,17 +251,6 @@ feature "Course show", type: :feature do
       end
     end
 
-    context "When navigating to the course from search and compare UI" do
-      let(:referer) { "#{Settings.search_and_compare_ui.base_url}/results" }
-
-      it "Does displays the back link" do
-        page.driver.header("Referer", referer)
-        visit course_path(course.provider_code, course.course_code)
-        expect(course_page).to have_back_link
-        expect(course_page.back_link[:href]).to eq referer
-      end
-    end
-
     context "When navigating to the course from the current application" do
       let(:referer) { "http://#{page.driver.request.host_with_port}/results" }
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -28,14 +28,6 @@ feature "View helpers", type: :helper do
       end
     end
 
-    context "With a referrer from search and compare ui" do
-      it "returns true" do
-        headers = { "HTTP_REFERER": Settings.search_and_compare_ui.base_url }
-        helper.request.headers.merge!(headers)
-        expect(helper.permitted_referrer?).to eq(true)
-      end
-    end
-
     context "With a referrer from the current application" do
       it "returns true" do
         headers = { "HTTP_REFERER": helper.request.host_with_port }


### PR DESCRIPTION
### Context
https://sentry.io/organizations/dfe-bat/issues/1672714348/?environment=research&project=1780060&referrer=alert_email

We don't need this config setting anymore since we are fully "on the rails"

### Changes proposed in this pull request
Remove all traces of "search and compare"

### Guidance to review
🚢 
