### PR TITLE
[1971] - Exclude "ActionController::BadRequest" errors from Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -11,6 +11,7 @@ Raven.configure do |config|
   config.inspect_exception_causes_for_exclusion = true
 
   config.excluded_exceptions += [
+    "ActionController::BadRequest",
     "JsonApiClient::Errors::ConnectionError",
     "Mime::Type::InvalidMimeType",
   ]


### PR DESCRIPTION
### Context
- Invalid params being sent to Find endpoints
- https://sentry.io/organizations/dfe-bat/issues/1849156439/?referrer=slack

### Changes proposed in this pull request
- Exclude this type of error from Sentry reporting
- It's a client error that we can't do anything about

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
