### PR TITLE
Use smart quotes, and other typographical fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,9 @@ gem "sentry-raven"
 # Render nice markdown
 gem "redcarpet"
 
+# Render smart quotes
+gem "rubypants"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ GEM
     rubocop-rspec (1.39.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    rubypants (0.7.1)
     rubyzip (2.3.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -428,6 +429,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.1)
   rspec_junit_formatter
   rubocop-govuk
+  rubypants
   scss_lint-govuk
   sentry-raven
   simplecov

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,11 +8,29 @@ module ApplicationHelper
     # autolink: parse links even when they are not enclosed in <> characters
     options = { autolink: true, lax_spacing: true }
     markdown = Redcarpet::Markdown.new(render, options)
-    source_with_smart_quotes = RubyPants.new(source).to_html
+    source_with_smart_quotes = smart_quotes(source)
     markdown.render(source_with_smart_quotes).html_safe
   end
 
   def smart_quotes(string)
-    RubyPants.new(string).to_html.html_safe
+    RubyPants.new(string, 2, ruby_pants_options).to_html
+  end
+
+private
+
+  # Use characters rather than HTML entities for smart quotes this matches how
+  # we write smart quotes in templates and allows us to use them in <title>
+  # elements
+  # https://github.com/jmcnevin/rubypants/blob/master/lib/rubypants.rb
+  def ruby_pants_options
+    {
+      double_left_quote: "“",
+      double_right_quote: "”",
+      single_left_quote: "‘",
+      single_right_quote: "’",
+      ellipsis: "…",
+      em_dash: "—",
+      en_dash: "–",
+    }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,11 @@ module ApplicationHelper
     # autolink: parse links even when they are not enclosed in <> characters
     options = { autolink: true, lax_spacing: true }
     markdown = Redcarpet::Markdown.new(render, options)
-    markdown.render(source).html_safe
+    source_with_smart_quotes = RubyPants.new(source).to_html
+    markdown.render(source_with_smart_quotes).html_safe
+  end
+
+  def smart_quotes(string)
+    RubyPants.new(string).to_html.html_safe
   end
 end

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -2,7 +2,7 @@
 <p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
 
 <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-<p class="govuk-body">Register with <%= link_to 'Get into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
+<p class="govuk-body">Register with <%= link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
 
 <h4 class="govuk-heading-m">Website support</h4>
 <p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -31,9 +31,9 @@
         <% course.preview_site_statuses.each do |site_status| %>
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">
-              <strong><%= site_status.site.location_name %></strong>
+              <strong><%= smart_quotes(site_status.site.location_name) %></strong>
               <br>
-              <%= site_status.site.decorate.full_address %>
+              <%= smart_quotes(site_status.site.decorate.full_address) %>
             </td>
             <td class="govuk-table__cell">
               <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
@@ -59,10 +59,10 @@
     <% course.preview_site_statuses.each do |site_status| %>
       {
         "code": "<%= site_status.site.code %>",
-        "name": "<%= site_status.site.location_name %>",
+        "name": "<%= smart_quotes(site_status.site.location_name) %>",
         "lat": "<%= site_status.site.latitude.present? ? site_status.site.latitude : course.provider.latitude %>",
         "lng": "<%= site_status.site.longitude.present? ? site_status.site.longitude : course.provider.longitude %>",
-        "address": "<%= site_status.site.decorate.full_address %>",
+        "address": "<%= smart_quotes(site_status.site.decorate.full_address) %>",
         "vacancies": "<%= site_status.has_vacancies? ? "" : "No vacancies" %>"
       },
     <% end %>

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -48,7 +48,7 @@
       <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
       <strong class="govuk-warning-text__text">
         <span class="govuk-warning-text__assistive">Warning</span>
-        You can't apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to 'Only courses with vacancies'.
+        You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.
       </strong>
     </div>
   <% end %>

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> – note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,6 +1,6 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> – note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
   <p class="govuk-body">
     Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates', class: 'govuk-link' %>.

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,6 +1,6 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
   <p class="govuk-body">
     Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://getintoteaching.education.gov.uk/explore-my-options/overseas-graduates', class: 'govuk-link' %>.

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -27,7 +27,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> – note that you’ll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -27,7 +27,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you'll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> - note that you’ll have to apply for <%= link_to "undergraduate student finance", "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -8,7 +8,9 @@
 
 <div data-module="ga-track-scrolling ga-track-copying">
   <h1 class="govuk-heading-xl">
-    <span class="govuk-!-font-size-36" data-qa="course__provider_name"><%= course.provider.provider_name %></span><br>
+    <span class="govuk-!-font-size-36" data-qa="course__provider_name">
+      <%= smart_quotes(course.provider.provider_name) %>
+    </span><br>
     <%= course.name_and_code %>
   </h1>
 
@@ -17,7 +19,7 @@
   <dl class="govuk-list--description govuk-!-margin-bottom-8">
     <% if (course.accrediting_provider.present? && course.accrediting_provider.provider_code != course.provider.provider_code) %>
       <dt class="govuk-list--description__label">Accredited body</dt>
-      <dd data-qa="course__accredited_body"><%= course.accrediting_provider.provider_name %></dd>
+      <dd data-qa="course__accredited_body"><%= smart_quotes(course.accrediting_provider.provider_name) %></dd>
     <% end %>
     <dt class="govuk-list--description__label">Financial support</dt>
     <dd data-qa="course__funding_option"><%= course.funding_option %></dd>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{course.name_and_code} with #{course.provider.provider_name}" %>
+<%= content_for :page_title, "#{course.name_and_code} with #{smart_quotes(course.provider.provider_name)}" %>
 
 <% if permitted_referrer? %>
   <%= content_for(:before_content) do %>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-xl">Sorry, something went wrong</h1>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">Sorry, we're experiencing technical difficulties.</p>
+      <p class="govuk-body">Sorry, we’re experiencing technical difficulties.</p>
       <p class="govuk-body">
         <%= govuk_mail_to(Settings.service_support.contact_email_address, "Contact the Becoming a Teacher team")%>
         if you continue to see this error.

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, "We don't understand the data you entered" %>
+<%= content_for :page_title, "We do not understand the data you entered" %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">We don't understand the data you entered.</h1>
+      <h1 class="govuk-heading-xl">We do not understand the data you entered.</h1>
       <p class="govuk-body">Try again, or contact us at <%= bat_contact_mail_to() %></p>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,7 +78,7 @@
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds govuk-footer__content-container">
             <p class="govuk-footer__content">
-              For personalised support and advice about teacher training, register with <%= link_to "Get into Teaching", "https://getintoteaching.education.gov.uk/", class: "govuk-footer__link" %>. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: "govuk-footer__link" %>, from 8am to 8pm, Monday to Friday.
+              For personalised support and advice about teacher training, register with <%= link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/", class: "govuk-footer__link" %>. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: "govuk-footer__link" %>, from 8am to 8pm, Monday to Friday.
             </p>
           </div>
         </div>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -10,7 +10,7 @@
 
         <h2 class="govuk-heading-l">Hyperlinking to Find postgraduate teacher training </h2>
         <p class="govuk-body">
-          We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find postgraduate teacher training’ pages must be displayed in the user's entire browser window.
+          We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find postgraduate teacher training’ pages must be displayed in the user’s entire browser window.
         </p>
 
         <h2 class="govuk-heading-l">Hyperlinking from Find postgraduate teacher training</h2>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -11,7 +11,7 @@
       <p class="govuk-body">Select the subjects you want to teach.</p>
       <h2 class="govuk-heading-m">Get financial support</h2>
       <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
-      <p class="govuk-body">Visit Get into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
+      <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
 
 
       <div class="accordion govuk-form-group" data-module="govuk-accordion">

--- a/app/views/results/_provider.html.erb
+++ b/app/views/results/_provider.html.erb
@@ -4,7 +4,7 @@
   </h2>
   <ul class="filter-form__value--list">
     <li data-qa="provider_name">
-      <%= @results_view.provider %>
+      <%= smart_quotes(@results_view.provider) %>
     </li>
   </ul>
   <%= link_to "Change provider or choose a location",

--- a/app/views/results/_try_another_search_text.html.erb
+++ b/app/views/results/_try_another_search_text.html.erb
@@ -1,7 +1,3 @@
 <p class="govuk-body">
-You can <%= link_to "try another search", root_path, class: "govuk-link" %>, for example by changing subject or location 
-<% if @results_view.with_salaries? %>
-or searching for courses that don't offer a salary
-<% end %>
-.
+You can <%= link_to "try another search", root_path, class: "govuk-link" %>, for example by changing subject or location <% if @results_view.with_salaries? %> or searching for courses that do not offer a salary<% end %>.
 </p>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -5,7 +5,7 @@
     <% if @results_view.provider_filter? %>
       <h1 class="govuk-heading-xl" data-qa="heading">
         <span class="govuk-caption-l">Teacher training courses</span>
-        <%= @results_view.provider %>
+        <%= smart_quotes(@results_view.provider) %>
       </h1>
     <% else %>
       <h1 class="govuk-heading-xl" data-qa="heading">Teacher training courses</h1>
@@ -102,8 +102,9 @@
         <li data-qa="course">
           <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
             <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link  search-result-link", rel: "prev", data: { qa: "course__link" } do %>
-              <span data-qa="course__provider_name" class="govuk-!-font-size-19"><%= course.provider.provider_name %></span>
-              <br>
+              <span data-qa="course__provider_name" class="govuk-!-font-size-19">
+                <%= smart_quotes(course.provider.provider_name) %>
+              </span><br>
               <span data-qa="course__name" class="search-result-link-name govuk-!-font-size-24"><%= course.decorate.display_title %></span>
             <% end %>
           </h3>
@@ -115,19 +116,19 @@
               <dd data-qa="course__site_distance"><%= @results_view.site_distance(course) %> mile<%= 's' if @results_view.site_distance(course) != 1 %> <span class="govuk-list--description__hint">to the training provider or their nearest training location</span></dd>
               <% if @results_view.nearest_address(course).present? %>
                 <dt class="govuk-list--description__label">Nearest address</dt>
-                <dd data-qa="course__nearest_address"><%= @results_view.nearest_address(course) %></dd>
+                <dd data-qa="course__nearest_address"><%= smart_quotes(@results_view.nearest_address(course)) %></dd>
               <% end  %>
             <% end %>
             <dt class="govuk-list--description__label">Financial support</dt>
             <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
             <% if course['accrediting_provider'].present? %>
               <dt class="govuk-list--description__label">Accredited body</dt>
-              <dd data-qa="course__accrediting_provider"><%= course['accrediting_provider']['provider_name'] %></dd>
+              <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>
             <% end %>
             <% unless @results_view.location_filter?  %>
               <dt class="govuk-list--description__label">Main address</dt>
               <dd data-qa="course__main_address">
-                <%= course.provider.decorate.short_address %>
+                <%= smart_quotes(course.provider.decorate.short_address) %>
               </dd>
             <% end %>
             <% if @results_view.vacancy_filter?  %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,9 +50,9 @@ en:
   location_filter:
     errors:
       no_option: "Please choose an option"
-      unknown_location: "We couldn't find this location, please check your input and try again"
+      unknown_location: "We couldn’t find this location, please check your input and try again"
       missing_location: "Please enter a postcode, city or town in England"
-      missing_provider: "We couldn't find this provider, please check your information and try again"
+      missing_provider: "We couldn’t find this provider, please check your information and try again"
       blank_provider: "You need to add some information"
       invalid_provider: "Please enter a minimum of two characters"
     fields:

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -388,7 +388,7 @@ feature "Location filter", type: :feature do
       filter_page.find_courses.click
 
       expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPostcode, town or city")
-      expect(filter_page.location_error.text).to eq("Error: We couldn't find this location, please check your input and try again")
+      expect(filter_page.location_error.text).to eq("Error: We couldn’t find this location, please check your input and try again")
       expect(filter_page).to have_location_query
       expect(filter_page).to have_unknown_location
     end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -124,7 +124,7 @@ feature "Provider filter", type: :feature do
         expect(current_path).to eq(location_filter_page.url)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq("query" => "ACME")
         expect(location_filter_page.error_text.text).to eq("Training provider")
-        expect(location_filter_page.provider_error.text).to eq("Error: We couldn't find this provider, please check your information and try again")
+        expect(location_filter_page.provider_error.text).to eq("Error: We couldn’t find this provider, please check your information and try again")
       end
     end
   end

--- a/spec/form_objects/result_filters/location_filter_form_spec.rb
+++ b/spec/form_objects/result_filters/location_filter_form_spec.rb
@@ -34,7 +34,7 @@ module ResultFilters
 
         it "has error" do
           subject.valid?
-          expect(subject.errors).to eq(["Postcode, town or city", "We couldn't find this location, please check your input and try again"])
+          expect(subject.errors).to eq(["Postcode, town or city", "We couldn’t find this location, please check your input and try again"])
         end
 
         it "has params" do

--- a/spec/views/results/try_another_search_text_spec.rb
+++ b/spec/views/results/try_another_search_text_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "results/try_another_search_text.html.erb", type: :view do
   let(:html) { render partial: "results/try_another_search_text.html.erb" }
-  let(:salary_suffix) { "or searching for courses that don't offer a salary" }
+  let(:salary_suffix) { "or searching for courses that do not offer a salary" }
 
   before do
     assign(:results_view, double(with_salaries?: with_salaries))


### PR DESCRIPTION
### Context

https://smartquotesforsmartpeople.com/

- Improve readability of titles and content by converting quotes to smart quotes, dots to ellipses, and dashes to en and em dashes, using RubyPants
- Fix hardcoded quotes
- Fix casing of Get Into Teaching

Ideally we would fix this upstream, by converting provider names and updating saved content in the database. However we don't know how the old UCAS systems will handle smart quotes in provider and location names.

# Before
![Screen Shot 2020-06-08 at 09 53 42](https://user-images.githubusercontent.com/319055/84024733-511e3c00-a982-11ea-84f0-f1d9c804be90.png)

# After
![Screen Shot 2020-06-08 at 09 53 51](https://user-images.githubusercontent.com/319055/84024738-524f6900-a982-11ea-9e2a-5d723a665d46.png)