### PR TITLE
[3676] - Specify number of locations in search results

### DIFF
--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -23,8 +23,12 @@
         <span class="govuk-list--description__hint govuk-!-padding-top-2">University</span>
       <% end %>
 
-      <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %> 
+      <%= "#{pluralize(@results_view.site_distance(course), 'mile')} from you" %>
       <br />
+      <% if @results_view.sites_count(course) > 1 %>
+        (Nearest of <%= @results_view.sites_count(course) %> locations to choose from)
+        <br />
+      <% end  %>
       You’ll be at university only some of the time
     </li>
   </ul>

--- a/spec/views/results/university_spec.rb
+++ b/spec/views/results/university_spec.rb
@@ -111,5 +111,30 @@ describe "results/university.html.erb", type: :view do
         expect(html).to have_css("span.govuk-details__summary-text", text: "Placement schools might be in commuting distance")
       end
     end
+
+    context "course has two locations" do
+      let(:site2) do
+        build(
+          :site,
+          **lat_lon,
+          address1: "3 Beech Rd",
+          address2: "Billericay",
+          address3: "Essex",
+          address4: "UK",
+          postcode: "CM12 5YF",
+        )
+      end
+
+      let(:site_statuses) do
+        [
+          build(:site_status, :full_time_and_part_time, site: site1),
+          build(:site_status, :full_time_and_part_time, site: site2),
+        ]
+      end
+
+      it "renders '(Nearest of 2 locations to choose from)'" do
+        expect(html).to match("(Nearest of 2 locations to choose from)")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context
Search results from universities that have multiple locations can be confusing. This [search for example](https://s121d03-research-find-as.azurewebsites.net/results?l=1&lat=51.511408&lng=-0.0251371&loc=E+India+Dock+Rd%2C+London+E14+6JE%2C+UK&lq=East+India+Dock+Road%2C+London+E14+6JE%2C+UK&rad=20&sortby=2&subjects[]=31) returns a result for the University of Cumbria based in Central East London. CUMBRIA IS NO WHERE NEAR EAST LONDON (!!) but they have a location in E London. This confused participants in research.

### Changes proposed in this pull request
Where a search returns a course provided by a University with multiple locations we now display `(Nearest of X locations to choose from)`, where `X` is the number of locations (running sites)

### Guidance to review
- Run the `search for example` above locally to see the changes in the flesh or [see the changes on the review app](https://s121d02-3676-find-as.azurewebsites.net/results?l=1&lat=51.5113413&lng=-0.0112808&loc=E+India+Dock+Rd%2C+London+E14%2C+UK&lq=East+India+Dock+Road%2C+London&rad=20&sortby=2&subjects%5B%5D=31)

<img width="1367" alt="locations_count" src="https://user-images.githubusercontent.com/5256922/87538620-66c70580-c694-11ea-98c9-edc8eca33bb0.png"> 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
