### PR TITLE
change healthcheck failure to 503

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -8,7 +8,7 @@ class HeartbeatController < ActionController::API
       teacher_training_api: api_alive?,
     }
 
-    render status: (checks.values.all? ? :ok : :bad_gateway),
+    render status: (checks.values.all? ? :ok : :service_unavailable),
            json: {
              checks: checks,
            }

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -34,15 +34,15 @@ describe "heartbeat requests" do
       end
     end
 
-    context "when the api returns 502" do
+    context "when the api returns 503" do
       before do
         stub_request(:get, healthcheck_endpoint)
-            .to_return(status: 502)
+            .to_return(status: 503)
         get "/healthcheck"
       end
 
-      it "returns status bad gateway" do
-        expect(response.status).to eq(502)
+      it "returns status service_unavailable" do
+        expect(response.status).to eq(503)
       end
 
       it "returns the expected response report" do
@@ -59,8 +59,8 @@ describe "heartbeat requests" do
         get "/healthcheck"
       end
 
-      it "returns status bad gateway" do
-        expect(response.status).to eq(502)
+      it "returns status service_unavailable" do
+        expect(response.status).to eq(503)
       end
 
       it "returns the expected response report" do
@@ -77,8 +77,8 @@ describe "heartbeat requests" do
         get "/healthcheck"
       end
 
-      it "returns status bad gateway" do
-        expect(response.status).to eq(502)
+      it "returns status service_unavailable" do
+        expect(response.status).to eq(503)
       end
 
       it "returns the expected response report" do


### PR DESCRIPTION
This was 502 bad gateway, however 503 service unavailable seems correct, esp
considering this service isn't acting as a proxy/gateway, but as a frontend.

### Context

Not a major issue, but since we were revisiting the healthcheck in publish and are using 503 there, it seems to be a good idea to bring other service in-line.

See Publish PR: https://github.com/DFE-Digital/publish-teacher-training/pull/1104

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
