### PR TITLE
Configure Skylight performance metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ gem "redcarpet"
 # Render smart quotes
 gem "rubypants"
 
+# Monitoring
+gem "skylight"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,10 @@ GEM
       capybara (~> 3.3)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
+    skylight (4.3.1)
+      skylight-core (= 4.3.1)
+    skylight-core (4.3.1)
+      activesupport (>= 4.2.0)
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -436,6 +440,7 @@ DEPENDENCIES
   sentry-raven
   simplecov (< 0.18)
   site_prism
+  skylight
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/azure/template.json
+++ b/azure/template.json
@@ -165,6 +165,14 @@
       "metadata": {
         "description": "Displays the 'apply for this course' button on course pages"
       }
+    },
+    "skylightAuthToken":{
+      "defaultValue": "",
+      "type": "string"
+    },
+    "skylightEnable":{
+      "defaultValue": false,
+      "type": "bool"
     }
   },
   "variables": {
@@ -291,6 +299,14 @@
               {
                 "name": "WEBSITE_SLOT_POLL_WORKER_FOR_CHANGE_NOTIFICATION",
                 "value": "0"
+              },
+              {
+                "name": "SKYLIGHT_AUTH_TOKEN",
+                "value": "[parameters('skylightAuthToken')]"
+              },
+              {
+                "name": "SKYLIGHT_ENABLE",
+                "value": "[parameters('skylightEnable')]"
               },
               {
                 "name": "SETTINGS__LOGSTASH__HOST",

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,7 @@ module FindTeacherTraining
 
     # https://thoughtbot.com/blog/content-compression-with-rack-deflater
     config.middleware.use Rack::Deflater
+
+    config.skylight.environments = Settings.skylight_enable ? [Rails.env] : []
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,5 @@ commit_sha_file: COMMIT_SHA
 cycle_has_ended:
 cycle_ending_soon:
 display_apply_button: true
+skylight_auth_token: replace_me
+skylight_enable: true

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,9 @@
+---
+#The authentication token for the application
+authentication: <%= Settings.skylight_auth_token %>
+ignored_endpoints:
+  - HeartbeatController#ping
+  - HeartbeatController#healthcheck
+  - HeartbeatController#sha
+agent:
+  sockfile_path: /tmp/find-postgraduate-teacher-training

--- a/docs/performance-monitoring.md
+++ b/docs/performance-monitoring.md
@@ -1,0 +1,27 @@
+# Performance Monitoring
+
+## External Integrations
+
+### Skylight
+
+skylight.io provides a rich set of performance monitoring tools, available form
+on the apps [dashboard page](https://www.skylight.io/app/applications/t8bEzG0cuIkd).
+
+#### Configuring in deployed environments
+
+In a deployed environment, the environment variable
+`SKYLIGHT_AUTH_TOKEN` should be set to the auth token available
+from the application setting in skylight.io.
+
+To enable Skylight for a given environment, the environment variable `SKYLIGHT_ENABLE` should be set to `true`.
+
+#### Configuring for local development
+
+In local development, if you need to test performance monitoring you can enable
+Skylight and set the auth token in a `development.local.yml` file with the token itself available on the
+[Skylight application setting page](https://www.skylight.io/app/settings/1woC6LIhRprp/app_settings)
+
+```
+skylight_enable: true
+skylight_auth_token: auth token goes here
+```


### PR DESCRIPTION
### Context
```
When I view the Skylight performance monitoring dashboard
I want to see performance monitoring stats per environment (qa, staging, production)
In order to make more informed decisions about performance issues
```

### Changes proposed in this pull request
- Configure skylight performance metrics

### Guidance to review
To run locally, see docs added to this PR

### Trello card
https://trello.com/c/tfpDMdkZ/2295-add-skylight-to-find

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
