### PR TITLE
[3579] Expose application SHA at /sha

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -14,6 +14,10 @@ class HeartbeatController < ActionController::API
            }
   end
 
+  def sha
+    render json: { sha: commit_sha }
+  end
+
 private
 
   def api_alive?
@@ -21,5 +25,13 @@ private
     response.success?
   rescue StandardError
     false
+  end
+
+  def commit_sha
+    File.read(commit_sha_path).strip
+  end
+
+  def commit_sha_path
+    Rails.root.join(Settings.commit_sha_file)
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,7 @@ steps:
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(System.PullRequest.SourceBranch)'> $(build.artifactstagingdirectory)/prbranch.info
+    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: docker pull $(IMAGE_NAME):latest || true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
+  get :sha, controller: :heartbeat
 
   scope module: "result_filters" do
     root to: "location#start"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,4 @@ logstash:
   port: # Our port here
   ssl_enable: true
 log_level: info
+commit_sha_file: COMMIT_SHA

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -9,6 +9,22 @@ describe "heartbeat requests" do
     end
   end
 
+  describe "GET /sha" do
+    around :each do |example|
+      File.open("COMMIT_SHA", "w") { |f| f.write "some-sha" }
+
+      example.run
+
+      File.delete("COMMIT_SHA")
+    end
+
+    it "returns sha" do
+      get "/sha"
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to eql({ "sha" => "some-sha" })
+    end
+  end
+
   describe "GET /healthcheck" do
     let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/r3oKBtu9/3579-s-expose-commit-sha-as-sha
- Expose the application SHA at /sha for developer debugging and third party integrations

### Changes proposed in this pull request

- At build time append application sha to a file
- This is then part of the docker container where it can be read exposed at /sha

### Guidance to review

#### Review apps

- Visit https://s121d02-3579-find-as.azurewebsites.net/sha
- Should return valid json with correct sha
- Sha should be the merge commit https://github.com/DFE-Digital/find-teacher-training/commit/780f8babae31ab4e0324f93fa16a7498f0701d80

#### Locally

- Checkout this PR
- at the project root directory create a file named `COMMIT_SHA`
- type a random string into this file and save
- visit the app at /sha
- Should return valid JSON with content `{"sha": "the-string-you-entered"}`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
