### PR TITLE
[1971] - Return html format from CoursesController#Show

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -12,7 +12,7 @@ class CoursesController < ApplicationController
       .find(params[:course_code])
       .first
   rescue JsonApiClient::Errors::NotFound
-    render file: "errors/not_found", status: :not_found
+    render file: "errors/not_found", status: :not_found, formats: [:html]
   end
 
   def apply

--- a/spec/requests/course_spec.rb
+++ b/spec/requests/course_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+describe "/course", type: :request do
+  context "a request with the incorrect format" do
+    it "returns the 404 page in html format" do
+      stub_request(:get, /#{Settings.teacher_training_api.base_url}/)
+        .to_return(status: 404, body: "", headers: {})
+
+      get "/course/fonts/Roboto-Regular.ttf"
+
+      expect(response.status).to eq(404)
+      expect(response.content_type).to eq("text/html")
+    end
+  end
+end


### PR DESCRIPTION
### Context
- Sentry error: https://sentry.io/organizations/dfe-bat/issues/1816969756/?project=1780060&referrer=slack
- A request to "/course/fonts/Roboto-Regular.ttf" was causing an error to occur because Rails is trying to return the 'not found' page with the wrong content type. It is trying to infer the content type from the bad request, which in this case was `ttf`

### Changes proposed in this pull request
- The controller is now hard coded to return in html format.

### Guidance to review

Not entirely sure if this is the best solution to this problem

#### Before

<img width="1625" alt="before" src="https://user-images.githubusercontent.com/5256922/90789676-15e3a600-e2ff-11ea-9c8a-5c8dd739ad57.png">

#### After

<img width="1247" alt="after" src="https://user-images.githubusercontent.com/5256922/90789689-18de9680-e2ff-11ea-8dfd-197fd7befc74.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
