### PR TITLE
Add holding copy for 2021 /20 financial incentives info

### DIFF
--- a/app/views/courses/_financial_support.html.erb
+++ b/app/views/courses/_financial_support.html.erb
@@ -1,20 +1,26 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
+  <div class="govuk-inset-text">
+    <p>
+      Financial support for 2021 to 2022 will be announced soon. Further information is available on <%= govuk_link_to 'Get Into Teaching','https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training' %>.
+    </p>
+  </div>
 
-  <% if course.salaried? %>
-    <%= render partial: 'courses/financial_support/salaried' %>
-  <% elsif course.excluded_from_bursary? %>
-    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
-  <% elsif course.bursary_only? %>
-    <%= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
-  <% elsif course.has_scholarship_and_bursary? %>
-    <%= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
-  <% else %>
-    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
-  <% end %>
+  <!-- Reinstate once incentives announced -->
+  <%# if course.salaried? %>
+    <%#= render partial: 'courses/financial_support/salaried' %>
+  <%# elsif course.excluded_from_bursary? %>
+    <%#= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+  <%# elsif course.bursary_only? %>
+    <%#= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
+  <%# elsif course.has_scholarship_and_bursary? %>
+    <%#= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
+  <%# else %>
+    <%#= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+  <%# end %>
 
-  <% if course.financial_support.present? %>
-    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>
-    <%= markdown(course.financial_support) %>
-  <% end %>
+  <%# if course.financial_support.present? %>
+<!--    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>-->
+    <%#= markdown(course.financial_support) %>
+  <%# end %>
 </div>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -7,11 +7,16 @@
     <%= form_with(url: subject_path, method: :post, data: { "ga-event-form" => "Subject" }) do |f| %>
       <%= render "shared/hidden_fields", exclude_keys: %w(subjects senCourses), form: f %>
       <h1 class="govuk-heading-xl" data-qa="heading">Find courses by subject</h1>
-
       <p class="govuk-body">Select the subjects you want to teach.</p>
+
       <h2 class="govuk-heading-m">Get financial support</h2>
-      <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
-      <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
+      <p class="govuk-body">
+        The bursaries and scholarships available for teacher training courses starting in the academic year 2021/22 will be announced soon.
+      </p>
+      <p class="govuk-body">
+        You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study.
+        Further information is available on <%= govuk_link_to 'Get Into Teaching','https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training' %>.
+      </p>
 
       <h2 class="govuk-heading-m">Find out about Subject knowledge enhancement courses</h2>
       <p class="govuk-body">

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -160,11 +160,14 @@ feature "Course show", type: :feature do
 
       expect(course_page).to_not have_salary_details
 
-      expect(course_page.scholarship_amount).to have_content("a scholarship of £2,000")
+      # TODO: Reinstate once financial incentives are confirmed for 2021-22
+      # Current holding copy is displayed in Financial Incentives section
 
-      expect(course_page.bursary_amount).to have_content("a bursary of £4,000")
+      # expect(course_page.scholarship_amount).to have_content("a scholarship of £2,000")
 
-      expect(course_page.financial_support_details).to have_content("Financial support from the training provider")
+      # expect(course_page.bursary_amount).to have_content("a bursary of £4,000")
+
+      # expect(course_page.financial_support_details).to have_content("Financial support from the training provider")
 
       expect(course_page.required_qualifications).to have_content(
         course.required_qualifications,


### PR DESCRIPTION
### Context
- The introduction of new course financial incentives is on hold, so in the meantime we need some copy changes to reflect that (as [per this document](https://docs.google.com/document/d/1J98rWHyoRJRM4ozL9HBBhPllWwocFGsrquq8oWV4dzw/edit)).
- Financial incentives info to be reinstated once announced (API work in progress for this)

### Changes proposed in this pull request
- Add holding copy to ‘Find a courses by subject’ page and course listing pages

### Guidance to review

Changes in screenshots below.

#### Find a courses by subject
<img width="916" alt="find_course_by_subject" src="https://user-images.githubusercontent.com/5256922/95097994-08a33f00-0726-11eb-9d21-50907ed5ebe2.png">

#### Course listing
<img width="926" alt="course_listing" src="https://user-images.githubusercontent.com/5256922/95098039-1953b500-0726-11eb-81f2-cecbcaaafc4b.png">

### Trello card
https://trello.com/c/YLQfceFb/2290-find-financial-incentive-holding-copy

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
