### PR TITLE
[3421] Show correct financial info for apprenticeships

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -98,7 +98,7 @@ class CourseDecorator < Draper::Decorator
   end
 
   def funding_option
-    if object.funding_type == "salary"
+    if salaried?
       "Salary"
     elsif excluded_from_bursary?
       "Student finance if you’re eligible"

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -91,6 +91,12 @@ describe CourseDecorator do
         it { is_expected.to eq("Salary") }
       end
 
+      context "Apprenticeship" do
+        let(:course) { build :course, funding_type: "apprenticeship" }
+
+        it { is_expected.to eq("Salary") }
+      end
+
       context "Bursary and Scholarship" do
         let(:mathematics) { build(:subject, :mathematics, scholarship: "2000", bursary_amount: "3000") }
         let(:course) { build :course, subjects: [mathematics] }


### PR DESCRIPTION
### Context

All apprenticeship courses were showing as offering some sort of financial support on the course page on find. They should be showing "Salary". It seems that we forgot to use an existing method in the if statement.

### Changes proposed in this pull request
Apprenticeship course
- before
<kbd><img width="662" alt="Screenshot 2020-05-28 at 17 51 48" src="https://user-images.githubusercontent.com/38078064/83170726-e44aac80-a10c-11ea-8f18-a12ca0e15285.png"></kbd>

- after
<kbd><img width="642" alt="Screenshot 2020-05-28 at 17 52 04" src="https://user-images.githubusercontent.com/38078064/83170761-ee6cab00-a10c-11ea-9265-43cd42a5d8b5.png"></kbd>


### Guidance to review
- all apprenticeship courses should say "Salary" in the Financial support section

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
