### PR TITLE
Course page copy updates (end of cycle)

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -13,10 +13,23 @@
                     data: { qa: 'course__apply_link' },
                     rel: "nofollow" %>
       </p>
+    <% else %>
+      <div data-qa="course__end_of_cycle_notice">
+        <p class="govuk-body">
+          Applications for this academic year (2020 to 2021) are now closed.
+        </p>
+        <p class="govuk-body">
+          Come back from 6 October 2020 to find out if this course is available for the next academic year.
+        </p>
+      </div>
     <% end %>
 
-    <h3 class="govuk-heading-m">Choose a training location</h3>
-    <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+    <% if Settings.display_apply_button %>
+      <h3 class="govuk-heading-m">Choose a training location</h3>
+      <p class="govuk-body" data-qa="course__training_location_guidance">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+    <% else %>
+      <h3 class="govuk-heading-m">Training locations</h3>
+    <% end %>
 
     <div id="locations-map" class="app-google-map" data-qa="course__locations_map"></div>
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -241,6 +241,10 @@ feature "Course show", type: :feature do
       expect(course_page.apply_link[:href]).to eq("/course/T92/X130/apply")
 
       expect(course_page).not_to have_content("When you apply you’ll need these codes for the Choices section of your application form")
+
+      expect(course_page).not_to have_end_of_cycle_notice
+
+      expect(course_page).to have_training_location_guidance
     end
 
     context "End of cycle" do
@@ -251,6 +255,8 @@ feature "Course show", type: :feature do
 
       it "does not display the 'apply for this course' button" do
         expect(course_page).not_to have_apply_link
+        expect(course_page).to have_end_of_cycle_notice
+        expect(course_page).not_to have_training_location_guidance
       end
     end
   end

--- a/spec/site_prism/page_objects/page/course.rb
+++ b/spec/site_prism/page_objects/page/course.rb
@@ -44,6 +44,8 @@ module PageObjects
       element :locations_map, "[data-qa=course__locations_map]"
       element :apply_link, "a[data-qa=course__apply_link]"
       element :back_link, "[data-qa=page-back]"
+      element :end_of_cycle_notice, "[data-qa=course__end_of_cycle_notice]"
+      element :training_location_guidance, "[data-qa=course__training_location_guidance]"
     end
   end
 end


### PR DESCRIPTION
### Context
We want users to know why the 'apply for this course' button is disabled as part of the end of cycle process

### Changes proposed in this pull request
- Add additional copy for end of cycle. Appears when 'apply for this course' button is disabled.
- Update 'Training locations' heading
- First paragraph under 'Training locations' head disappears when 'apply for this course' button is disabled.

### Screen shot

<img width="831" alt="copy_update" src="https://user-images.githubusercontent.com/5256922/92253693-bd4c0580-eec7-11ea-9804-36ad7561376f.png">

### Trello card
https://trello.com/c/4eMTDtqy/2083-end-of-cycle-copy-changes

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
