### PR TITLE
Use syslog_drain to send logs to logstash in PaaS

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -77,6 +77,5 @@ jobs:
           TF_VAR_paas_sentry_dsn: ${{ secrets.SENTRY_DSN }}
           TF_VAR_paas_settings_google_gcp_api_key: ${{ secrets.GOOGLE_GCP_API_KEY }}
           TF_VAR_paas_settings_google_maps_api_key: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          TF_VAR_paas_settings_logstash_host: ${{ secrets.LOGSTASH_HOST }}
-          TF_VAR_paas_settings_logstash_port: ${{ secrets.LOGSTASH_PORT }}
+          TF_VAR_paas_logstash_url: ${{ secrets.LOGSTASH_URL }}
           TF_VAR_paas_app_docker_image: ${{ format('{0}:paas-{1}', env.DOCKERHUB_REPOSITORY, github.sha) }}

--- a/config/environments/qa_paas.rb
+++ b/config/environments/qa_paas.rb
@@ -1,0 +1,10 @@
+require Rails.root.join("config/environments/production")
+Rails.application.configure do
+  # Logging
+  config.log_level = :info
+  config.rails_semantic_logger.format = :json
+  config.semantic_logger.backtrace_level = :error
+  config.semantic_logger.add_appender(io: STDOUT, level: config.log_level, formatter: config.rails_semantic_logger.format)
+
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,6 +1,8 @@
-LogStashLogger.configure do |config|
-  config.customize_event do |event|
-    event["application"] = Settings.application_name
-    event["environment"] = Rails.env
+if Settings.logstash.host && Settings.logstash.port
+  LogStashLogger.configure do |config|
+    config.customize_event do |event|
+      event["application"] = Settings.application_name
+      event["environment"] = Rails.env
+    end
   end
 end

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -43,5 +43,5 @@ resource cloudfoundry_route web_app_route {
 resource cloudfoundry_user_provided_service logging {
   name             = local.logging_service_name
   space            = data.cloudfoundry_space.space.id
-  syslog_drain_url = "${var.settings_logstash_host}:${var.settings_logstash_port}"
+  syslog_drain_url = var.logstash_url
 }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -30,9 +30,7 @@ variable settings_google_gcp_api_key {}
 
 variable settings_google_maps_api_key {}
 
-variable settings_logstash_host {}
-
-variable settings_logstash_port {}
+variable logstash_url {}
 
 
 locals {
@@ -53,7 +51,5 @@ locals {
     SETTINGS__DISPLAY_APPLY_BUTTON = var.settings_display_apply_button
     SETTINGS__GOOGLE__GCP_API_KEY  = var.settings_google_gcp_api_key
     SETTINGS__GOOGLE__MAPS_API_KEY = var.settings_google_maps_api_key
-    SETTINGS__LOGSTASH__HOST       = var.settings_logstash_host
-    SETTINGS__LOGSTASH__PORT       = var.settings_logstash_port
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -37,6 +37,5 @@ module paas {
   settings_display_apply_button = var.paas_settings_display_apply_button
   settings_google_gcp_api_key   = var.paas_settings_google_gcp_api_key
   settings_google_maps_api_key  = var.paas_settings_google_maps_api_key
-  settings_logstash_host        = var.paas_settings_logstash_host
-  settings_logstash_port        = var.paas_settings_logstash_port
+  logstash_url                  = var.paas_logstash_url
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,9 +28,7 @@ variable paas_settings_google_gcp_api_key {}
 
 variable paas_settings_google_maps_api_key {}
 
-variable paas_settings_logstash_host {}
-
-variable paas_settings_logstash_port {}
+variable paas_logstash_url {}
 
 locals {
   cf_api_url = "https://api.london.cloud.service.gov.uk"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -1,7 +1,7 @@
 # PaaS
 paas_sso_code                      = ""
 paas_app_environment               = "qa"
-paas_rails_env                     = "qa"
+paas_rails_env                     = "qa_paas"
 paas_web_app_instances             = 1
 paas_web_app_memory                = 512
 paas_sentry_dsn                    = ""


### PR DESCRIPTION
### Context

Write logs to STDOUT and configure logit service in PaaS to send logs to logit.

### Changes proposed in this pull request

Use `qa_paas` env for testing in PaaS.
Use `logstash_url` to configure syslog_drain_url

### Trello card

https://trello.com/c/GbIMKsJw/2252-configure-logging-in-paas

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
