### PR TITLE
[3427] Udpate apply link for bolton uni courses

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,6 +25,16 @@ class CoursesController < ApplicationController
 
     Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
 
-    redirect_to "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
+    # If course provider is University of Bolton and Maths or Computing
+    if course.provider.provider_code == "8N5" && (course.course_code == "V595" || course.course_code == "Y710")
+      case course.course_code
+      when "V595"
+        redirect_to "https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1101-D&code2=0001"
+      when "Y710"
+        redirect_to "https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1100-D&code2=0001"
+      end
+    else
+      redirect_to "https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
+    end
   end
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe CoursesController do
       expect(response).to redirect_to("https://www.apply-for-teacher-training.education.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
     end
 
+    context "a course from University of Bolton" do
+      let(:provider) { build(:provider, provider_code: "8N5") }
+      let(:course) { build(:course, course_code: "V595", provider: provider) }
+
+      it "redirects to University of Bolton's applications service" do
+        get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+        expect(response).to redirect_to("https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1101-D&code2=0001")
+      end
+    end
+
     it "writes to log" do
       allow(Rails).to receive(:logger).and_return(logger)
       expect(logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")


### PR DESCRIPTION
### Context
The University of Bolton don't want candidates to use UCAS APPLY when applying for their courses.

### Changes proposed in this pull request
Redirect candidates to their own application service.

### Guidance to review
- `/course/8N5/V595#section-apply`
- `/course/8N5/Y710#section-apply`

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
