### PR TITLE
[DO NOT MERGE YET] - Temporarily hide financial incentive info

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -57,26 +57,26 @@
                             <% end %>
                           </span>
 
-                          <% if subject.decorate.has_scholarship_and_bursary? %>
-                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} are available" %>
-                          <% elsif subject.decorate.has_scholarship? %>
-                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} are available" %>
-                          <% elsif subject.decorate.has_bursary? %>
-                            <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} available" %>
-                          <% end %>
-                          <% if subject.decorate.early_career_payments? %>
-                            <% financial_info.concat(", \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).") %>
-                          <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
-                            <% financial_info.concat(".") %>
-                          <% end %>
-                          <span class="govuk-body" data-qa="subject__info"><%= financial_info %></span>
+                          <%# if subject.decorate.has_scholarship_and_bursary? %>
+                            <%# financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} are available" %>
+                          <%# elsif subject.decorate.has_scholarship? %>
+                            <%# financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, :delimiter => ',')} are available" %>
+                          <%# elsif subject.decorate.has_bursary? %>
+                            <%# financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, :delimiter => ',')} available" %>
+                          <%# end %>
+                          <%# if subject.decorate.early_career_payments? %>
+                            <%# financial_info.concat(", \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).") %>
+                          <%# elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
+                            <%# financial_info.concat(".") %>
+                          <%# end %>
+<!--                          <span class="govuk-body" data-qa="subject__info"><%#= financial_info %></span>-->
 
-                          <% if subject.subject_knowledge_enhancement_course_available %>
-                            <span class="govuk-!-display-block" data-qa="subject__ske_course">
-                              You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? "also" : "" %> take a
-                              <%= link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses", class: "govuk-link" %>.
-                            </span>
-                          <% end %>
+                          <%# if subject.subject_knowledge_enhancement_course_available %>
+<!--                            <span class="govuk-!-display-block" data-qa="subject__ske_course">-->
+<!--                              You can <%#= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? "also" : "" %> take a-->
+<!--                              <%#= link_to "subject knowledge enhancement (SKE) course", "https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses", class: "govuk-link" %>.-->
+<!--                            </span>-->
+                          <%# end %>
                         <% end %>
                       </div>
                     <% end %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -124,7 +124,8 @@
                 <% end %>
             <% end %>
             <dt class="govuk-list--description__label">Financial support</dt>
-            <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
+<!--            <dd data-qa="course__funding_options"><%#= course.decorate.funding_option %></dd>-->
+            <dd data-qa="course__funding_options">Financial support for 2021 to 2022 will be announced soon</dd>
             <% if course['accrediting_provider'].present? %>
               <dt class="govuk-list--description__label">Accredited body</dt>
               <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -50,7 +50,7 @@ feature "Search results", type: :feature do
         expect(first_course.provider_name.text).to eq("BHSSA")
         expect(first_course.description.text).to eq("PGCE with QTS full time")
         expect(first_course.accrediting_provider.text).to eq("University of Brighton")
-        expect(first_course.funding_options.text).to eq("Student finance if you’re eligible")
+        # expect(first_course.funding_options.text).to eq("Student finance if you're eligible")
         expect(first_course.main_address.text).to eq("Hove Park School, Hangleton Way, Hove, East Sussex, BN3 8AA")
         expect(first_course).not_to have_show_vacanices
       end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -295,8 +295,8 @@ feature "Subject filter", type: :feature do
 
     it "displays financial information" do
       subjects = filter_page.subject_areas.first.subjects
-      expect(subjects.fourth.info.text).to eq("Bursaries of £6,000 available.")
-      expect(subjects.fourth.ske_course.text).to eq("You can also take a subject knowledge enhancement (SKE) course.")
+      # expect(subjects.fourth.info.text).to eq("Bursaries of £6,000 available.")
+      # expect(subjects.fourth.ske_course.text).to eq("You can also take a subject knowledge enhancement (SKE) course.")
     end
   end
 


### PR DESCRIPTION
### Context
- Temporary fix whilst API issues are investigated
- This PR should be reversed once fixed


### Changes proposed in this pull request

- Hide financial incentive info in 'Find courses by subjects` page
- Add ' Financial support for 2021 to 2022 will be announced soon' on course results summaries

### Guidance to review

1. Find courses by subject

<img width="765" alt="subjects" src="https://user-images.githubusercontent.com/5256922/95177655-5bc4d280-07b6-11eb-8800-0e894e8b7bf4.png">

2. Results

<img width="945" alt="results" src="https://user-images.githubusercontent.com/5256922/95177683-641d0d80-07b6-11eb-8ad4-293b47ceaf93.png">


### Trello card

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
