### PR TITLE
[3366]-deploy-find-ftt-to-paas-with-terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,14 @@ config/settings.local.yml
 config/settings/*.local.yml
 config/environments/*.local.yml
 coverage
+
+# Terraform
+*.tfstate
+*.tfstate.backup
+.terraform/environment
+terraform.tfplan
+terraform.tfstate
+terraform.tfstate.d/
+./*.tfstate
+lock.json
+

--- a/terraform/paas/backend.tf
+++ b/terraform/paas/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend azurerm {
+    container_name = "paas-tfstate"
+    key            = "paas-find.tfstate"
+  }
+}

--- a/terraform/paas/data.tf
+++ b/terraform/paas/data.tf
@@ -1,0 +1,12 @@
+data cloudfoundry_domain local {
+  name = "london.cloudapps.digital"
+}
+
+data cloudfoundry_org org {
+  name = "dfe-teacher-services"
+}
+
+data cloudfoundry_space space {
+  name = var.app.space
+  org  = data.cloudfoundry_org.org.id
+}

--- a/terraform/paas/provider.tf
+++ b/terraform/paas/provider.tf
@@ -1,0 +1,6 @@
+provider cloudfoundry {
+  api_url  = var.api_url
+  user     = var.user
+  password = var.password
+}
+

--- a/terraform/paas/resources.tf
+++ b/terraform/paas/resources.tf
@@ -1,0 +1,29 @@
+resource cloudfoundry_app find-teacher-training {
+  name         = var.app.name
+  space        = data.cloudfoundry_space.space.id
+  docker_image = var.app.docker_image
+  strategy     = "blue-green-v2"
+
+  environment = {
+    ASSETS_PRECOMPILE                                = var.app_env.ASSETS_PRECOMPILE
+    RAILS_ENV                                        = var.app_env.RAILS_ENV
+    RAILS_SERVE_STATIC_FILES                         = var.app_env.RAILS_SERVE_STATIC_FILES
+    SECRET_KEY_BASE                                  = var.SECRET_KEY_BASE
+    SENTRY_DSN                                       = var.SENTRY_DSN
+    SETTINGS__GOOGLE__GCP_API_KEY                    = var.SETTINGS__GOOGLE__GCP_API_KEY
+    SETTINGS__GOOGLE__MAPS_API_KEY                   = var.SETTINGS__GOOGLE__MAPS_API_KEY
+    SETTINGS__REDIRECT_RESULTS_TO_C_SHARP            = var.app_env.SETTINGS__REDIRECT_RESULTS_TO_C_SHARP
+    WEBPACKER_DEV_SERVER_HOST                        = var.app_env.WEBPACKER_DEV_SERVER_HOST
+    WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION = var.app_env.WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION
+  }
+
+  routes {
+    route = cloudfoundry_route.find-teacher-training-route.id
+  }
+}
+
+resource cloudfoundry_route find-teacher-training-route {
+  domain   = data.cloudfoundry_domain.local.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = var.app.hostname
+}

--- a/terraform/paas/terraform_qa.tfvars
+++ b/terraform/paas/terraform_qa.tfvars
@@ -1,0 +1,15 @@
+app = {
+  name         = "qa-find-postgraduate-teacher-training"
+  docker_image = "dfedigital/find-teacher-training:latest"
+  hostname     = "qa-find-postgraduate-teacher-training"
+  space        = "find-qa"
+}
+
+app_env = {
+  ASSETS_PRECOMPILE                                = true
+  RAILS_ENV                                        = "qa"
+  RAILS_SERVE_STATIC_FILES                         = true
+  SETTINGS__REDIRECT_RESULTS_TO_C_SHARP            = false
+  WEBPACKER_DEV_SERVER_HOST                        = "webpacker"
+  WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION = "0"
+}

--- a/terraform/paas/variables.tf
+++ b/terraform/paas/variables.tf
@@ -1,0 +1,36 @@
+variable app {
+  type = map
+}
+
+variable app_env {
+  type = map
+}
+
+variable api_url {
+  type = string
+}
+
+variable user {
+  type = string
+}
+
+variable password {
+  type = string
+}
+
+variable SECRET_KEY_BASE {
+  type = string
+}
+
+variable SENTRY_DSN {
+  type = string
+}
+
+variable SETTINGS__GOOGLE__GCP_API_KEY {
+  type = string
+}
+
+variable SETTINGS__GOOGLE__MAPS_API_KEY {
+  type = string
+}
+

--- a/terraform/paas/versions.tf
+++ b/terraform/paas/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
### Context

Deploying the find webapp and point it to the QA API running on Azure.
Deploy via docker (not via buildpack) as it's DfE strategic direction and our apps are already packaged as docker images. The latest docker image published to dockerhub may be used.

### Changes proposed in this pull request

The terraform files should reside in the find repository. We should be able to:
- deploy with the same image: should be no-op
- deploy with a new image: should update the app
- deploy with blue-green strategy should cause no outage
- store terraform state in an Azure storage account

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
