### PR TITLE
Throttle autocomplete calls

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -21,16 +21,16 @@ new backLink($backLink).init();
 const $toggle = document.querySelector('[data-module="toggle"]');
 new toggle($toggle).init();
 
-// initAutocomplete({
-//   element: "location-autocomplete",
-//   input: "location",
-//   path: "/location-suggestions",
-// });
-// initAutocomplete({
-//   element: "provider-autocomplete",
-//   input: "provider",
-//   path: "/provider-suggestions",
-// });
+initAutocomplete({
+  element: "location-autocomplete",
+  input: "location",
+  path: "/location-suggestions",
+});
+initAutocomplete({
+  element: "provider-autocomplete",
+  input: "provider",
+  path: "/provider-suggestions",
+});
 
 loadAnalytics();
 new initCookieBanner();

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -1,4 +1,5 @@
 import accessibleAutocomplete from "accessible-autocomplete";
+import throttle from 'lodash.throttle'
 
 export const getPath = (endpoint,query) => {
   return `${endpoint}?query=${query}`;
@@ -47,7 +48,7 @@ const initAutocomplete = ({element, input, path}) => {
         name: $input.name,
         defaultValue: $input.value,
         minLength: 3,
-        source: request(path),
+        source: throttle(request(path), 500),
         templates: {
           inputValue: inputValueTemplate,
           suggestion: suggestionTemplate


### PR DESCRIPTION
### Context

Our autocomplete hammers our server with too many requests.

### Changes proposed in this pull request

Use `lodash.throttle` which supports both leading and trailing calls.

### Guidance to review

Test it in the review app, check the dev console.

### Trello card

https://trello.com/c/FXy5da3M/2299-add-js-autocomplete-back-to-find-provider-and-location-search

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review