### PR TITLE
'Cycle ending soon' interim page

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -8,4 +8,6 @@ class PagesController < ApplicationController
   def accessibilty; end
 
   def cycle_has_ended; end
+
+  def cycle_ending_soon; end
 end

--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -1,0 +1,30 @@
+<%= content_for :page_title, "Cycle ending soon" %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Find Postgraduate Teacher Training</h1>
+      <h2 class="govuk-heading-m">Find courses starting this academic year (2020 to 2021)</h2>
+      <p class="govuk-body">
+        There are still some vacancies for some courses starting this academic year.
+      </p>
+
+      <h3 class="govuk-heading-s">If you’re applying for the first time</h3>
+      <p class="govuk-body">
+        Apply no later than 7 September.
+      </p>
+      <h3 class="govuk-heading-s">If you’re applying again</h3>
+      <p class="govuk-body">
+        Apply no later than 18 September.
+      </p>
+
+      <h2 class="govuk-heading-m">Find courses starting this academic year (2021 to 2022)</h2>
+      <p class="govuk-body">
+        You can find courses from 6 October 2020 and apply from 13 October 2020.
+      </p>
+      <p class="govuk-body">
+        <%= link_to "Find courses with vacancies", start_location_path, class: "govuk-button  " %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,20 @@ Rails.application.routes.draw do
     get "/cycle-has-ended", to: redirect("/", status: 301)
   end
 
+  if Settings.cycle_ending_soon
+    root to: redirect("/cycle-ending-soon", status: 302), as: "cycle_ending_soon_root"
+    get "/cycle-ending-soon", to: "pages#cycle_ending_soon"
+    scope module: "result_filters", path: "/start" do
+      get "location", to: "location#start", as: "start_location"
+    end
+  else
+    get "/cycle-ending-soon", to: redirect("/", status: 301)
+    # During the cycle there is no need for a separate path for
+    # start#location but this was the root path in the
+    # legacy c# app so we're redirecting to root
+    get "/start/location", to: redirect("/", status: "301")
+  end
+
   scope module: "result_filters" do
     root to: "location#start"
   end
@@ -25,10 +39,6 @@ Rails.application.routes.draw do
   scope module: "result_filters", path: "/start" do
     get "subject", to: "subject#start", as: "start_subject"
   end
-
-  # There is no need for a separate path for start#location but this was the
-  # root path in the legacy c# app so we're redirecting to root
-  get "/start/location", to: redirect("/", status: "301")
 
   get "/terms-conditions", to: "pages#terms", as: "terms"
   get "/accessibility", to: "pages#accessibility", as: "accessibility"

--- a/spec/requests/cycle_ending_soon_spec.rb
+++ b/spec/requests/cycle_ending_soon_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-describe "/start", type: :request do
+RSpec.describe "/cycle-ending-soon", type: :request do
   context "within cycle" do
-    it "redirects from '/start/location' to '/'" do
-      get "/start/location"
+    it "redirects from '/cycle-ending-soon' to '/'" do
+      get "/cycle-ending-soon"
 
       expect(response).to redirect_to("/")
     end
   end
 
-  context "nearing end of cycle" do
+  context "cycle ending soon" do
     before do
       allow(Settings).to receive(:cycle_ending_soon).and_return(true)
       Rails.application.reload_routes!
@@ -20,10 +20,10 @@ describe "/start", type: :request do
       Rails.application.reload_routes!
     end
 
-    it "navigates to '/start/location'" do
-      get "/start/location"
+    it "redirects from '/' to the '/cycle-ending-soon'" do
+      get "/"
 
-      expect(response.status).to eq(200)
+      expect(response).to redirect_to("/cycle-ending-soon")
     end
   end
 end


### PR DESCRIPTION
### Context
Find to be closed on 3rd October (when UCAS stop allowing applications) and display the interim page shown on [design history](https://bat-design-history.netlify.app/find-teacher-training/end-of-cycle/).

Leading up to the closure we want to show a 'cycle ending soon' interim page

### Changes proposed in this pull request
- When Settings.cycle_ending_soon is set to 'true', users will be redirected to the interim page when requesting the root path.

<img width="1362" alt="cycle_ending_soon" src="https://user-images.githubusercontent.com/5256922/91954283-81fbdc00-ecf9-11ea-9828-8c6d1cfc831a.png">

### Trello card
https://trello.com/c/s7Hj3oH0/2058-dev-find-cycle-ending-soon-interim-page

### Guidance to review
- In your `development.local.yml` file set `cycle_ending_soon` to `true`.
- When you navigate to the the root path you should be redirected to the interim page
- When click the `find courses with vacancies button` you should be taken to `/start/location`.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
