### PR TITLE
Update Azure template to include end of cycle feature flags

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -144,6 +144,28 @@
       "metadata": {
         "description": "API Key for Google Geocode"
       }
+    },
+    "settingsCycleEndingSoon": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "When true, requests to '/' will be redirected to '/cycle-ending-soon"
+      }
+    },
+    "settingsCycleHasEnded": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "When true, requests to root, search, results and course pages will be redirected to '/cycle-has-ended"
+      }
+
+    },
+    "settingsDisableApplyButton": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Disables the 'apply' button on course pages"
+      }
     }
   },
   "variables": {
@@ -286,6 +308,18 @@
               {
                 "name": "SETTINGS__GOOGLE__GCP_API_KEY",
                 "value": "[parameters('settingsGoogleGeocodeAPIKey')]"
+              },
+              {
+                "name": "SETTTINGS__CYCLE_ENDING_SOON",
+                "value": "[parameters('settingsCycleEndingSoon')]"
+              },
+              {
+                "name": "SETTINGS__CYCLE_HAS_ENDED",
+                "value": "[parameters('settingsCycleHasEnded']"
+              },
+              {
+                "name": "SETTINGS__DISABLE_APPLY_BUTTON",
+                "value":  "[parameters('settingsDisableApplyButton)]",
               }
             ]
           },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,4 +19,6 @@ logstash:
   ssl_enable: true
 log_level: info
 commit_sha_file: COMMIT_SHA
-cycle_has_ended: false
+cycle_has_ended:
+cycle_ending_soon:
+disable_apply_button:


### PR DESCRIPTION
### Context
A number of changes will take place on Find as part of the end of cycle process. To prepare for this we want to be able to toggle end of cycle functionality easily.

### Changes proposed in this pull request
- The azure template has been updated so that we can toggle end of cycle functionality via the Azure portal.
- This will be a lot quicker than raising a PR every time we want to update a feature flag.

### Guidance to review

### Trello
https://trello.com/c/pF2NLAY9/2070-add-azure-config-for-end-of-cycle-feature-flags

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
