### PR TITLE
[3502] Add code climate test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -122,7 +122,7 @@ group :test do
   gem "faker"
 
   # Show test coverage %
-  gem "simplecov", require: false
+  gem "simplecov", "< 0.18", require: false
 
   # Page object for Capybara
   gem "site_prism"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
+    json (2.3.0)
     json_api_client (1.16.1)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -341,10 +342,11 @@ GEM
     semantic_range (2.3.0)
     sentry-raven (2.13.0)
       faraday (>= 0.7.6, < 1.0)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     site_prism (3.4.2)
       addressable (~> 2.5)
       capybara (~> 3.3)
@@ -432,7 +434,7 @@ DEPENDENCIES
   rubypants
   scss_lint-govuk
   sentry-raven
-  simplecov
+  simplecov (< 0.18)
   site_prism
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,15 +43,6 @@ steps:
     containerCommand: rails webpacker:compile
     runInBackground: false
 
-- bash: |
-    set -x
-    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
-    test_result=$?
-    cat  --number rspec-results.xml
-    sed -i '1,2d' rspec-results.xml
-    if [ "$test_result" == "0" ] ; then true ; else false ; fi
-  displayName: 'Run tests'
-
 - task: Docker@1
   displayName: Run ruby linter
   inputs:
@@ -75,6 +66,16 @@ steps:
     imageName: $(IMAGE_NAME)
     containerCommand: brakeman
     runInBackground: false
+
+- bash: |
+    set -x
+    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    test_result=$?
+    cat  --number rspec-results.xml
+    sed -i '1,2d' rspec-results.xml
+    if [ "$test_result" == "0" ] ; then true ; else false ; fi
+  displayName: 'Run tests'
+
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,16 +69,19 @@ steps:
 
 - bash: |
     set -x
+    # Start up container and run the ruby test suite
     docker run --name test-run-image -d $(IMAGE_NAME)
     docker exec test-run-image rails spec SPEC_OPTS='--format RspecJunitFormatter --out rspec-results.xml'
     test_result=$?
 
+    # Copy test results and coverage to docker host (used by another script)
     docker cp test-run-image:/app/rspec-results.xml .
     docker cp test-run-image:/app/coverage .
-    docker stop test-run-image
-    docker rm test-run-image
 
-    if [ "$test_result" == "0" ]; then true; else false; fi
+    # Remove container
+    docker rm -f test-run-image
+
+    exit $test_result
   displayName: 'Run Ruby tests'
 
 - task: Docker@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,8 +74,15 @@ steps:
     cat  --number rspec-results.xml
     sed -i '1,2d' rspec-results.xml
     if [ "$test_result" == "0" ] ; then true ; else false ; fi
-  displayName: 'Run tests'
+  displayName: 'Run Ruby tests'
 
+- task: Docker@1
+  displayName: Run JavaScript tests
+  inputs:
+    command: Run an image
+    imageName: $(IMAGE_NAME)
+    containerCommand: yarn test
+    runInBackground: false
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,11 +69,18 @@ steps:
 
 - bash: |
     set -x
-    docker run --rm $(IMAGE_NAME) rails spec SPEC_OPTS='--format RspecJunitFormatter' >rspec-results.xml
+    docker run --name test-run-image -d $(IMAGE_NAME)
+    docker exec test-run-image rails spec SPEC_OPTS='--format RspecJunitFormatter'
     test_result=$?
-    cat  --number rspec-results.xml
-    sed -i '1,2d' rspec-results.xml
-    if [ "$test_result" == "0" ] ; then true ; else false ; fi
+      if [ "$test_result" != "0" ]
+      then
+          echo "##vso[task.logissue type=error] Test task failed."
+          exit 1
+      fi
+
+    docker cp test-run-image:/app/coverage .
+    docker stop test-run-image
+    docker rm test-run-image
   displayName: 'Run Ruby tests'
 
 - task: Docker@1
@@ -83,6 +90,22 @@ steps:
     imageName: $(IMAGE_NAME)
     containerCommand: yarn test
     runInBackground: false
+
+- script: |
+    set -x
+    curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    chmod +x ./cc-test-reporter
+
+    ./cc-test-reporter before-build
+    # As the tests were run in the docker container the paths to the coverage are prefixed with "/app/"
+    # So we need to replace it with the docker hosts current directory
+    sed "s|\"/app/|\"`pwd`/|g" coverage/.resultset.json -i
+    ./cc-test-reporter after-build
+  displayName: 'Publish Code Climate Test Coverage'
+  env:
+    CC_TEST_REPORTER_ID: $(ccReporterID)
+    AGENT_JOBSTATUS: $(Agent.JobStatus)
+    GIT_BRANCH: $(Build.SourceBranchName)
 
 - task: Docker@1
   displayName: Tag image with current build number $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,17 +70,15 @@ steps:
 - bash: |
     set -x
     docker run --name test-run-image -d $(IMAGE_NAME)
-    docker exec test-run-image rails spec SPEC_OPTS='--format RspecJunitFormatter'
+    docker exec test-run-image rails spec SPEC_OPTS='--format RspecJunitFormatter --out rspec-results.xml'
     test_result=$?
-      if [ "$test_result" != "0" ]
-      then
-          echo "##vso[task.logissue type=error] Test task failed."
-          exit 1
-      fi
 
+    docker cp test-run-image:/app/rspec-results.xml .
     docker cp test-run-image:/app/coverage .
     docker stop test-run-image
     docker rm test-run-image
+
+    if [ "$test_result" == "0" ]; then true; else false; fi
   displayName: 'Run Ruby tests'
 
 - task: Docker@1
@@ -104,7 +102,6 @@ steps:
   displayName: 'Publish Code Climate Test Coverage'
   env:
     CC_TEST_REPORTER_ID: $(ccReporterID)
-    AGENT_JOBSTATUS: $(Agent.JobStatus)
     GIT_BRANCH: $(Build.SourceBranchName)
 
 - task: Docker@1


### PR DESCRIPTION
### Context
We need a way to surface code smells and test coverage. Code climate is used in API and Code Climate was configured to analysis this repo but it did not include the test coverage.
 
### Changes proposed in this pull request
- Adds JavaScript test step to the pipeline so it mirror Publish pipeline
- Reorder tests so linting is run before ruby/JS testing
- Sets simplecov version to 0.17.x so that code climates test reporter will work
- Add new script to the pipeline to push the test coverage score to code climate (This is only run if all our existing tasks pass.

### Guidance to review
I checked on Code Climate and can confirm that Code climate is receiving the requests sent to it:
![image](https://user-images.githubusercontent.com/3441519/84267643-4b5d5d80-ab1e-11ea-9b15-4f2111d112fb.png)


Ignore `merge` entries. These are submissions where we run the azure pipeline twice. This is an existing issue where the azure pipeline is run twice, once for the PR and another for new pushed commits. We will have to look at why we are running it twice.


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
