### PR TITLE
Create better errors experience - redirect to 422 page when query is invalid

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -4,10 +4,16 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Page not found</h1>
-      <p class="govuk-body">If you entered a web address please check it was correct.</p>
       <p class="govuk-body">
-        <%= govuk_mail_to(Settings.service_support.contact_email_address, "Contact the Becoming a Teacher team")%>
-        if you believe you are seeing this message in error.
+        If you entered a web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button and you
+        need to speak to someone about this problem
+        <%= govuk_mail_to(Settings.service_support.contact_email_address, "contact the Becoming a Teacher team")%>.
       </p>
     </div>
   </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -4,7 +4,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">We do not understand the data you entered.</h1>
-      <p class="govuk-body">Try again, or contact us at <%= bat_contact_mail_to() %></p>
+      <p class="govuk-body">
+        If you entered a web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button and you
+        need to speak to someone about this problem
+        <%= govuk_mail_to(Settings.service_support.contact_email_address, "contact the Becoming a Teacher team")%>.
+      </p>
     </div>
   </div>
 </div>

--- a/lib/rack/handle_bad_encoding.rb
+++ b/lib/rack/handle_bad_encoding.rb
@@ -5,11 +5,11 @@ module Rack
     end
 
     def call(env)
-      if %w[/location-suggestions /provider-suggestions].include?(env["REQUEST_PATH"])
+      if %w[/location-suggestions /provider-suggestions /results].include?(env["REQUEST_PATH"])
         begin
           Rack::Utils.parse_nested_query(env["QUERY_STRING"].to_s)
         rescue Rack::Utils::InvalidParameterError
-          env["QUERY_STRING"] = ""
+          return [301, { "Location" => "/422", "Content-Type" => "text/html" }, []]
         end
       end
 

--- a/spec/lib/rack/handle_bad_encoding_spec.rb
+++ b/spec/lib/rack/handle_bad_encoding_spec.rb
@@ -1,10 +1,12 @@
 require "rails_helper"
 
 describe Rack::HandleBadEncoding do
+  include Rack::Test::Methods
+
   let(:app) { double }
   let(:middleware) { described_class.new(app) }
 
-  %w[/location-suggestions /provider-suggestions].each do |path|
+  %w[/location-suggestions /provider-suggestions /results].each do |path|
     context "request path is #{path}" do
       context "query does not contain invalid encodings" do
         it "does not modify the query" do
@@ -24,21 +26,21 @@ describe Rack::HandleBadEncoding do
       end
 
       context "query contains invalid encodings" do
-        it "modifies the query" do
-          expect(app).to receive(:call).with(
-            "QUERY_STRING" => "",
-            "REQUEST_PATH" => path,
-          )
-          middleware.call(
+        it "redirects to 422 page" do
+          expect(app).to_not receive(:call)
+
+          request = middleware.call(
             "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",
             "REQUEST_PATH" => path,
           )
+
+          expect(request).to eq([301, { "Location" => "/422", "Content-Type" => "text/html" }, []])
         end
       end
     end
   end
 
-  context "request path is not 'location-suggestions' or '/provider-suggestions'" do
+  context "request path is not 'location-suggestions', '/provider-suggestions' or '/results'" do
     it "does not modify the query" do
       expect(app).to receive(:call).with(
         "QUERY_STRING" => "query=%2Flondon%2bot%Forder%3Ddescending%26page%3D5%26sort%3Dcreated_at",


### PR DESCRIPTION
### Context
- A large part of find involves building a search query which is then passed on to the Teacher Training API.
- Previously we were sanitising an invalid query, returning all results. Often these errors are triggered by bots and other _evil_ forces 😈 . But rather than being helpful, this may in fact confuse the user who (unmaliciously) passes in an invalid query by accident (e.g. copy and pasting from a word document).
- Example Sentry error - https://sentry.io/organizations/dfe-bat/issues/1778885702/?environment=production&project=1780060&query=is%3Aunresolved

### Changes proposed in this pull request
- The middleware has been changed to redirect any invalid requests to the 422 page.
- Update guidance on both the 422 and 404 pages (now more closely in line with Apply's error pages).

### Guidance to review
- Spin up the app locally and modify your query so that it is invalid. You should be redirected to the 422 page
E.g. `http://localhost:3002/results?%%%%%%%%nasty%%%%%%%%l=2&subjects%5B%5D=31`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
