### PR TITLE
Update course fees display

### DIFF
--- a/app/views/courses/_fees.html.erb
+++ b/app/views/courses/_fees.html.erb
@@ -3,31 +3,33 @@
 
   <% if course.fee_uk_eu.present? %>
     <div class="body-text">
-      <table class="govuk-table app-table--vertical-align-middle">
-        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for <%= course.year_range %> are as follows:</caption>
-        <thead class="govuk-table__head">
+      <% if course.fee_uk_eu.present? && course.fee_international.present? %>
+        <table class="govuk-table app-table--vertical-align-middle">
+          <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees
+            for <%= course.year_range %> are as follows:
+          </caption>
+          <thead class="govuk-table__head">
           <tr class="govuk-visually-hidden govuk-table__row">
             <th class="govuk-table__header">Student type</th>
             <th class="govuk-table__header">Fees to pay</th>
           </tr>
-        </thead>
-        <tbody class="govuk-table__body">
+          </thead>
+          <tbody class="govuk-table__body">
           <tr class="govuk-table__row">
             <td class="govuk-table__cell">UK students</td>
             <td class="govuk-table__cell" data-qa="course__uk_fees"><%= number_to_currency(course.fee_uk_eu) %></td>
           </tr>
           <tr class="govuk-table__row">
-            <td class="govuk-table__cell">EU students</td>
-            <td class="govuk-table__cell" data-qa="course__eu_fees"><%= number_to_currency(course.fee_uk_eu) %></td>
+            <td class="govuk-table__cell">International students</td>
+            <td class="govuk-table__cell" data-qa="course__international_fees"><%= number_to_currency(course.fee_international) %></td>
           </tr>
-          <% if course.fee_international.present? %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell">International students</td>
-              <td class="govuk-table__cell" data-qa="course__international_fees"><%= number_to_currency(course.fee_international) %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      <% else %>
+        <p class="govuk-body">
+          The course fees for UK students in <%= course.year_range %> are <%= number_to_currency(course.fee_uk_eu) %>
+        </p>
+      <% end %>
     </div>
 
     <% if course.fee_details.present? %>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -146,15 +146,7 @@ feature "Course show", type: :feature do
         course.how_school_placements_work,
       )
 
-      # expect(course_page).to have_content(
-      #   "The course fees for #{Settings.current_cycle} - #{Settings.current_cycle + 1} are as follows",
-      # )
-
       expect(course_page.uk_fees).to have_content(
-        "£9,250",
-      )
-
-      expect(course_page.eu_fees).to have_content(
         "£9,250",
       )
 
@@ -258,6 +250,27 @@ feature "Course show", type: :feature do
         expect(course_page).to have_end_of_cycle_notice
         expect(course_page).not_to have_training_location_guidance
       end
+    end
+  end
+
+  describe "A course without international fees" do
+    let(:course) do
+      build(:course,
+            course_code: "X130",
+            fee_uk_eu: "9250.0",
+            fee_international: nil,
+            provider: provider,
+            provider_code: provider.provider_code,
+            recruitment_cycle: current_recruitment_cycle,
+            accrediting_provider: accrediting_provider)
+    end
+
+    it "only displays uk fees" do
+      expect(course_page).to have_content(
+        "The course fees for UK students in #{Settings.current_cycle} to #{Settings.current_cycle + 1} are £9,250",
+      )
+
+      expect(course_page).to_not have_international_fees
     end
   end
 


### PR DESCRIPTION
### Context
Course listings on Find contain section containing information about fees. 

### Changes proposed in this pull request

In the fees section:
- Remove EU course fees from table
- Only display a table if UK and International fees are present, else display UK fees inline

### Screenshots

**1. A course with UK fees only**
<img width="1092" alt="fees_uk_only" src="https://user-images.githubusercontent.com/5256922/94918982-860f4b00-04ab-11eb-99aa-b6f7fdbaa8dd.png">

**2. A course with UK and international fees**
<img width="1038" alt="fees_uk_and_international" src="https://user-images.githubusercontent.com/5256922/94918996-8a3b6880-04ab-11eb-99cc-2a07b7703e31.png">

### Trello card
https://trello.com/c/UkFQGmVA/2251-add-box-to-display-international-student-fees

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
