### PR TITLE
Fix broken specs resulting from change in cycle

### DIFF
--- a/spec/controllers/result_filters/subject_controller_spec.rb
+++ b/spec/controllers/result_filters/subject_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ResultFilters::SubjectController do
   describe "#new" do
     context "when subjects is a comma delimited string" do
       it "returns a 200" do
-        stub_request(:get, "http://localhost:3001/api/v3/subject_areas?include=subjects")
+        stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects")
            .with(
              headers: {
                "Accept" => "application/vnd.api+json",

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -409,7 +409,7 @@ describe CourseDecorator do
 
   describe "#year_range" do
     it "returns correct year range" do
-      expect(decorated_course.year_range).to eq("2020 to 2021")
+      expect(decorated_course.year_range).to eq("#{Settings.current_cycle} to #{Settings.current_cycle + 1}")
     end
   end
 

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -19,14 +19,10 @@ feature "cookie banner", type: :feature do
     ]
   end
 
-  let(:default_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
 
   def stub_results_request
-    stub_request(:get, default_url)
+    stub_request(:get, courses_url)
       .with(query: base_parameters)
       .to_return(
         body: File.new("spec/fixtures/api_responses/ten_courses.json"),

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -20,7 +20,7 @@ feature "cookie banner", type: :feature do
   end
 
   let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -20,7 +20,7 @@ feature "cookie banner", type: :feature do
   end
 
   let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -22,8 +22,7 @@ feature "Search results", type: :feature do
   let(:page_index) { nil }
 
   let(:stub_courses_request) do
-    url = "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-    stub_request(:get, url)
+    stub_request(:get, courses_url)
       .with(query: base_parameters)
       .to_return(
         body: File.new("spec/fixtures/api_responses/ten_courses.json"),

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -22,7 +22,7 @@ feature "Search results", type: :feature do
   let(:page_index) { nil }
 
   let(:stub_courses_request) do
-    url = "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    url = "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
     stub_request(:get, url)
       .with(query: base_parameters)
       .to_return(

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -22,7 +22,7 @@ feature "Search results", type: :feature do
   let(:page_index) { nil }
 
   let(:stub_courses_request) do
-    url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    url = "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
     stub_request(:get, url)
       .with(query: base_parameters)
       .to_return(

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -7,7 +7,7 @@ feature "Funding filter", type: :feature do
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -6,10 +6,6 @@ feature "Funding filter", type: :feature do
 
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
 
   before do

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -7,7 +7,7 @@ feature "Funding filter", type: :feature do
   let(:salary_course_param_value_from_c_sharp) { "8" }
   let(:all_course_param_value_from_c_sharp) { "15" }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -6,7 +6,7 @@ feature "Location filter back link", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   before do
@@ -115,7 +115,7 @@ feature "Location filter back link", type: :feature do
   def stub_provider_request
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/recruitment_cycles/2020/providers",
+      "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
     ).with(
       query: {
         "fields[providers]" => "provider_code,provider_name",

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -6,7 +6,7 @@ feature "Location filter back link", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   before do
@@ -115,7 +115,7 @@ feature "Location filter back link", type: :feature do
   def stub_provider_request
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
+      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
     ).with(
       query: {
         "fields[providers]" => "provider_code,provider_name",

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -5,9 +5,6 @@ feature "Location filter back link", type: :feature do
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
 
   before do
     stub_results_page_request

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -6,12 +6,7 @@ feature "Location filter", type: :feature do
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
-
   let(:stub_subject_area_request) do
     stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects")
   end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -7,13 +7,13 @@ feature "Location filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }
 
   let(:stub_subject_area_request) do
-    stub_request(:get, "http://localhost:3001/api/v3/subject_areas?include=subjects")
+    stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects")
   end
 
   before do
@@ -33,7 +33,7 @@ feature "Location filter", type: :feature do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
+        "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
       ).with(
         query: {
           "fields[providers]" => "provider_code,provider_name",

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -7,7 +7,7 @@ feature "Location filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }
@@ -33,7 +33,7 @@ feature "Location filter", type: :feature do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/recruitment_cycles/2020/providers",
+        "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
       ).with(
         query: {
           "fields[providers]" => "provider_code,provider_name",
@@ -282,7 +282,7 @@ feature "Location filter", type: :feature do
         type: Provider,
         resources: providers,
         fields: { providers: %i[provider_code provider_name] },
-        params: { recruitment_cycle_year: 2020 },
+        params: { recruitment_cycle_year: Settings.current_cycle },
         search: "ACME",
       )
 
@@ -305,7 +305,7 @@ feature "Location filter", type: :feature do
           type: Provider,
           resources: providers,
           fields: { providers: %i[provider_code provider_name] },
-          params: { recruitment_cycle_year: 2020 },
+          params: { recruitment_cycle_year: Settings.current_cycle },
           search: "ACME",
         )
 

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -6,11 +6,11 @@ feature "Provider filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
 
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:providers_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -4,11 +4,6 @@ feature "Provider filter", type: :feature do
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:location_filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
-
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:providers_url) do
     "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
   end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -6,11 +6,11 @@ feature "Provider filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
 
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:providers_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -4,7 +4,7 @@ feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
 
   before do

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -4,7 +4,7 @@ feature "Qualifications filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
 
   before do

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -4,7 +4,7 @@ feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -4,7 +4,7 @@ feature "Study type filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -5,7 +5,7 @@ feature "Subject filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
 
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }
@@ -13,7 +13,7 @@ feature "Subject filter", type: :feature do
   let(:stub_subject_areas_request) do
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/subject_areas?include=subjects",
+      "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects",
     ).to_return(
       body: File.new("spec/fixtures/api_responses/subject_areas.json"),
       headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -5,7 +5,7 @@ feature "Subject filter", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
 
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -3,13 +3,7 @@ require "rails_helper"
 feature "Subject filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::SubjectPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
-
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
-
   let(:stub_subject_areas_request) do
     stub_request(
       :get,

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -4,7 +4,7 @@ feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -3,10 +3,6 @@ require "rails_helper"
 feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters }
 
   before do

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -4,7 +4,7 @@ feature "Vacancy filter", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters }

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -5,7 +5,7 @@ feature "results", type: :feature do
   let(:sort) { "provider.provider_name,name" }
   let(:params) {}
   let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters("sort" => sort) }

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -5,7 +5,7 @@ feature "results", type: :feature do
   let(:sort) { "provider.provider_name,name" }
   let(:params) {}
   let(:default_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters("sort" => sort) }
@@ -28,7 +28,7 @@ feature "results", type: :feature do
   before do
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
     ).to_return(
       body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
       headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -4,15 +4,11 @@ feature "results", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:sort) { "provider.provider_name,name" }
   let(:params) {}
-  let(:default_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters("sort" => sort) }
 
   let(:results_page_request) do
     {
-      course_stub: stub_request(:get, default_url)
+      course_stub: stub_request(:get, courses_url)
         .with(query: base_parameters)
         .to_return(
           body: courses,
@@ -117,7 +113,7 @@ feature "results", type: :feature do
 
   context "provider sorting" do
     let(:ascending_stub) do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: results_page_parameters("sort" => "provider.provider_name,name"))
         .to_return(
           body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -126,7 +122,7 @@ feature "results", type: :feature do
     end
 
     let(:descending_stub) do
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: results_page_parameters("sort" => "-provider.provider_name,-name"))
         .to_return(
           body: File.new("spec/fixtures/api_responses/ten_courses.json"),

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -4,7 +4,7 @@ describe "Suggested salary searches" do
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   def default_query_for_location_search(radius:)
@@ -14,7 +14,7 @@ describe "Suggested salary searches" do
   def stub_subjects
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
     ).to_return(
       body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
       headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -4,7 +4,7 @@ describe "Suggested salary searches" do
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   def default_query_for_location_search(radius:)

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -3,9 +3,6 @@ require "rails_helper"
 describe "Suggested salary searches" do
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:courses_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
 
   def default_query_for_location_search(radius:)
     { l: 1, loc: "Cat Town", lq: "Cat Town", lat: 51.4980188, lng: -0.1300436, rad: radius }

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -4,10 +4,6 @@ feature "suggested searches", type: :feature do
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:sort) { "distance" }
-  let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
-
   let(:base_parameters) { results_page_parameters("sort" => sort) }
 
   def suggested_search_count_parameters

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -150,7 +150,7 @@ feature "suggested searches", type: :feature do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
+        "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
       ).with(
         query: {
           "fields[providers]" => "provider_code,provider_name",

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -5,7 +5,7 @@ feature "suggested searches", type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:sort) { "distance" }
   let(:courses_url) do
-    "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
+    "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
   end
 
   let(:base_parameters) { results_page_parameters("sort" => sort) }
@@ -150,7 +150,7 @@ feature "suggested searches", type: :feature do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/recruitment_cycles/2020/providers",
+        "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
       ).with(
         query: {
           "fields[providers]" => "provider_code,provider_name",

--- a/spec/models/base_spec.rb
+++ b/spec/models/base_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Base do
     end
 
     it "connection sends X-Request-Id header" do
-      stub = stub_request(:post, "http://localhost:3001/api/v3/bases")
+      stub = stub_request(:post, "#{Settings.teacher_training_api.base_url}/api/v3/bases")
         .with(
           body: "{\"data\":{\"type\":\"bases\",\"attributes\":{}}}",
           headers: {

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -26,7 +26,7 @@ describe "heartbeat requests" do
   end
 
   describe "GET /healthcheck" do
-    let(:healthcheck_endpoint) { "http://localhost:3001/healthcheck" }
+    let(:healthcheck_endpoint) { "#{Settings.teacher_training_api.base_url}/healthcheck" }
 
     context "when everything is ok" do
       before do

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 describe "/results", type: :request do
+  let(:courses_url) { "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
+
   context "a valid request" do
     before do
-      default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
-
       stub_request(
         :get,
         "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
@@ -13,7 +13,7 @@ describe "/results", type: :request do
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
 
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: results_page_parameters)
         .to_return(
           body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -29,8 +29,6 @@ describe "/results", type: :request do
 
   context "API returns client error (400)" do
     before do
-      default_url = "http://localhost:3001/api/v3/recruitment_cycles/2020/courses"
-
       stub_request(
         :get,
         "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
@@ -39,7 +37,7 @@ describe "/results", type: :request do
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
       )
 
-      stub_request(:get, default_url)
+      stub_request(:get, courses_url)
         .with(query: results_page_parameters)
         .to_return(status: 400)
     end

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 describe "/results", type: :request do
-  let(:courses_url) { "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
-
   context "a valid request" do
     before do
       stub_request(

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,13 +1,13 @@
 require "rails_helper"
 
 describe "/results", type: :request do
-  let(:courses_url) { "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
+  let(:courses_url) { "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
 
   context "a valid request" do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+        "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
       ).to_return(
         body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -31,7 +31,7 @@ describe "/results", type: :request do
     before do
       stub_request(
         :get,
-        "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+        "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
       ).to_return(
         body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -67,6 +67,10 @@ module Helpers
     expect(page).to be_displayed
     expect(Rack::Utils.parse_nested_query(current_query_string)).to eq(expected_query_params)
   end
+
+  def courses_url
+    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/stub_subjects_request.rb
+++ b/spec/support/stub_subjects_request.rb
@@ -1,7 +1,7 @@
 def stub_subjects_request
   stub_request(
     :get,
-    "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+    "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
   ).to_return(
     body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
     headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -23,8 +23,6 @@ describe ResultsView do
     }
   end
 
-  let(:courses_url) { "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
-
   before do
     stub_request(
       :get,
@@ -843,7 +841,7 @@ describe ResultsView do
     subject { described_class.new(query_parameters: query_parameters) }
 
     def stub_request_with_meta_count(count)
-      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/2020/courses")
+      stub_request(:get, courses_url)
         .with(query: results_page_parameters)
         .to_return(
           body: { meta: { count: count } }.to_json,

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -23,12 +23,12 @@ describe ResultsView do
     }
   end
 
-  let(:courses_url) { "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
+  let(:courses_url) { "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
 
   before do
     stub_request(
       :get,
-      "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
     ).to_return(
       body: File.new("spec/fixtures/api_responses/subjects_sorted_name_code.json"),
       headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -843,7 +843,7 @@ describe ResultsView do
     subject { described_class.new(query_parameters: query_parameters) }
 
     def stub_request_with_meta_count(count)
-      stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/2020/courses")
         .with(query: results_page_parameters)
         .to_return(
           body: { meta: { count: count } }.to_json,

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -23,6 +23,8 @@ describe ResultsView do
     }
   end
 
+  let(:courses_url) { "http://localhost:3001/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses" }
+
   before do
     stub_request(
       :get,
@@ -403,7 +405,7 @@ describe ResultsView do
 
     context "there are more than three results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -416,7 +418,7 @@ describe ResultsView do
 
     context "there are no results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -485,7 +487,7 @@ describe ResultsView do
 
         context "there are more than three results" do
           before do
-            stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+            stub_request(:get, courses_url)
               .with(query: results_page_parameters)
               .to_return(
                 body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -499,14 +501,14 @@ describe ResultsView do
         context "there are less than three results" do
           context "there are suggested courses found" do
             before do
-              stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+              stub_request(:get, courses_url)
                 .with(query: results_page_parameters)
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/two_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
 
-              stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+              stub_request(:get, courses_url)
                 .with(query: suggested_search_count_parameters)
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -519,13 +521,13 @@ describe ResultsView do
 
           context "there are no suggested courses found" do
             before do
-              stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+              stub_request(:get, courses_url)
                 .with(query: results_page_parameters)
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/two_courses.json"),
                   headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
                 )
-              stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+              stub_request(:get, courses_url)
                 .with(query: suggested_search_count_parameters)
                 .to_return(
                   body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -767,7 +769,7 @@ describe ResultsView do
 
     context "there are more than three results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/ten_courses.json"),
@@ -780,7 +782,7 @@ describe ResultsView do
 
     context "there are no results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/empty_courses.json"),
@@ -797,7 +799,7 @@ describe ResultsView do
 
     context "there are two results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/two_courses.json"),
@@ -810,7 +812,7 @@ describe ResultsView do
 
     context "there is one result" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/one_course.json"),
@@ -823,7 +825,7 @@ describe ResultsView do
 
     context "there are no results" do
       before do
-        stub_request(:get, "http://localhost:3001/api/v3/recruitment_cycles/2020/courses")
+        stub_request(:get, courses_url)
           .with(query: results_page_parameters)
           .to_return(
             body: File.new("spec/fixtures/api_responses/empty_courses.json"),


### PR DESCRIPTION
### Context
Many of the api test stubs are hard coded to the `2020` cycle year. When stubbing the API we need to concatenate `Settings.current_cycle` into API URL stings so that when the current cycle is updated from `2020` to `2021`, the tests do not break.

### Changes proposed in this pull request
- Create [course_url helper](https://github.com/DFE-Digital/find-teacher-training/pull/456/files#diff-3bb5ea059ab3c1c6dbccd241014d50b2) so that it is only defined in one place. 
- Concatenate the settings values for `cycle_year` and `teacher_training_api.base_url` so that any changes in these settings will not break specs

### Guidance to review
- Lots of file changes sorry, but they're small changes 
- Potentially there is scope to do some more url refactoring but will card this up as priority is to get the specs working

### Trello card
https://trello.com/c/CcJuw6ym/2254-new-cycle-2021-fix-broken-find-tests

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
