### PR TITLE
[1969] - Use 'additional_paths' in webpacker config

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,7 +11,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: ["node_modules/govuk-frontend/govuk"]
+  additional_paths: ["node_modules/govuk-frontend/govuk"]
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
### Changes proposed in this pull request
- Update `webpacker` config to remove deprecation warning - _"The resolved_paths option has been deprecated. Use additional_paths instead."_

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
