### PR TITLE
[3705] Handle subjects passed as a Hash

### DIFF
--- a/app/services/convert_deprecated_csharp_parameters_service.rb
+++ b/app/services/convert_deprecated_csharp_parameters_service.rb
@@ -39,7 +39,11 @@ private
   end
 
   def legacy_to_rails_array(array)
-    array.split(",")
+    if array.instance_of?(String)
+      array.split(",")
+    elsif array.is_a?(Hash)
+      array.values
+    end
   end
 
   def legacy_to_rails_boolean(boolean)

--- a/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
+++ b/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
@@ -1,4 +1,6 @@
-describe ConvertDeprecatedCsharpParametersService do
+require "rails_helper"
+
+RSpec.describe ConvertDeprecatedCsharpParametersService do
   let(:service) { described_class.new }
   let(:service_call) { service.call(parameters: input_parameters) }
 
@@ -26,6 +28,34 @@ describe ConvertDeprecatedCsharpParametersService do
         "senCourses" => true,
         "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
         "subjects" => %w[1 2 3],
+      })
+    end
+  end
+
+  context "given deprecated parameters" do
+    let(:input_parameters) do
+      {
+        "fulltime" => "True",
+        "hasvacancies" => "True",
+        "parttime" => "True",
+        "senCourses" => "True",
+        "qualifications" => "QtsOnly,PgdePgceWithQts,Other",
+        "subjects" => { "0" => "27" }.with_indifferent_access,
+      }
+    end
+
+    it "flags that the parameters are deprecated" do
+      expect(service_call[:deprecated]).to eq(true)
+    end
+
+    it "returns the correct parameters" do
+      expect(service_call[:parameters]).to eq({
+        "fulltime" => true,
+        "hasvacancies" => true,
+        "parttime" => true,
+        "senCourses" => true,
+        "qualifications" => %w[QtsOnly PgdePgceWithQts Other],
+        "subjects" => %w[27],
       })
     end
   end


### PR DESCRIPTION
### Context

- https://trello.com/c/9b3X9r0P/3705-nomethoderror-resultscontrollerindex
- https://sentry.io/organizations/dfe-bat/issues/1787111413/?project=1780060&referrer=slack#exception
- Old links to Find were sending subjects as Hash which was not handled correctly

### Changes proposed in this pull request

- This fixes old links which send subjects as a hash in the query params

### Guidance to review

- Visit url in sentry error on localhost
- Should not see error screen or exception
- Should see correct results

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
