### PR TITLE
Gracefully handle invalid pagination param

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -6,5 +6,12 @@ class ResultsController < ApplicationController
     end
 
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
+
+    begin
+      @courses = @results_view.courses.all
+      @number_of_courses_string = @results_view.number_of_courses_string
+    rescue JsonApiClient::Errors::ClientError
+      render template: "errors/unprocessable_entity", status: :unprocessable_entity
+    end
   end
 end

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -4,7 +4,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">We do not understand the data you entered.</h1>
-      <p class="govuk-body">Try again, or contact us at <%= bat_contact_mail_to() %></p>
+      <p class="govuk-body">
+        If you entered a web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button and you
+        need to speak to someone about this problem
+        <%= govuk_mail_to(Settings.service_support.contact_email_address, "contact the Becoming a Teacher team")%>.
+      </p>
     </div>
   </div>
 </div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@results_view.number_of_courses_string}" %>
+<%= content_for :page_title, "#{@number_of_courses_string}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -103,7 +103,7 @@
       </div>
     <% end %>
     <ul class="govuk-list search-results">
-      <% @results_view.courses.each do |course| %>
+      <% @courses.each do |course| %>
         <li data-qa="course">
           <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
             <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link  search-result-link", rel: "prev", data: { qa: "course__link" } do %>
@@ -145,6 +145,6 @@
         </li>
       <% end %>
     </ul>
-    <%= paginate(@results_view.courses, total_pages: @results_view.total_pages) %>
+    <%= paginate(@courses, total_pages: @results_view.total_pages) %>
   </div>
 </div>

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,27 +1,52 @@
 require "rails_helper"
 
 describe "/results", type: :request do
-  before do
-    default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+  context "a valid request" do
+    before do
+      default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
 
-    stub_request(
-      :get,
-      "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-    ).to_return(
-      body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
-      headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
-    )
+      stub_request(
+        :get,
+        "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      ).to_return(
+        body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
 
-    stub_request(:get, default_url)
+      stub_request(:get, default_url)
         .with(query: results_page_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/ten_courses.json"),
           headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
         )
+    end
+
+    it "returns success (200)" do
+      get "/results"
+      expect(response).to have_http_status(200)
+    end
   end
 
-  it "returns success (200)" do
-    get "/results"
-    expect(response).to have_http_status(200)
+  context "API returns client error (400)" do
+    before do
+      default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+
+      stub_request(
+        :get,
+        "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      ).to_return(
+        body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
+        headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
+      )
+
+      stub_request(:get, default_url)
+        .with(query: results_page_parameters)
+        .to_return(status: 400)
+    end
+
+    it "returns unprocessable entity (422)" do
+      get "/results"
+      expect(response).to have_http_status(422)
+    end
   end
 end


### PR DESCRIPTION
### Context

Now that there are less courses active some users are receiving a 500 error on Find when they use bookmarked links for a search query containing an invalid page parameter. I.e they request page 6 of the search query results but there are no longer 6 pages worth of results.

In this situation the Teacher Training API is returning a 400 error but Find is not gracefully handling this and returning a 500.

### Changes proposed in this pull request
- Rescue `JsonApiClient::Errors::ClientError` in the `ResultsController` and redirect to the `422` error page.

### Guidance to review
This is a short term fix. An additional ticket will be created to refactor the `ResultsView` and separate the API query building functionality and subsequent request into separate service.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
