### PR TITLE
[3396] - Remove "UK" from location autocomplete

### DIFF
--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -10,11 +10,20 @@ class LocationSuggestion
       response = get("#{Settings.google.places_api_path}?#{query.to_query}")
 
       if response.success?
-        JSON.parse(response.body)["predictions"].map { |p| p["description"] }.take(5)
+        JSON.parse(response.body)["predictions"]
+          .map(&format_prediction)
+          .take(5)
       end
     end
 
   private
+
+    def format_prediction
+      lambda do |prediction|
+        prediction_split = prediction["description"].split(",")
+        prediction_split.first(prediction_split.size - 1).join(",")
+      end
+    end
 
     def build_query(input)
       {

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -2,13 +2,15 @@ require "rails_helper"
 
 describe LocationSuggestion do
   describe "#suggest" do
-    let(:location1) { "123 Seseme Street" }
-    let(:location2) { "New York, NY" }
-    let(:query) { "New York" }
+    let(:location1) { "Cardiff, UK" }
+    let(:location2) { "Cardiff Road, Newport, UK" }
+    let(:location3) { "Cardiff House, Peckham Park Road, London, UK" }
+    let(:query) { "Cardiff" }
     let(:predictions) do
       [
         { description: location1 },
         { description: location2 },
+        { description: location3 },
       ]
     end
     let(:params) do
@@ -50,10 +52,11 @@ describe LocationSuggestion do
       end
 
       context "successful request" do
-        it "returns the result" do
-          expect(location_suggestions.count).to eq(2)
-          expect(location_suggestions.first).to eq(location1)
-          expect(location_suggestions.last).to eq(location2)
+        it "returns the formatted result" do
+          expect(location_suggestions.count).to eq(3)
+          expect(location_suggestions.first).to eq("Cardiff")
+          expect(location_suggestions.second).to eq("Cardiff Road, Newport")
+          expect(location_suggestions.last).to eq("Cardiff House, Peckham Park Road, London")
         end
       end
     end


### PR DESCRIPTION
### Context
When a user on Find searches for courses by location, currently each result displayed in the autocomplete ends with `, UK`. This is unnecessary because locations should be based in UK.

### Changes proposed in this pull request
- Format the response from the google places API to remove "UK" from location suggestions


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
