### PR TITLE
'Cycle has ended' interim page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -6,4 +6,6 @@ class PagesController < ApplicationController
   def privacy; end
 
   def accessibilty; end
+
+  def cycle_has_ended; end
 end

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -1,0 +1,17 @@
+<%= content_for :page_title, "Find postgraduate teacher training" %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Find postgraduate teacher training</h1>
+      <h2 class="govuk-heading-m">Applications closed</h2>
+      <p class="govuk-body">
+        Applications for this academic year (2020 to 2021) are now closed.
+      </p>
+      <h2 class="govuk-heading-m">Find courses starting next academic year (2021 to 2022)</h2>
+      <p class="govuk-body">
+        You can find courses from 6 October 2020 and apply from 13 October 2020.
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,16 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
+  if Settings.cycle_has_ended
+    get "/cycle-has-ended", to: "pages#cycle_has_ended", as: "cycle_has_ended"
+    get "/", to: redirect("/cycle-has-ended", status: 302)
+    get "/results", to: redirect("/cycle-has-ended", status: 302), as: "results_redirect"
+    get "/course/*path", to: redirect("/cycle-has-ended", status: 302)
+    get "/start/*path", to: redirect("/cycle-has-ended", status: 302)
+  else
+    get "/cycle-has-ended", to: redirect("/", status: 301)
+  end
+
   scope module: "result_filters" do
     root to: "location#start"
   end
@@ -16,7 +26,7 @@ Rails.application.routes.draw do
     get "subject", to: "subject#start", as: "start_subject"
   end
 
-  # There is no need for a seperate path for start#location but this was the
+  # There is no need for a separate path for start#location but this was the
   # root path in the legacy c# app so we're redirecting to root
   get "/start/location", to: redirect("/", status: "301")
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,3 +19,4 @@ logstash:
   ssl_enable: true
 log_level: info
 commit_sha_file: COMMIT_SHA
+cycle_has_ended: false

--- a/spec/requests/end_of_cycle_spec.rb
+++ b/spec/requests/end_of_cycle_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "/cycle-has-ended", type: :request do
+  context "within cycle" do
+    it "redirects '/cycle-has-ended' to '/'" do
+      get "/cycle-has-ended"
+
+      expect(response).to redirect_to("/")
+    end
+  end
+
+  context "end of cycle" do
+    before do
+      allow(Settings).to receive(:cycle_has_ended).and_return(true)
+      Rails.application.reload_routes!
+    end
+
+    after do
+      allow(Settings).to receive(:cycle_has_ended).and_return(false)
+      Rails.application.reload_routes!
+    end
+
+    [
+      "/",
+      "/start/foo",
+      "/results",
+      "/course/foo",
+    ].each do |path|
+      it "redirects #{path} to '/cycle-has-ended'" do
+        get path
+
+        expect(response).to redirect_to("/cycle-has-ended")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Find is to be closed on 3rd October (when UCAS stop allowing applications) and will display the interim 'cycle has ended' page.

### Changes proposed in this pull request
- Add a new 'cycle has ended' interim page for end of cycle.
- When `Settings.cycle_has_ended` is set to `true`, any requests to the root, search, results and course pages will be redirected to the interim page

### Guidance to review
- In your `development.local.yml` file, set `cycle_has_ended` to `true`.
- When you try to navigate to root, search, results or course pages, you should be redirected to the interim page


### Trello card
https://trello.com/c/8kQxqDWt/2016-dev-find-cycle-has-ended-interim-page-3oct

### Screenshot
<img width="1321" alt="cycle_has_ended" src="https://user-images.githubusercontent.com/5256922/91443113-c6572a00-e86a-11ea-8b0b-ad4d84e136c7.png">

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
