### PR TITLE
Add link to Teacher Training Courses API to footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,7 +77,7 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-heading-m">Get support</h2>
-            <div class="govuk-grid-row">
+            <div class="govuk-grid-row govuk-!-margin-bottom-5">
               <div class="govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Telephone</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">


### PR DESCRIPTION
### Context

Publish and register team would like to include a link to the Teacher Training Courses API from Find. This PR adds a link to the footer to this resource.

### Changes proposed in this pull request

Adds a link, and adjusts a margin for consistency across BAT services. 

![footer-find](https://user-images.githubusercontent.com/813383/92127737-85768c80-edf9-11ea-9e32-4311c00230ad.png)

### Guidance to review

Still reviewing what is the appropriate link text for this item.

### Trello card

https://trello.com/c/Rsu2LZhw

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
