### PR TITLE
[3712] Change '-' to 'to' for year ranges

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -120,7 +120,7 @@ class CourseDecorator < Draper::Decorator
   end
 
   def year_range
-    "#{object.recruitment_cycle_year} – #{object.recruitment_cycle_year.to_i + 1}"
+    "#{object.recruitment_cycle_year} to #{object.recruitment_cycle_year.to_i + 1}"
   end
 
   def placements_heading

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -409,7 +409,7 @@ describe CourseDecorator do
 
   describe "#year_range" do
     it "returns correct year range" do
-      expect(decorated_course.year_range).to eq("2020 – 2021")
+      expect(decorated_course.year_range).to eq("2020 to 2021")
     end
   end
 


### PR DESCRIPTION
### Context
We need to change hyphens to 'to' because it's:

- better/easier for screenreaders to read out "to" than 'dashes'
- recommended in the GDS Style guide https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#dates
- To be consistent with Apply and Publish

The year_range method in course_decorater.rb is using a '-' instead of a 'to'.  year_range is called in one partial about course fees.  
### Changes proposed in this pull request
A very simple change of a hyphen to a 'to' in year_range definition

### Guidance to review
Before
- visit https://www.find-postgraduate-teacher-training.service.gov.uk/course/2AT/AK12#section-fees

After 
- visit https://s121d02-3712-find-as.azurewebsites.net/course/2AT/AK12#section-fees


### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
- [x] Product review
