### PR TITLE
[3675] prevents 0.0 miles displaying + test

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -178,10 +178,10 @@ class ResultsView
 
     min_distance = distances.min
 
-    if min_distance && min_distance < 1 && min_distance >= 0.05
-      min_distance.round(1)
-    elsif min_distance && min_distance < 0.05
+    if min_distance && min_distance < 0.05
       min_distance.ceil(1)
+    elsif min_distance && min_distance < 1
+      min_distance.round(1)
     else
       min_distance.round(0)
     end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -178,8 +178,10 @@ class ResultsView
 
     min_distance = distances.min
 
-    if min_distance && min_distance < 1
+    if min_distance && min_distance < 1 && min_distance >= 0.05
       min_distance.round(1)
+    elsif min_distance && min_distance < 0.05
+      min_distance.ceil(1)
     else
       min_distance.round(0)
     end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -670,6 +670,23 @@ describe ResultsView do
         expect(results_view.site_distance(course)).to eq(0.1)
       end
     end
+
+    context "closest site distance is less than 0.05 miles" do
+      let(:parameter_hash) { { "lat" => "51.4975", "lng" => "0.1357" } }
+
+      it "calculates the distance to the closest site, rounding up to prevent 0.0 miles displaying" do
+        site1 = build(:site, latitude: 51.4970, longitude: 0.1358, address1: "1 Foo Street", postcode: "BAA0NE")
+
+        course = build(
+          :course,
+          site_statuses: [
+            build(:site_status, :full_time_and_part_time, site: site1),
+          ],
+        )
+
+        expect(results_view.site_distance(course)).to eq(0.1)
+      end
+    end
   end
 
   context "locations" do


### PR DESCRIPTION
### Context/Trello ticket

https://trello.com/c/y1qY5V10/3675-sdisplay-instances-of-00-miles-as-01-miles-in-search-results

### Changes proposed in this pull request

Used the 'ceil' method to prevent 0.0 miles displaying and added a test.

### Guidance to review

1) Search Find for a postcode where a school offers training.
2) Ensure that it displays 0.1 miles from you.

![image](https://user-images.githubusercontent.com/50492247/87580959-208f9780-c6d0-11ea-870d-8e3241ba6b14.png)


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
