### PR TITLE
[3684] Add X-Request-Id to API client connection

### DIFF
--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -1,18 +1,21 @@
 class Base < JsonApiClient::Resource
   include Draper::Decoratable
 
-  def run(request_method, path, params: nil, headers: {}, body: nil)
-    super(
-      request_method,
-      path,
-      params: params,
-      headers: headers.update(
-        "X-Request-Id" => RequestStore.store[:request_id],
-      ),
-      body: body
-    )
+  class ConnectionWithRequestId < JsonApiClient::Connection
+    def run(request_method, path, params: nil, headers: {}, body: nil)
+      super(
+        request_method,
+        path,
+        params: params,
+        headers: headers.update(
+          "X-Request-Id" => RequestStore.store[:request_id],
+        ),
+        body: body
+      )
+    end
   end
 
   self.site = "#{Settings.teacher_training_api.base_url}/api/v3/"
   self.paginator = JsonApiClient::Paginating::NestedParamPaginator
+  self.connection_class = ConnectionWithRequestId
 end

--- a/spec/models/base_spec.rb
+++ b/spec/models/base_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Base do
+  describe "connection_class" do
+    before do
+      RequestStore.store[:request_id] = "some-request-id"
+    end
+
+    it "connection sends X-Request-Id header" do
+      stub = stub_request(:post, "http://localhost:3001/api/v3/bases")
+        .with(
+          body: "{\"data\":{\"type\":\"bases\",\"attributes\":{}}}",
+          headers: {
+            "X-Request-Id" => "some-request-id",
+          },
+        ).to_return(status: 200, body: "", headers: {})
+
+      Base.new.save
+
+      expect(stub).to have_been_requested
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/2jQCohxd/3684-add-requestid-to-logging-for-find
- Find API client was never adding custom `X-Request-Id` header to api calls

### Changes proposed in this pull request

- Previous connection_class was not correctly set therefore the custom request_id header was never sent

### Guidance to review

- Make API call in review app e.g. https://s121d02-3684-find-as.azurewebsites.net/results?l=2&subjects%5B%5D=31
- Find the request in kibana
- This request will have an associated `request_id`
- Search for this `request_id` in kibana under the api
- It should have correlating log which will be the corresponding API request

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
