### PR TITLE
[3434] - Location filter provider search with one character

### DIFF
--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -4,7 +4,12 @@ module ResultFilters
 
     def new
       if params[:query].blank?
-        flash[:error] = [I18n.t("location_filter.fields.provider")]
+        flash[:error] = [t("location_filter.fields.provider"), t("location_filter.errors.blank_provider")]
+        return redirect_back
+      end
+
+      if params[:query].length == 1
+        flash[:error] = [t("location_filter.fields.provider"), t("location_filter.errors.invalid_provider")]
         return redirect_back
       end
 
@@ -15,7 +20,7 @@ module ResultFilters
         .all
 
       if @provider_suggestions.count.zero?
-        flash[:error] = [I18n.t("location_filter.fields.provider")]
+        flash[:error] = [I18n.t("location_filter.fields.provider"), I18n.t("location_filter.errors.missing_provider")]
         redirect_back
       elsif @provider_suggestions.count == 1
         redirect_to results_path(

--- a/app/helpers/result_filters/location_helper.rb
+++ b/app/helpers/result_filters/location_helper.rb
@@ -3,7 +3,10 @@ module ResultFilters
     def provider_error?
       return false if flash[:error].nil?
 
-      flash[:error].include?(I18n.t("location_filter.fields.provider"))
+      flash[:error].include?(t("location_filter.fields.provider")) ||
+        flash[:error].include?(t("location_filter.errors.blank_provider")) ||
+        flash[:error].include?(t("location_filter.errors.missing_provider")) ||
+        flash[:error].include?(t("location_filter.errors.invalid_provider"))
     end
 
     def location_error?

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -122,7 +122,7 @@
                   <span class="govuk-hint">Enter the name or provider code</span>
                   <% if provider_error? %>
                     <span class="govuk-error-message" id="provider-error" data-qa="provider-error">
-                    <span class="govuk-visually-hidden">Error: </span><%= I18n.t("location_filter.errors.missing_provider") %>
+                    <span class="govuk-visually-hidden">Error: </span><%= flash[:error].last %>
                   </span>
                   <% end %>
                 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,7 +52,9 @@ en:
       no_option: "Please choose an option"
       unknown_location: "We couldn't find this location, please check your input and try again"
       missing_location: "Please enter a postcode, city or town in England"
-      missing_provider: "We couldn't find this provider, please check your input and try again"
+      missing_provider: "We couldn't find this provider, please check your information and try again"
+      blank_provider: "You need to add some information"
+      invalid_provider: "Please enter a minimum of two characters"
     fields:
       location: "Postcode, town or city"
       provider: "Training provider"

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -54,24 +54,51 @@ feature "Location filter", type: :feature do
         )
     end
 
-    it "displays the courses" do
-      results_page.load
-      results_page.location_filter.link.click
-      filter_page.by_provider.click
-      filter_page.provider_search.fill_in(with: "ACME")
-      filter_page.find_courses.click
+    context "valid provider search" do
+      it "displays the courses" do
+        results_page.load
+        results_page.location_filter.link.click
+        filter_page.by_provider.click
+        filter_page.provider_search.fill_in(with: "ACME")
+        filter_page.find_courses.click
 
-      expect(provider_page.heading.text).to eq("Pick a provider")
-      provider_page.provider_suggestions[0].hyperlink.click
+        expect(provider_page.heading.text).to eq("Pick a provider")
+        provider_page.provider_suggestions[0].hyperlink.click
 
-      expect(results_page.courses.first).to have_main_address
-      expect(results_page.courses.first).not_to have_site_distance_to_location_query
-      expect(results_page.courses.first).not_to have_nearest_address
+        expect(results_page.courses.first).to have_main_address
+        expect(results_page.courses.first).not_to have_site_distance_to_location_query
+        expect(results_page.courses.first).not_to have_nearest_address
 
-      expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
-      expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
-      expect(results_page.provider_filter.link.text).to eq("Change provider or choose a location")
-      expect(results_page.courses.count).to eq(4)
+        expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
+        expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
+        expect(results_page.provider_filter.link.text).to eq("Change provider or choose a location")
+        expect(results_page.courses.count).to eq(4)
+      end
+    end
+
+    context "invalid provider search" do
+      context "blank search" do
+        it "displays an error" do
+          results_page.load
+          results_page.location_filter.link.click
+          filter_page.by_provider.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_content("You need to add some information")
+        end
+      end
+
+      context "invalid one character provider search" do
+        it "displays an error" do
+          results_page.load
+          results_page.location_filter.link.click
+          filter_page.by_provider.click
+          filter_page.provider_search.fill_in(with: "A")
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_content("Please enter a minimum of two characters")
+        end
+      end
     end
   end
 

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -124,7 +124,7 @@ feature "Provider filter", type: :feature do
         expect(current_path).to eq(location_filter_page.url)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq("query" => "ACME")
         expect(location_filter_page.error_text.text).to eq("Training provider")
-        expect(location_filter_page.provider_error.text).to eq("Error: We couldn't find this provider, please check your input and try again")
+        expect(location_filter_page.provider_error.text).to eq("Error: We couldn't find this provider, please check your information and try again")
       end
     end
   end


### PR DESCRIPTION
### Context
API has been updated to allow for two character provider searches. See https://github.com/DFE-Digital/teacher-training-api/pull/1378

### Changes proposed in this pull request
- On the location filter page, a validation error is displayed on the form if the user searches for a provider with a query string containing only one character

![errors](https://user-images.githubusercontent.com/5256922/83134337-1d1e5d80-a0dc-11ea-8228-43561b4a01d1.gif)

### Guidance to review
- Run this branch against https://github.com/DFE-Digital/teacher-training-api/pull/1378
- Visit `/results/filter/location`. Select other provider and enter a single character in the search field. Validation error should be displayed

### Notes
- Need some copy guidance on the error message
- In doing this work I noticed that GOVUK form builder needs to be added to this page. Also the ProviderController should be using a form object. Potentially the ProviderController logic should be merged into the LocationController and a similar pattern to Publish be adopted. I think this should be a separate piece of work - will add ticket to ideas board.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
