### PR TITLE
[3576] COPY: Course fees now uses year range

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -119,6 +119,10 @@ class CourseDecorator < Draper::Decorator
     object.has_vacancies? ? "Yes" : "No"
   end
 
+  def year_range
+    "#{object.recruitment_cycle_year} – #{object.recruitment_cycle_year.to_i + 1}"
+  end
+
 private
 
   def find_max(attribute)

--- a/app/views/courses/_fees.html.erb
+++ b/app/views/courses/_fees.html.erb
@@ -4,7 +4,7 @@
   <% if course.fee_uk_eu.present? %>
     <div class="body-text">
       <table class="govuk-table app-table--vertical-align-middle">
-        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for <%= Settings.current_cycle %> are as follows:</caption>
+        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for <%= course.year_range %> are as follows:</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-visually-hidden govuk-table__row">
             <th class="govuk-table__header">Student type</th>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -406,4 +406,10 @@ describe CourseDecorator do
       expect(decorated_course.has_vacancies?).to eq("Yes")
     end
   end
+
+  describe "#year_range" do
+    it "returns correct year range" do
+      expect(decorated_course.year_range).to eq("2020 – 2021")
+    end
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/lD6tJVsR/3576-s-publish-preview-functionality-should-match-find
- When viewing a course, under the fees section, it is showing the year and not the range of years of the cycle   

### Changes proposed in this pull request

- Show year range of course instead of just the starting year
- This matches what is seen in publish when previewing a course

### Guidance to review

- Find any course
- Navigate to fees section
- For the year it should be a range eg `2019 - 2020` and not a single year `2019`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
