### PR TITLE
Remove "also" from Financial Support section

### DIFF
--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> – note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
+    You may be eligible for a <%= link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/tuition-fee-and-maintenance-loans", class: "govuk-link" %> – note that you’ll have to apply for <%= link_to "undergraduate student finance" , "https://www.gov.uk/student-finance", class: "govuk-link" %>.
   </p>
 
   <p class="govuk-body">


### PR DESCRIPTION
### Context

Paul Genders:

> There's a small typo in the 'Financial support' text for certain courses in Find. These courses being: non-salaried ones that don't offer bursaries or scholarships (eg Psychology).
>
> The first line of the text says: "You may also be eligible for a loan while you study – note that you’ll have to apply for undergraduate student finance." The word 'also' should be removed.
>
> eg https://www.find-postgraduate-teacher-training.service.gov.uk/course/B60/33MM

### Changes proposed in this pull request

Remove the word as it should work like this in both cases.

### Guidance to review

Does this make sense?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review