### PR TITLE
3674 truncate location string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,5 @@ terraform.tfstate.d/
 ./*.tfstate
 lock.json
 
-## sanatised production data
+## sanitised production data
 *.sql.gz

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ terraform.tfstate.d/
 ./*.tfstate
 lock.json
 
+## sanatised production data
+*.sql.gz

--- a/app/views/results/_non_university.html.erb
+++ b/app/views/results/_non_university.html.erb
@@ -6,7 +6,7 @@
   <%= (number_of_sites > 1) ? "Nearest location" :  "Location"%>
 </dt>
 <dd>
-  <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %> 
+  <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
   <% if number_of_sites > 1 %>
     <div class="govuk-!-margin-top-0">
       (Nearest of <%= number_of_sites %> locations to choose from)
@@ -17,5 +17,7 @@
   <% if nearest_location_name != "Main Site" %>
     <%= nearest_location_name %><br />
   <% end %>
-  <%= nearest_address %>
+  <div class="app-text-ellipsis">
+    <%= nearest_address %>
+  </div>
 </dd>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -21,6 +21,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "patterns/definition-list";
 @import "patterns/filters";
 @import "patterns/pagination";
+@import "patterns/text-ellipsis";
 
 .govuk-list--dash {
   margin-bottom: govuk-spacing(8);

--- a/app/webpacker/styles/patterns/_text-ellipsis.scss
+++ b/app/webpacker/styles/patterns/_text-ellipsis.scss
@@ -1,0 +1,7 @@
+.app-text-ellipsis {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+}


### PR DESCRIPTION
### Changes proposed in this pull request

- Added an ellipsis to  long location descriptions.

## Before

![image](https://user-images.githubusercontent.com/50492247/87529810-6ffda580-c687-11ea-9613-3cedb53d80e2.png)


## After

![image](https://user-images.githubusercontent.com/50492247/87530267-05009e80-c688-11ea-9f27-c5ed8174fa72.png)




- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
