### PR TITLE
Update copy on ‘find course by subject’ page

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -13,6 +13,14 @@
       <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
       <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
 
+      <h2 class="govuk-heading-m">Find out about Subject knowledge enhancement courses</h2>
+      <p class="govuk-body">
+        For some subjects you can take a Subject knowledge enhancement (SKE) course. SKE courses for candidates starting ITT in 2021/22 will not be available at the start of the recruitment cycle from 1 October 2020. Following completion of the Spending Review we will confirm the approach to SKE including when courses will start.
+      </p>
+      <p class="govuk-body">
+        Visit Get Into Teaching to find out more about <%= govuk_link_to 'Subject knowledge enhancement', 'https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses' %> courses.
+      </p>
+
 
       <div class="accordion govuk-form-group" data-module="govuk-accordion">
         <% @subject_areas.each_with_index do |subject_area, counter| %>


### PR DESCRIPTION
### Changes proposed in this pull request
- Adds information about subject knowledge enhancement courses to `/start/subject`

### Screenshot
<img width="901" alt="Screenshot 2020-10-05 at 08 46 43" src="https://user-images.githubusercontent.com/5256922/95053654-a4ae5580-06e8-11eb-8060-7459f0a7732e.png">

### Trello card
https://trello.com/c/XLwad9XS/2258-dev-copy-changes-on-find-course-by-subject-page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
