### PR TITLE
Disable emphasis markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
     # Fix common markdown errors:
     # - using bullets rather than *
     # - not putting a space between * and word
-    source = source.gsub(/•\s?/, "* ").gsub(/^\*(?!\s)/, "* ")
+    source = source.gsub(/•\s?/, "* ").gsub(/^\*(?![\s\*])/, "* ")
 
     # Convert quotes to smart quotes
     source_with_smart_quotes = smart_quotes(source)

--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -8,6 +8,18 @@ module Govuk
       # No user input HTML please
     end
 
+    def emphasis(text)
+      # Disable feature
+    end
+
+    def double_emphasis(text)
+      # Disable feature
+    end
+
+    def triple_emphasis(text)
+      # Disable feature
+    end
+
     def list(content, list_type)
       case list_type
       when :ordered

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -23,7 +23,14 @@ feature "Application helpers", type: :helper do
 
       expect(output).to include("<li>test</li>")
       expect(output).to include("<li>no space here</li>")
-      expect(output).to include("<li>also <em>here</em></li>")
+      expect(output).to include("<li>also *here*</li>")
+    end
+
+    it "ignores emphasis markdown" do
+      output = helper.markdown("This does not have *emphasis*\n**something important**\n***super***")
+      expect(output).to include("This does not have *emphasis*")
+      expect(output).to include("**something important**")
+      expect(output).to include("***super***")
     end
 
     it "converts quotes to smart quotes" do

--- a/spec/lib/govuk/markdown_renderer_spec.rb
+++ b/spec/lib/govuk/markdown_renderer_spec.rb
@@ -162,7 +162,7 @@ describe Govuk::MarkdownRenderer do
     end
   end
 
-  context "h6" do
+  describe "h6" do
     let(:markdown) do
       <<~MD
         ###### heading level 6
@@ -172,6 +172,54 @@ describe Govuk::MarkdownRenderer do
     it "renders correct HTML" do
       expected_html = <<~HTML
         <h3 class="govuk-heading-m">heading level 6</h3>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "em" do
+    let(:markdown) do
+      <<~MD
+        *emphasis*
+      MD
+    end
+
+    it "does not render emphasis tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">*emphasis*</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "strong" do
+    let(:markdown) do
+      <<~MD
+        **strong**
+      MD
+    end
+
+    it "does not render strong tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">**strong**</p>
+      HTML
+
+      expect_equal_ignoring_ws(html, expected_html)
+    end
+  end
+
+  describe "strong emphasis" do
+    let(:markdown) do
+      <<~MD
+        ***strong emphasis***
+      MD
+    end
+
+    it "does not render strong or emphasis tags" do
+      expected_html = <<~HTML
+        <p class="govuk-body">***strong emphasis***</p>
       HTML
 
       expect_equal_ignoring_ws(html, expected_html)


### PR DESCRIPTION
We don't want to allow providers to mark content in italics, bold or bold italic using markdown.

These are currently undocumented markdown features in Publish, but for any providers who know their markdown, they'll find that they currently work.

This is consistent with how GOV.UK renders content.