### PR TITLE
Adjust spacing in footer to match that used on other BAT footers

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,7 +77,7 @@
         <div class="govuk-footer__meta">
           <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
             <h2 class="govuk-heading-m">Get support</h2>
-            <div class="govuk-grid-row">
+            <div class="govuk-grid-row govuk-!-margin-bottom-5">
               <div class="govuk-grid-column-one-half">
                 <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Telephone</h2>
                 <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">


### PR DESCRIPTION
### Context

Small tweak to footer spacing to be consistent with that used by other BAT service footers, and increase space between contact details and support links.

### Changes proposed in this pull request

Before:

<img width="505" alt="Screenshot 2020-09-07 at 13 07 52" src="https://user-images.githubusercontent.com/813383/92386267-620a5500-f10b-11ea-9146-8459353204aa.png">


After:

<img width="515" alt="Screenshot 2020-09-07 at 13 08 37" src="https://user-images.githubusercontent.com/813383/92386270-659ddc00-f10b-11ea-9d53-544983d29063.png">


### Guidance to review

### Trello card

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
