### PR TITLE
[2001] -Update Geocoder gem configuration | Fix deprecation warnings

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -12,7 +12,7 @@ class CoursesController < ApplicationController
       .find(params[:course_code])
       .first
   rescue JsonApiClient::Errors::NotFound
-    render file: "errors/not_found", status: :not_found, formats: [:html]
+    render template: "errors/not_found", status: :not_found, formats: [:html]
   end
 
   def apply

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
   # supports SocketError and Timeout::Error
-  always_raise: :all,
+  always_raise: [Geocoder::InvalidApiKey, Geocoder::OverQueryLimitError],
 
   units: :mi, # :km for kilometers or :mi for miles
 )

--- a/spec/requests/course_spec.rb
+++ b/spec/requests/course_spec.rb
@@ -9,7 +9,7 @@ describe "/course", type: :request do
       get "/course/fonts/Roboto-Regular.ttf"
 
       expect(response.status).to eq(404)
-      expect(response.content_type).to eq("text/html")
+      expect(response.media_type).to eq("text/html")
     end
   end
 end


### PR DESCRIPTION
### Context

#### Geocoder
- Sentry issue - https://sentry.io/organizations/dfe-bat/issues/1698390575/?project=1780060&referrer=slack

#### Deprecation warnings

```
DEPRECATION WARNING: render file: should be given the absolute path to a file (called from rescue in show at find-teacher-training/app/controllers/courses_controller.rb:15)

DEPRECATION WARNING: Rails 6.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from block (3 levels) in <top (required)> at find-teacher-training/spec/requests/course_spec.rb:12)
```

### Changes proposed in this pull request
- Update Geocoder gem config to automatically rescue any of those things out of our control (e.g. timeouts) but allow to raise for things under our control e.g. if we go over our api limit, or have an incorrect key. See [Geocoder documentation](https://github.com/alexreisner/geocoder#error-handling) for more info.
- Fix deprecation warnings

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
