### PR TITLE
use terraform 0.12.29 in github actions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -28,6 +28,11 @@ jobs:
     - name: Checkout the repository to the GitHub Actions runner
       uses: actions/checkout@v2
 
+    - name: Use Terraform 0.12.29
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 0.12.29
+  
     - name: Install Terraform CloudFoundry Provider
       run: |
           mkdir -p $HOME/.terraform.d/plugins/linux_amd64


### PR DESCRIPTION
### Context
GitHub Actions uses the latest available version of terraform if a version is not specified.

### Changes proposed in this pull request
Use terraform 0.12 which the terraform files in this repo target.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
~- [ ] Tested by running locally~
~- [ ] Product review~
