### PR TITLE
remove usage of set-env

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Set Environment variable
         run: |
-          echo ::set-env name=DOCKER_IMAGE::$DOCKER_IMAGE
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
         env:
           DOCKER_IMAGE: ${{ format('{0}:paas-{1}', env.DOCKERHUB_REPOSITORY, github.sha) }}
 


### PR DESCRIPTION
### Context

see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

### Checklist

- [x] Make sure all information from the Trello card is in here
~- [x] Attach to Trello card~
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
