### PR TITLE
End of cycle - remove 'apply for this course' button

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -6,12 +6,14 @@
   <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
 
   <% if @course.has_vacancies? %>
-    <p class="govuk-body">
-      <%= link_to "Apply for this course", apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-                  class: "govuk-button govuk-button--start",
-                  data: { qa: 'course__apply_link' },
-                  rel: "nofollow" %>
-    </p>
+    <% if Settings.display_apply_button %>
+      <p class="govuk-body">
+        <%= link_to "Apply for this course", apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+                    class: "govuk-button govuk-button--start",
+                    data: { qa: 'course__apply_link' },
+                    rel: "nofollow" %>
+      </p>
+    <% end %>
 
     <h3 class="govuk-heading-m">Choose a training location</h3>
     <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>

--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -17,13 +17,13 @@
       <p class="govuk-body">
         Apply no later than 18 September.
       </p>
+      <p class="govuk-body">
+        <%= link_to "Find courses with vacancies", start_location_path, class: "govuk-button" %>
+      </p>
 
-      <h2 class="govuk-heading-m">Find courses starting this academic year (2021 to 2022)</h2>
+      <h2 class="govuk-heading-m">Find courses starting next academic year (2021 to 2022)</h2>
       <p class="govuk-body">
         You can find courses from 6 October 2020 and apply from 13 October 2020.
-      </p>
-      <p class="govuk-body">
-        <%= link_to "Find courses with vacancies", start_location_path, class: "govuk-button  " %>
       </p>
     </div>
   </div>

--- a/azure/template.json
+++ b/azure/template.json
@@ -160,11 +160,11 @@
       }
 
     },
-    "settingsDisableApplyButton": {
+    "settingsDisplayApplyButton": {
       "type": "bool",
-      "defaultValue": false,
+      "defaultValue": true,
       "metadata": {
-        "description": "Disables the 'apply' button on course pages"
+        "description": "Displays the 'apply for this course' button on course pages"
       }
     }
   },
@@ -319,7 +319,7 @@
               },
               {
                 "name": "SETTINGS__DISABLE_APPLY_BUTTON",
-                "value":  "[parameters('settingsDisableApplyButton')]"
+                "value":  "[parameters('settingsDisplayApplyButton')]"
               }
             ]
           },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,4 +21,4 @@ log_level: info
 commit_sha_file: COMMIT_SHA
 cycle_has_ended:
 cycle_ending_soon:
-disable_apply_button:
+display_apply_button: true

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -242,6 +242,17 @@ feature "Course show", type: :feature do
 
       expect(course_page).not_to have_content("When you apply you’ll need these codes for the Choices section of your application form")
     end
+
+    context "End of cycle" do
+      before do
+        allow(Settings).to receive(:display_apply_button).and_return(false)
+        visit course_path(course.provider_code, course.course_code)
+      end
+
+      it "does not display the 'apply for this course' button" do
+        expect(course_page).not_to have_apply_link
+      end
+    end
   end
 
   describe "Showing the back button" do


### PR DESCRIPTION
### Context
- As part of the end of cycle process we do not want users to be able to apply for courses from Sep 18th.

### Changes proposed in this pull request
- This change allows the button to be toggle on / off via Azure or local settings (default is set to true / display the button).

### Guidance to review
- To test locally, spin up the app and set the value of `display_apply_button` in your `development.local.yml` to false. When you navigate to a course listing the 'apply for this course' button should not be visible.

### Trello card
https://trello.com/c/vQRmFS25/2067-find-dev-apply-for-this-course-button-changes-18-9-13-10

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
