### PR TITLE
[3684] Assigns Request_ID to tag in Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,13 +2,14 @@
 
 class ApplicationController < ActionController::Base
   before_action :store_request_id
+  before_action :assign_sentry_contexts
 
   def store_request_id
     RequestStore.store[:request_id] = request.uuid
   end
 
   def assign_sentry_contexts
-    Raven.extra_context(request_id: RequestStore.store[:request_id])
+    Raven.tags_context(request_id: RequestStore.store[:request_id])
   end
 
   def append_info_to_payload(payload)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -17,6 +17,15 @@ describe ApplicationController, type: :controller do
     end
   end
 
+  describe "#assign_sentry_contexts" do
+    it "assigns a request id to Sentry tags" do
+      allow(Raven).to receive(:tags_context).and_return({})
+      controller.__send__(:store_request_id)
+      controller.__send__(:assign_sentry_contexts)
+      expect(Raven).to have_received(:tags_context).with(request_id: request_uuid)
+    end
+  end
+
   describe "#append_info_to_payload" do
     it "sets the request_id in the payload to the request uuid" do
       payload = {}


### PR DESCRIPTION
### Context
Request ids generated from Find were not showing up in the tags in the error logs in Sentry
[https://trello.com/c/2jQCohxd/3684-add-requestid-to-logging-for-find](url)

### Changes proposed in this pull request
Request ids are now assigned to tags section in Sentry

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [ ] Product review
