### PR TITLE
[3524] Smart quotes handles nil input

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -20,6 +20,8 @@ module ApplicationHelper
   end
 
   def smart_quotes(string)
+    return "" if string.blank?
+
     RubyPants.new(string, 2, ruby_pants_options).to_html
   end
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -50,5 +50,11 @@ feature "Application helpers", type: :helper do
       output = helper.smart_quotes("\"Wow -- what's this...\", O'connor asked.")
       expect(output).to include("“Wow – what’s this…”, O’connor asked.")
     end
+
+    context "when nil" do
+      it "returns empty string" do
+        expect(helper.smart_quotes(nil)).to be_blank
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/FKlI0Stn/3524-sentry-error-nil-for-smart-quotes
- An sentry error was reporting an error around smart quotes when the input was `nil`

### Changes proposed in this pull request

- For smart quotes method had nil input and return empty string

### Guidance to review

- test should pass
- alternatively visit sentry error and run same query on local environment and should not see an error

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
