### PR TITLE
Update copy on 'cycle-ending-soon' page

### DIFF
--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -4,26 +4,24 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Find postgraduate teacher training</h1>
-      <h2 class="govuk-heading-m">Find courses starting this academic year (2020 to 2021)</h2>
+      <div class="govuk-warning-text">
+        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+        <strong class="govuk-warning-text__text">
+          <span class="govuk-warning-text__assistive">Warning</span>
+          It’s no longer possible to apply for courses for the 2020 to 2021 academic year
+        </strong>
+      </div>
+      <h2 class="govuk-heading-m">Find courses starting in the 2021 to 2022 academic year</h2>
       <p class="govuk-body">
-        There are still a few vacancies for courses starting this academic year.
-      </p>
-
-      <h3 class="govuk-heading-s">If you’re applying for the first time</h3>
-      <p class="govuk-body">
-        Apply no later than 6pm on 7 September.
-      </p>
-      <h3 class="govuk-heading-s">If you’re applying again</h3>
-      <p class="govuk-body">
-        Apply no later than 6pm on 18 September.
+        Come back from 6 October 2020 to find courses.
       </p>
       <p class="govuk-body">
-        <%= link_to "Find courses with vacancies", start_location_path, class: "govuk-button" %>
+        You’ll be able to submit an application from 13 October 2020.
       </p>
-
-      <h2 class="govuk-heading-m">Find courses starting next academic year (2021 to 2022)</h2>
+      <h2 class="govuk-heading-m">If you’ve already applied</h2>
       <p class="govuk-body">
-        You can find courses from 6 October 2020 and apply from 13 October 2020.
+        To help candidates who've already applied get placed on an available course,
+        <%= link_to "this website is still showing some courses (these may not be available for the 2021 to 2022 academic year)", start_location_path, class: "govuk-link" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
### Context
Some copy updates are required to make it easier for potential candidates to understand the 'end of cycle' event.

### Changes proposed in this pull request
Copy changes implemented as per this doc - https://docs.google.com/document/d/1mqgyiSuMag-OHBzMlkiEJCrygEYrm_fVqp_Q1tlHXhM/edit

### Updated page
<img width="1018" alt="cycle-ending-soon-copy_update" src="https://user-images.githubusercontent.com/5256922/94686360-a233b080-0322-11eb-9448-f34f1bee6fa7.png">

### Trello card

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
