### PR TITLE
updated confing/settings environment files e.g. staging.yml from  htt…

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,5 +1,5 @@
 base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api2.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.publish-teacher-training-courses.service.gov.uk
 valid_referers:
   - https://www.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,5 +1,5 @@
 base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api2.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
 valid_referers:
   - https://www.qa.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,5 +1,5 @@
 base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
 valid_referers:
   - https://www.staging.find-postgraduate-teacher-training.education.gov.uk


### PR DESCRIPTION
…ps://api2.staging.publish-teacher-training-courses.service.gov.uk to  https://api.staging.publish-teacher-training-courses.service.gov.uk

### Context
In order to santise api's url, references of "https://api2.staging.publish-teacher-training-courses.service.gov.uk" changed to "https://api.staging.publish-teacher-training-courses.service.gov.uk"

### Changes proposed in this pull request

References of "https://api2.staging.publish-teacher-training-courses.service.gov.uk" changed to "https://api.staging.publish-teacher-training-courses.service.gov.uk"

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [] Attach to Trello card
- [x ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
