### PR TITLE
Fix common mistakes with markdown lists 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,13 @@ module ApplicationHelper
     # autolink: parse links even when they are not enclosed in <> characters
     options = { autolink: true, lax_spacing: true }
     markdown = Redcarpet::Markdown.new(render, options)
+
+    # Fix common markdown errors:
+    # - using bullets rather than *
+    # - not putting a space between * and word
+    source = source.gsub(/•\s?/, "* ").gsub(/^\*(?!\s)/, "* ")
+
+    # Convert quotes to smart quotes
     source_with_smart_quotes = smart_quotes(source)
     markdown.render(source_with_smart_quotes).html_safe
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+feature "Application helpers", type: :helper do
+  describe "#markdown" do
+    it "converts markdown to HTML" do
+      expect(helper.markdown("test")).to eq("<p class=\"govuk-body\">test</p>")
+    end
+
+    it "converts markdown lists to HTML lists" do
+      expect(helper.markdown("* test\n* another test")).to include("<li>test</li>")
+    end
+
+    it "converts bullets into HTML lists" do
+      output = helper.markdown("* test\n• bullet\n•bullet without space")
+
+      expect(output).to include("<li>test</li>")
+      expect(output).to include("<li>bullet</li>")
+      expect(output).to include("<li>bullet without space</li>")
+    end
+
+    it "converts markdown lists into HTML when space missed between * and word" do
+      output = helper.markdown("* test\n*no space here\n*also *here*")
+
+      expect(output).to include("<li>test</li>")
+      expect(output).to include("<li>no space here</li>")
+      expect(output).to include("<li>also <em>here</em></li>")
+    end
+
+    it "converts quotes to smart quotes" do
+      output = helper.markdown("\"Wow -- what's this...\", O'connor asked.")
+      expect(output).to eq("<p class=\"govuk-body\">“Wow – what’s this…”, O’connor asked.</p>")
+    end
+  end
+
+  describe "#smart_quotes" do
+    it "converts quotes to smart quotes" do
+      output = helper.smart_quotes("\"Wow -- what's this...\", O'connor asked.")
+      expect(output).to include("“Wow – what’s this…”, O’connor asked.")
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -30,6 +30,12 @@ feature "Application helpers", type: :helper do
       output = helper.markdown("\"Wow -- what's this...\", O'connor asked.")
       expect(output).to eq("<p class=\"govuk-body\">“Wow – what’s this…”, O’connor asked.</p>")
     end
+
+    # Redcarpet fixes out of the box
+    it "fixes incorrect markdown links" do
+      output = helper.markdown("[Google] (https://www.google.com)")
+      expect(output).to include("<a href=\"https://www.google.com\" class=\"govuk-link\">Google</a>")
+    end
   end
 
   describe "#smart_quotes" do


### PR DESCRIPTION
### Context

- Convert bullets to asterisks before processing markdown
- Include spaces between asterisks and words when they start a new line
- Add helper spec

| Mistake | Before | After |
|--|--|--|
| No spaces | ![Screen Shot 2020-06-08 at 15 41 20](https://user-images.githubusercontent.com/319055/84049926-f1855800-a9a4-11ea-9f81-18d220fadfa0.png) | ![Screen Shot 2020-06-08 at 15 41 33](https://user-images.githubusercontent.com/319055/84049931-f34f1b80-a9a4-11ea-9bab-cddca858d9e7.png) |
| Using bullets |![Screen Shot 2020-06-08 at 15 42 22](https://user-images.githubusercontent.com/319055/84050023-18438e80-a9a5-11ea-83e5-431aa13a1e03.png) | ![Screen Shot 2020-06-08 at 15 42 31](https://user-images.githubusercontent.com/319055/84050026-1974bb80-a9a5-11ea-84aa-5d835bba1882.png)|