### PR TITLE
Update ‘current_cycle’ to ‘2021’

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@ base_url: http://localhost:3002
 teacher_training_api:
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
-current_cycle: 2020
+current_cycle: 2021
 google:
   maps_api_key: replace_me
   maps_api_url: https://maps.googleapis.com/maps/api/staticmap


### PR DESCRIPTION
### Context
When Find reopens we need to display courses from the latest cycle

### Changes proposed in this pull request
Update app config

### Guidance to review
When you run the app and search for courses, you should see in the logs that course requests include the 2021 recruitment cycle

### Trello card
https://trello.com/c/usXMOiXv/2177-dev-6th-oct-find-reopens-revert-to-orig-land-page

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
