### PR TITLE
[3690] - Add results path to 'handle_bad_encoding' middleware

### DIFF
--- a/lib/rack/handle_bad_encoding.rb
+++ b/lib/rack/handle_bad_encoding.rb
@@ -5,7 +5,7 @@ module Rack
     end
 
     def call(env)
-      if %w[/location-suggestions /provider-suggestions].include?(env["REQUEST_PATH"])
+      if %w[/location-suggestions /provider-suggestions /results].include?(env["REQUEST_PATH"])
         begin
           Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
         rescue Rack::Utils::InvalidParameterError

--- a/spec/lib/rack/handle_bad_encoding_spec.rb
+++ b/spec/lib/rack/handle_bad_encoding_spec.rb
@@ -4,7 +4,7 @@ describe Rack::HandleBadEncoding do
   let(:app) { double }
   let(:middleware) { described_class.new(app) }
 
-  %w[/location-suggestions /provider-suggestions].each do |path|
+  %w[/location-suggestions /provider-suggestions /results].each do |path|
     context "request path is #{path}" do
       context "query does not contain invalid encodings" do
         it "does not modify the query" do


### PR DESCRIPTION
### Context
- Fix for Sentry issue => https://sentry.io/organizations/dfe-bat/issues/1778885702/?environment=production&project=1780060&query=is%3Aunresolved

### Changes proposed in this pull request
- If a user calls the results path with a malformed query the middleware will sanitize the query to prevent the error from being raised

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
