### PR TITLE
Fix validations on start wizard when nearing end of cycle

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -73,7 +73,12 @@ module ResultFilters
     end
 
     def back_to_current_page_if_error(form_params)
-      if flash[:start_wizard]
+      if flash[:start_wizard] && Settings.cycle_ending_soon
+        # In this scenario we do not want to redirect to 'root_path'
+        # because root_path is '/cycle-ending-soon' and the
+        # validation errors will be lost
+        redirect_to start_location_path(form_params)
+      elsif flash[:start_wizard] && !Settings.cycle_ending_soon
         redirect_to root_path(form_params)
       else
         redirect_to location_path(form_params)

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -145,16 +145,42 @@ feature "Location filter", type: :feature do
     end
 
     describe "when using the wizard" do
-      it "progresses to next step instead of going straight to results" do
-        start_page.load
-        start_page.by_postcode_town_or_city.click
-        start_page.location_query.fill_in(with: "SW1P 3BT")
-        start_page.find_courses.click
+      context "within cycle" do
+        context "valid search" do
+          it "progresses to next step instead of going straight to results" do
+            start_page.load
+            start_page.by_postcode_town_or_city.click
+            start_page.location_query.fill_in(with: "SW1P 3BT")
+            start_page.find_courses.click
 
-        URI(current_url).then do |uri|
-          expect(uri.path).to eq("/start/subject")
-          expect(uri.query)
-            .to eq("l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2")
+            URI(current_url).then do |uri|
+              expect(uri.path).to eq("/start/subject")
+              expect(uri.query)
+                .to eq("l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2")
+            end
+          end
+        end
+
+        context "no option selected" do
+          it "displays an error" do
+            start_page.load
+            start_page.find_courses.click
+
+            expect(start_page).to have_content(/Please choose an option/)
+          end
+        end
+      end
+
+      context "nearing end of cycle" do
+        context "no options selected" do
+          it "displays an error" do
+            allow(Settings).to receive(:cycle_ending_soon).and_return(true)
+
+            start_page.load
+            start_page.find_courses.click
+
+            expect(start_page).to have_content(/Please choose an option/)
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
- When `Settings.cycle_ending_soon` is set to `true` the LocationsController was not redirecting back to the ‘start/location’ page when validation errors occur. Instead it was redirecting to the ‘/cycle-ending-soon’ page. This is also causing Find end to end tests to fail ([see related PR](https://github.com/DFE-Digital/find-teacher-training-tests/pull/52)).

### Changes proposed in this pull request
- New logic has been added to the LocationsController to detect whether `Settings.cycle_ending_soon` is `true` and if so, will redirect back to ‘/start/location’ when a search validation error occurs.

### Before
![before](https://user-images.githubusercontent.com/5256922/92597250-07a1fd80-f29f-11ea-992e-700413ff4fd1.gif)

### After 
![after](https://user-images.githubusercontent.com/5256922/92597268-0cff4800-f29f-11ea-95fd-52d1b78a1fd5.gif)

### Trello card
https://trello.com/c/AidwYrAz/2119-fix-broken-find-end-to-end-tests

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
