### PR TITLE
3540 m update find search results for universities as an area

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -30,6 +30,10 @@ class Course < Base
     applications_open_from.split("-").third if applications_open_from.present?
   end
 
+  def university_based?
+    provider_type == "university"
+  end
+
   def further_education?
     level == "further_education" && subjects.any? { |s| s.subject_name == "Further education" || s.subject_code = "41" }
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -29,4 +29,8 @@ class Course < Base
   def day
     applications_open_from.split("-").third if applications_open_from.present?
   end
+
+  def further_education?
+    level == "further_education" && subjects.any? { |s| s.subject_name == "Further education" || s.subject_code = "41" }
+  end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -203,6 +203,10 @@ class ResultsView
     !new_or_running_sites_for(course).empty?
   end
 
+  def sites_count(course)
+    new_or_running_sites_for(course).count
+  end
+
   def subjects
     subject_codes.any? ? filtered_subjects : all_subjects[0...NUMBER_OF_SUBJECTS_DISPLAYED]
   end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -207,6 +207,14 @@ class ResultsView
     new_or_running_sites_for(course).count
   end
 
+  def nearest_location_name(course)
+    nearest_address = new_or_running_sites_for(course).min_by do |site|
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
+    end
+
+    nearest_address.location_name
+  end
+
   def subjects
     subject_codes.any? ? filtered_subjects : all_subjects[0...NUMBER_OF_SUBJECTS_DISPLAYED]
   end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -406,6 +406,7 @@ private
       base_query = base_query.where("latitude" => latitude)
       base_query = base_query.where("longitude" => longitude)
       base_query = base_query.where("radius" => radius_to_query)
+      base_query = base_query.where(expand_university: true)
     end
 
     base_query = base_query.where("provider.provider_name" => provider) if provider.present?

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -254,6 +254,18 @@ class ResultsView
     end
   end
 
+  def placement_schools_summary(course)
+    site_distance = site_distance(course)
+
+    if site_distance < 11
+      "Placement schools are near you"
+    elsif site_distance < 21
+      "Placement schools might be near you"
+    else
+      "Placement schools might be in commuting distance"
+    end
+  end
+
 private
 
   def nearest_location(course)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -186,9 +186,7 @@ class ResultsView
   end
 
   def nearest_address(course)
-    nearest_address = new_or_running_sites_for(course).min_by do |site|
-      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
-    end
+    nearest_address = nearest_location(course)
 
     [
       nearest_address.address1,
@@ -208,11 +206,7 @@ class ResultsView
   end
 
   def nearest_location_name(course)
-    nearest_address = new_or_running_sites_for(course).min_by do |site|
-      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
-    end
-
-    nearest_address.location_name
+    nearest_location(course).location_name
   end
 
   def subjects
@@ -261,6 +255,12 @@ class ResultsView
   end
 
 private
+
+  def nearest_location(course)
+    new_or_running_sites_for(course).min_by do |site|
+      lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
+    end
+  end
 
   def results_per_page
     RESULTS_PER_PAGE

--- a/app/views/results/_non_university.html.erb
+++ b/app/views/results/_non_university.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 
   <% if nearest_address.present? %>
-    <span class="govuk-list--description__hint">Location</span>
+    <span class="govuk-list--description__hint govuk-!-padding-top-2">Location</span>
     <% if nearest_location_name != "Main Site" %>
       <%= nearest_location_name %><br />
     <% end %>

--- a/app/views/results/_non_university.html.erb
+++ b/app/views/results/_non_university.html.erb
@@ -1,0 +1,23 @@
+<% number_of_sites = @results_view.sites_count(course) %>
+<% nearest_address = @results_view.nearest_address(course) %>
+<% nearest_location_name = @results_view.nearest_location_name(course) %>
+
+<dt class="govuk-list--description__label">
+  <%= (number_of_sites > 1) ? "Nearest location" :  "Location"%>
+</dt>
+<dd data-qa="course__site_distance">
+  <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %> 
+  <% if number_of_sites > 1 %>
+    <div class="govuk-!-margin-top-0">
+      (Nearest of <%= number_of_sites %> locations to choose from)
+    </div>
+  <% end %>
+
+  <% if nearest_address.present? %>
+    <span class="govuk-list--description__hint">Location</span>
+    <% if nearest_location_name != "Main Site" %>
+      <%= nearest_location_name %><br />
+    <% end %>
+    <%= nearest_address %>
+  <% end %>
+</dd>

--- a/app/views/results/_non_university.html.erb
+++ b/app/views/results/_non_university.html.erb
@@ -5,7 +5,7 @@
 <dt class="govuk-list--description__label">
   <%= (number_of_sites > 1) ? "Nearest location" :  "Location"%>
 </dt>
-<dd data-qa="course__site_distance">
+<dd>
   <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %> 
   <% if number_of_sites > 1 %>
     <div class="govuk-!-margin-top-0">
@@ -13,11 +13,9 @@
     </div>
   <% end %>
 
-  <% if nearest_address.present? %>
-    <span class="govuk-list--description__hint govuk-!-padding-top-2">Location</span>
-    <% if nearest_location_name != "Main Site" %>
-      <%= nearest_location_name %><br />
-    <% end %>
-    <%= nearest_address %>
+  <span class="govuk-list--description__hint govuk-!-padding-top-2">Location</span>
+  <% if nearest_location_name != "Main Site" %>
+    <%= nearest_location_name %><br />
   <% end %>
+  <%= nearest_address %>
 </dd>

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -1,0 +1,41 @@
+<% site_distance = @results_view.site_distance(course)%>
+
+<dt class="govuk-list--description__label">Location</dt>
+
+<dd data-qa="course__site_distance">
+  <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0">
+    <li>
+      <% if course.further_education? %>
+        <span class="govuk-list--description__hint govuk-!-margin-top-0">University</span>
+      <% else %>
+        <span class="govuk-list--description__hint govuk-!-margin-top-0">Placement schools</span>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              <% if site_distance < 11 %>
+                Placement schools are near you
+              <% elsif site_distance < 21 %>
+                Placement schools might be near you
+              <% else %>
+                Placement schools might be in commuting distance
+              <% end %>
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
+            <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+            <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: "govuk-link" do %>
+              More about placements on this course
+            <% end %>
+          </div>
+        </details>
+        You’ll be placed in schools for most of your course
+        <span class="govuk-list--description__hint govuk-!-padding-top-2">University</span>
+      <% end %>
+
+      <%= "#{pluralize(site_distance, 'mile')} from you" %> 
+      <br />
+      You’ll be at university only some of the time
+    </li>
+  </ul>
+</dd>

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -2,7 +2,7 @@
 
 <dt class="govuk-list--description__label">Location</dt>
 
-<dd data-qa="course__site_distance">
+<dd>
   <ul class="govuk-list govuk-!-margin-top-0 govuk-!-margin-bottom-0">
     <li>
       <% if course.further_education? %>
@@ -24,9 +24,7 @@
           <div class="govuk-details__text">
             <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
             <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-            <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: "govuk-link" do %>
-              More about placements on this course
-            <% end %>
+            <%= link_to "More about placements on this course", course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: "govuk-link" %>
           </div>
         </details>
         You’ll be placed in schools for most of your course

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -1,5 +1,3 @@
-<% site_distance = @results_view.site_distance(course)%>
-
 <dt class="govuk-list--description__label">Location</dt>
 
 <dd>
@@ -12,13 +10,7 @@
         <details class="govuk-details" data-module="govuk-details">
           <summary class="govuk-details__summary">
             <span class="govuk-details__summary-text">
-              <% if site_distance < 11 %>
-                Placement schools are near you
-              <% elsif site_distance < 21 %>
-                Placement schools might be near you
-              <% else %>
-                Placement schools might be in commuting distance
-              <% end %>
+              <%= @results_view.placement_schools_summary(course) %>
             </span>
           </summary>
           <div class="govuk-details__text">
@@ -31,7 +23,7 @@
         <span class="govuk-list--description__hint govuk-!-padding-top-2">University</span>
       <% end %>
 
-      <%= "#{pluralize(site_distance, 'mile')} from you" %> 
+      <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %> 
       <br />
       You’ll be at university only some of the time
     </li>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -112,6 +112,14 @@
             <dt class="govuk-list--description__label">Course</dt>
             <dd data-qa="course__description"><%= course.description%></dd>
             <% if @results_view.location_filter? && @results_view.has_sites?(course)  %>
+              <% if course.university_based? %>
+                <%= render partial: 'results/university', locals: {course: course} %>
+              <% else %>
+                <%= render partial: 'results/non_university', locals: {course: course} %>
+                <% end %>
+            <% end %>
+
+            <% if @results_view.location_filter? && @results_view.has_sites?(course)  %>
               <dt class="govuk-list--description__label">Distance</dt>
               <dd data-qa="course__site_distance"><%= @results_view.site_distance(course) %> mile<%= 's' if @results_view.site_distance(course) != 1 %> <span class="govuk-list--description__hint">to the training provider or their nearest training location</span></dd>
               <% if @results_view.nearest_address(course).present? %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -118,15 +118,6 @@
                 <%= render partial: 'results/non_university', locals: {course: course} %>
                 <% end %>
             <% end %>
-
-            <% if @results_view.location_filter? && @results_view.has_sites?(course)  %>
-              <dt class="govuk-list--description__label">Distance</dt>
-              <dd data-qa="course__site_distance"><%= @results_view.site_distance(course) %> mile<%= 's' if @results_view.site_distance(course) != 1 %> <span class="govuk-list--description__hint">to the training provider or their nearest training location</span></dd>
-              <% if @results_view.nearest_address(course).present? %>
-                <dt class="govuk-list--description__label">Nearest address</dt>
-                <dd data-qa="course__nearest_address"><%= smart_quotes(@results_view.nearest_address(course)) %></dd>
-              <% end  %>
-            <% end %>
             <dt class="govuk-list--description__label">Financial support</dt>
             <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
             <% if course['accrediting_provider'].present? %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -64,6 +64,7 @@ $govuk-image-url-function: frontend-image-url;
 
   > li {
     @include govuk-responsive-padding(4, "top");
+    @include govuk-responsive-padding(4, "bottom");
     border-bottom: 1px solid $govuk-border-colour;
     margin: 0;
   }

--- a/app/webpacker/styles/patterns/_definition-list.scss
+++ b/app/webpacker/styles/patterns/_definition-list.scss
@@ -4,7 +4,7 @@
 }
 
 %govuk-list--description > dt {
-  @include govuk-font($size: 19, $weight: normal);
+  @include govuk-font($size: 19, $weight: bold);
   vertical-align: top;
 
   @include mq ($from: desktop) {
@@ -40,7 +40,6 @@
   @extend %govuk-list--description;
 
   &__label:after {
-    content: ":";
     display: inline-block;
   }
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -76,6 +76,7 @@ FactoryBot.define do
 
       course.recruitment_cycle = evaluator.recruitment_cycle
       course.provider_code = evaluator.provider&.provider_code
+      course.provider_type = evaluator.provider&.provider_type
       course.recruitment_cycle_year = evaluator&.recruitment_cycle&.year
     end
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -80,6 +80,11 @@ FactoryBot.define do
       course.recruitment_cycle_year = evaluator&.recruitment_cycle&.year
     end
 
+    trait :further_education do
+      level { "further_education" }
+      subjects { [build(:subject, :further_education)] }
+    end
+
     trait :with_vacancy do
       has_vacancies? { true }
     end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
     sequence(:id)
     sequence(:provider_code) { |n| "A#{n}" }
     provider_name { "ACME SCITT #{provider_code}" }
-    accredited_body? { false }
+
+    lead_school
+
     can_add_more_sites? { true }
     courses { [] }
     train_with_us { Faker::Lorem.sentence(word_count: 100) }
@@ -81,6 +83,27 @@ FactoryBot.define do
 
       provider.recruitment_cycle = evaluator.recruitment_cycle
       provider.recruitment_cycle_year = evaluator.recruitment_cycle.year
+
+      provider.provider_type = if provider.accredited_body?
+                                 %w[scitt university].sample
+                               else
+                                 "lead_school"
+                               end
+    end
+
+    trait :lead_school do
+      accredited_body? { false }
+      provider_type { "lead_school" }
+    end
+
+    trait :scitt do
+      accredited_body? { true }
+      provider_type { "scitt" }
+    end
+
+    trait :university do
+      accredited_body? { true }
+      provider_type { "university" }
     end
   end
 end

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -54,6 +54,11 @@ FactoryBot.define do
       subject_code { "00" }
     end
 
+    trait :further_education do
+      subject_name { "Further education" }
+      subject_code { "41" }
+    end
+
     trait :design_and_technology do
       subject_name { "Design and technology" }
       subject_code { "DT" }

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -66,8 +66,6 @@ feature "Location filter", type: :feature do
         provider_page.provider_suggestions[0].hyperlink.click
 
         expect(results_page.courses.first).to have_main_address
-        expect(results_page.courses.first).not_to have_site_distance_to_location_query
-        expect(results_page.courses.first).not_to have_nearest_address
 
         expect(results_page.heading.text).to eq("Teacher training courses ACME SCITT 0")
         expect(results_page.provider_filter.name.text).to eq("ACME SCITT 0")
@@ -130,8 +128,6 @@ feature "Location filter", type: :feature do
       it "displays the courses" do
         expect(results_page.heading.text).to eq("Teacher training courses")
 
-        expect(results_page.courses.first).to have_site_distance_to_location_query
-        expect(results_page.courses.first).to have_nearest_address
         expect(results_page.courses.first).not_to have_main_address
 
         expect(results_page.location_filter.name.text).to eq("Westminster, London SW1P 3BT, UK Within 20 miles of the pin")
@@ -145,8 +141,6 @@ feature "Location filter", type: :feature do
       # 'nearest site' or 'distance to site' info
       it "does not display nearest site information" do
         expect(results_page.heading.text).to eq("Teacher training courses")
-        expect(results_page.courses.fifth).not_to have_site_distance_to_location_query
-        expect(results_page.courses.fifth).not_to have_nearest_address
       end
     end
 

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -111,6 +111,7 @@ feature "Location filter", type: :feature do
             "filter[latitude]" => "51.4980188",
             "filter[radius]" => "20",
             "sort" => "distance",
+            "filter[expand_university]" => true,
           ),
         )
         .to_return(
@@ -311,6 +312,7 @@ feature "Location filter", type: :feature do
             "filter[latitude]" => "51.4980188",
             "filter[radius]" => "20",
             "sort" => "distance",
+            "filter[expand_university]" => true,
           ),
         )
         .to_return(

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -73,6 +73,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
+        "filter[expand_university]" => true,
       ),
     )
   end
@@ -85,6 +86,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
+        "filter[expand_university]" => true,
       ),
     )
   end
@@ -96,6 +98,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
+        "filter[expand_university]" => true,
       ),
     )
   end

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -24,7 +24,7 @@ feature "suggested searches", type: :feature do
 
   def results_page_request(radius:, results_to_return:)
     stub_request(:get, courses_url)
-      .with(query: base_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius))
+      .with(query: base_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius, "filter[expand_university]" => true))
       .to_return(
         body: course_fixture_for(results: results_to_return),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -33,7 +33,7 @@ feature "suggested searches", type: :feature do
 
   def suggested_search_count_request(radius:, results_to_return:)
     stub_request(:get, courses_url)
-      .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius))
+      .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius, "filter[expand_university]" => true))
       .to_return(
         body: course_fixture_for(results: results_to_return),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/fixtures/api_responses/ten_courses.json
+++ b/spec/fixtures/api_responses/ten_courses.json
@@ -5,6 +5,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "385N",
@@ -128,6 +129,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "38KK",
@@ -267,6 +269,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "3855",
@@ -402,6 +405,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "385J",
@@ -513,6 +517,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "3DTC",
@@ -620,6 +625,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "Z923",
@@ -731,6 +737,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "3FL7",
@@ -839,6 +846,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "3854",
@@ -950,6 +958,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "384R",
@@ -1097,6 +1106,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "385V",

--- a/spec/fixtures/api_responses/two_courses.json
+++ b/spec/fixtures/api_responses/two_courses.json
@@ -5,6 +5,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "X130",
@@ -88,6 +89,7 @@
       "type": "courses",
       "attributes": {
         "findable?": true,
+        "provider_type": "university",
         "open_for_applications?": true,
         "has_vacancies?": true,
         "course_code": "2XNM",

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -15,8 +15,6 @@ module PageObjects
         element :accrediting_provider, '[data-qa="course__accrediting_provider"]'
         element :funding_options, '[data-qa="course__funding_options"]'
         element :main_address, '[data-qa="course__main_address"]'
-        elements :site_distance_to_location_query, '[data-qa="course__site_distance"]'
-        elements :nearest_address, '[data-qa="course__nearest_address"]'
         elements :show_vacanices, '[data-qa="course__has_vacancies"]'
       end
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -707,6 +707,12 @@ describe ResultsView do
         expect(results_view.sites_count(course)).to eq(1)
       end
     end
+
+    describe "#site_distance" do
+      it "returns the running or new sites count" do
+        expect(results_view.site_distance(course)).to eq(0.1)
+      end
+    end
   end
 
   describe "#sort_options" do

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -577,6 +577,59 @@ describe ResultsView do
     end
   end
 
+  describe "#placement_schools_summary" do
+    let(:results_view) { described_class.new(query_parameters: parameter_hash) }
+
+    let(:site1) do
+      build(:site, latitude: 51.5079, longitude: 0.0877, address1: "1 Foo Street", postcode: "BAA0NE")
+    end
+
+    let(:site_statuses) do
+      [build(:site_status, :full_time_and_part_time, site: site1)]
+    end
+
+    let(:course) do
+      build(
+        :course,
+        site_statuses: site_statuses,
+      )
+    end
+
+    subject do
+      results_view.placement_schools_summary(course)
+    end
+
+    context "site_distance less than 11 miles" do
+      let(:parameter_hash) do
+        {
+          "lat" => "51.5079",
+          "lng" => "0.0877",
+        }
+      end
+      it { expect(subject).to eq("Placement schools are near you") }
+    end
+
+    context "site_distance less than 21 miles" do
+      let(:parameter_hash) do
+        {
+          "lat" => "51.6985",
+          "lng" => "0.1367",
+        }
+      end
+      it { expect(subject).to eq("Placement schools might be near you") }
+    end
+
+    context "site_distance more than 21 miles" do
+      let(:parameter_hash) do
+        {
+          "lat" => "52",
+          "lng" => "0.1367",
+        }
+      end
+      it { expect(subject).to eq("Placement schools might be in commuting distance") }
+    end
+  end
+
   describe "#site_distance" do
     let(:results_view) { described_class.new(query_parameters: parameter_hash) }
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -520,13 +520,13 @@ describe ResultsView do
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
               stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
-                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 10))
+                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 10, "filter[expand_university]" => true))
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/four_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
               stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
-                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 20))
+                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 20, "filter[expand_university]" => true))
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/ten_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -545,19 +545,19 @@ describe ResultsView do
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
               stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
-                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 10))
+                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 10, "filter[expand_university]" => true))
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/empty_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
               stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
-                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 20))
+                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 20, "filter[expand_university]" => true))
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/empty_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
               stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
-                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 50))
+                .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 0.1, "filter[longitude]" => 2.4, "filter[radius]" => 50, "filter[expand_university]" => true))
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/empty_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/views/results/non_university_spec.rb
+++ b/spec/views/results/non_university_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+describe "results/non_university.html.erb", type: :view do
+  let(:html) do
+    render partial: "results/non_university.html.erb", locals: { course: course }
+  end
+
+  let(:site1) do
+    build(
+      :site,
+      latitude: 51.4985,
+      longitude: 0.1367,
+      address1: "10 Windy Way",
+      address2: "Witham",
+      address3: "Essex",
+      address4: "UK",
+      postcode: "CM8 2SD",
+    )
+  end
+
+  let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+  let(:course) do
+    build(:course, site_statuses: site_statuses)
+  end
+
+  before do
+    assign(:results_view, ResultsView.new(query_parameters: parameter_hash))
+  end
+
+  context "single site" do
+    let(:site_statuses) do
+      [
+        build(:site_status, :full_time_and_part_time, site: site1),
+      ]
+    end
+
+    it "renders dt with Location" do
+      expect(html).to have_css("dt.govuk-list--description__label", text: "Location")
+      expect(html).to have_no_css("dt.govuk-list--description__label", text: "Nearest location")
+    end
+
+    it "renders '0.1 miles from you'" do
+      expect(html).to match("0.1 miles from you")
+    end
+
+    it "does not renders 'locations to choose from'" do
+      expect(html).to have_no_css("div.govuk-\\!-margin-top-0")
+      expect(html).to_not match("locations to choose from")
+    end
+
+    it "does not renders `Main Site` as nearest_location_name" do
+      expect(html).to_not match("Main Site")
+    end
+
+    it "renders nearest address'" do
+      expect(html).to match("10 Windy Way, Witham, Essex, UK, CM8 2SD")
+    end
+
+    it "renders location" do
+      expect(html).to have_css("span.govuk-list--description__hint.govuk-\\!-padding-top-2", text: "Location")
+    end
+  end
+
+  context "multi sites" do
+    let(:site2) do
+      build(
+        :site,
+        latitude: 51.4980,
+        longitude: 0.1367,
+        address1: "101 Windy Way",
+        address2: "Witham",
+        address3: "Essex",
+        address4: "UK",
+        postcode: "CM8 2SD",
+        location_name: "campus main site",
+      )
+    end
+    let(:site_statuses) do
+      [
+        build(:site_status, :full_time_and_part_time, site: site1),
+        build(:site_status, :full_time_and_part_time, site: site2),
+      ]
+    end
+
+    it "renders dt with Nearest location" do
+      expect(html).to have_no_css("dt.govuk-list--description__label", text: "Location")
+      expect(html).to have_css("dt.govuk-list--description__label", text: "Nearest location")
+    end
+
+    it "renders choose from" do
+      expect(html).to have_css("div.govuk-\\!-margin-top-0", text: "(Nearest of 2 locations to choose from)")
+    end
+
+    it "renders nearest location name" do
+      expect(html).to match("campus main site")
+    end
+
+    it "renders nearest address'" do
+      expect(html).to match("101 Windy Way, Witham, Essex, UK, CM8 2SD")
+    end
+
+    it "renders location" do
+      expect(html).to have_css("span.govuk-list--description__hint.govuk-\\!-padding-top-2", text: "Location")
+    end
+  end
+end

--- a/spec/views/results/university_spec.rb
+++ b/spec/views/results/university_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+describe "results/university.html.erb", type: :view do
+  let(:html) do
+    render partial: "results/university.html.erb", locals: { course: course }
+  end
+
+  let(:site1) do
+    build(
+      :site,
+      **lat_lon,
+      address1: "10 Windy Way",
+      address2: "Witham",
+      address3: "Essex",
+      address4: "UK",
+      postcode: "CM8 2SD",
+    )
+  end
+
+  let(:lat_lon) do
+    {
+      latitude: 51.4985,
+      longitude: 0.1367,
+    }
+  end
+
+  let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+  let(:site_statuses) do
+    [
+      build(:site_status, :full_time_and_part_time, site: site1),
+    ]
+  end
+
+  before do
+    assign(:results_view, ResultsView.new(query_parameters: parameter_hash))
+  end
+
+  context "further education course" do
+    let(:course) do
+      build(:course, :further_education, provider: build(:provider), site_statuses: site_statuses)
+    end
+
+    it "renders University" do
+      expect(html).to have_css("span.govuk-list--description__hint.govuk-\\!-margin-top-0", text: "University")
+    end
+
+    it "renders '0.1 miles from you'" do
+      expect(html).to match("0.1 miles from you")
+    end
+  end
+
+  context "non further education course" do
+    let(:course) do
+      build(:course, provider: build(:provider), site_statuses: site_statuses)
+    end
+
+    it "renders Placement schools" do
+      expect(html).to have_css("span.govuk-list--description__hint.govuk-\\!-margin-top-0", text: "Placement schools")
+    end
+
+    it "renders link" do
+      expect(html).to have_link("More about placements on this course", href: course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: "section-schools"), visible: false)
+    end
+
+    it "renders University" do
+      expect(html).to have_css("span.govuk-list--description__hint.govuk-\\!-padding-top-2", text: "University")
+    end
+
+    it "renders dt with Location" do
+      expect(html).to have_css("dt.govuk-list--description__label", text: "Location")
+      expect(html).to have_no_css("dt.govuk-list--description__label", text: "Nearest location")
+    end
+
+    context "site_distance < 11" do
+      it "renders '0.1 miles from you'" do
+        expect(html).to match("0.1 miles from you")
+      end
+
+      it "renders Placement schools distance summary" do
+        expect(html).to have_css("span.govuk-details__summary-text", text: "Placement schools are near you")
+      end
+    end
+
+    context "site_distance < 21" do
+      let(:lat_lon) do
+        { latitude: 51.6985,
+          longitude: 0.1367 }
+      end
+
+      it "renders '14 miles from you'" do
+        expect(html).to match("14 miles from you")
+      end
+
+      it "renders Placement schools distance summary" do
+        expect(html).to have_css("span.govuk-details__summary-text", text: "Placement schools might be near you")
+      end
+    end
+
+    context "site_distance < 21" do
+      let(:lat_lon) do
+        { latitude: 52,
+          longitude: 0.1367 }
+      end
+
+      it "renders '35 miles from you'" do
+        expect(html).to match("35 miles from you")
+      end
+
+      it "renders Placement schools distance summary" do
+        expect(html).to have_css("span.govuk-details__summary-text", text: "Placement schools might be in commuting distance")
+      end
+    end
+  end
+end

--- a/spec/views/results/university_spec.rb
+++ b/spec/views/results/university_spec.rb
@@ -72,7 +72,7 @@ describe "results/university.html.erb", type: :view do
       expect(html).to have_no_css("dt.govuk-list--description__label", text: "Nearest location")
     end
 
-    context "site_distance < 11" do
+    context "site_distance less than 11 miles" do
       it "renders '0.1 miles from you'" do
         expect(html).to match("0.1 miles from you")
       end
@@ -82,7 +82,7 @@ describe "results/university.html.erb", type: :view do
       end
     end
 
-    context "site_distance < 21" do
+    context "site_distance less than 21 miles" do
       let(:lat_lon) do
         { latitude: 51.6985,
           longitude: 0.1367 }
@@ -97,7 +97,7 @@ describe "results/university.html.erb", type: :view do
       end
     end
 
-    context "site_distance < 21" do
+    context "site_distance more than 21 miles" do
       let(:lat_lon) do
         { latitude: 52,
           longitude: 0.1367 }


### PR DESCRIPTION
### Context
based on https://github.com/DFE-Digital/find-teacher-training/pull/295

### Changes proposed in this pull request
Added an expand_university filter flag defaulted as `true` for forward motion
Fixed css search results 
Added partial views for non uni vs uni vs fe course results views

### Guidance to review
Should be review along with https://github.com/DFE-Digital/teacher-training-api/pull/1435, as that should be merge in first due to the boost distance for expanding uni as an area

#### Before

##### Non fe uni course
![image](https://user-images.githubusercontent.com/470137/86448283-73e80a00-bd0e-11ea-8f29-16f09b68c14b.png)

##### Non uni course (single site)
![image](https://user-images.githubusercontent.com/470137/86448563-d6410a80-bd0e-11ea-9162-ac8c9fda0255.png)

##### Non uni course (multiple site)
![image](https://user-images.githubusercontent.com/470137/86448718-10aaa780-bd0f-11ea-8c04-64a1bd11d19b.png)

##### fe uni course
![image](https://user-images.githubusercontent.com/470137/86448859-4780bd80-bd0f-11ea-9080-5bb124d76de7.png)

#### After

##### Non fe uni course
![image](https://user-images.githubusercontent.com/470137/86448073-2a97ba80-bd0e-11ea-92b2-43dd24ab08e8.png)

##### Non uni course (single site)
![image](https://user-images.githubusercontent.com/470137/86448551-ce816600-bd0e-11ea-8de9-fd86101b6637.png)

##### Non uni course (multiple site)
![image](https://user-images.githubusercontent.com/470137/86448690-08526c80-bd0f-11ea-8474-e3c245d1aea0.png)

##### fe uni course
![image](https://user-images.githubusercontent.com/470137/86448844-42237300-bd0f-11ea-9d1e-29d710cf8d9c.png)




### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
