### PR TITLE
Only send actionable exceptions to Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,5 +1,7 @@
 # https://docs.sentry.io/clients/ruby/config
 Raven.configure do |config|
+  config.silence_ready = true
+
   # > Inspect an incoming exception's causes when determining whether or not that
   # exception should be excluded
   #

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,14 @@
+# https://docs.sentry.io/clients/ruby/config
+Raven.configure do |config|
+  # > Inspect an incoming exception's causes when determining whether or not that
+  # exception should be excluded
+  #
+  # This will also exclude exceptions like `ActionView::Template::Error` if
+  # they're caused by `JsonApiClient::Errors::ConnectionError`, like
+  # https://sentry.io/organizations/dfe-bat/issues/1845349352
+  config.inspect_exception_causes_for_exclusion = true
+
+  config.excluded_exceptions += [
+    "JsonApiClient::Errors::ConnectionError",
+  ]
+end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -12,5 +12,6 @@ Raven.configure do |config|
 
   config.excluded_exceptions += [
     "JsonApiClient::Errors::ConnectionError",
+    "Mime::Type::InvalidMimeType",
   ]
 end


### PR DESCRIPTION
### Context

We like to limit exceptions in Sentry to ones that require developer action.

### Changes proposed in this pull request

Exclude some errors - see individual commits for detailed explanations.

### Guidance to review

Trust!

### Trello card

https://trello.com/c/yuYyGcGo/1956-take-ownership-of-the-find-application

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- ~[ ] Tested by running locally~
- ~[ ] Product review~
