### PR TITLE
Revert "Add holding copy for 2021 to 2020 financial incentives info"

### DIFF
--- a/app/views/courses/_financial_support.html.erb
+++ b/app/views/courses/_financial_support.html.erb
@@ -1,26 +1,20 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
-  <div class="govuk-inset-text">
-    <p>
-      Financial support for 2021 to 2022 will be announced soon. Further information is available on <%= govuk_link_to 'Get Into Teaching','https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training' %>.
-    </p>
-  </div>
 
-  <!-- Reinstate once incentives announced -->
-  <%# if course.salaried? %>
-    <%#= render partial: 'courses/financial_support/salaried' %>
-  <%# elsif course.excluded_from_bursary? %>
-    <%#= render partial: 'courses/financial_support/loan', locals: { course: course } %>
-  <%# elsif course.bursary_only? %>
-    <%#= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
-  <%# elsif course.has_scholarship_and_bursary? %>
-    <%#= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
-  <%# else %>
-    <%#= render partial: 'courses/financial_support/loan', locals: { course: course } %>
-  <%# end %>
+  <% if course.salaried? %>
+    <%= render partial: 'courses/financial_support/salaried' %>
+  <% elsif course.excluded_from_bursary? %>
+    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+  <% elsif course.bursary_only? %>
+    <%= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
+  <% elsif course.has_scholarship_and_bursary? %>
+    <%= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
+  <% else %>
+    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+  <% end %>
 
-  <%# if course.financial_support.present? %>
-<!--    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>-->
-    <%#= markdown(course.financial_support) %>
-  <%# end %>
+  <% if course.financial_support.present? %>
+    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>
+    <%= markdown(course.financial_support) %>
+  <% end %>
 </div>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -7,16 +7,11 @@
     <%= form_with(url: subject_path, method: :post, data: { "ga-event-form" => "Subject" }) do |f| %>
       <%= render "shared/hidden_fields", exclude_keys: %w(subjects senCourses), form: f %>
       <h1 class="govuk-heading-xl" data-qa="heading">Find courses by subject</h1>
-      <p class="govuk-body">Select the subjects you want to teach.</p>
 
+      <p class="govuk-body">Select the subjects you want to teach.</p>
       <h2 class="govuk-heading-m">Get financial support</h2>
-      <p class="govuk-body">
-        The bursaries and scholarships available for teacher training courses starting in the academic year 2021/22 will be announced soon.
-      </p>
-      <p class="govuk-body">
-        You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study.
-        Further information is available on <%= govuk_link_to 'Get Into Teaching','https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training' %>.
-      </p>
+      <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
+      <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
 
       <h2 class="govuk-heading-m">Find out about Subject knowledge enhancement courses</h2>
       <p class="govuk-body">

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -160,14 +160,11 @@ feature "Course show", type: :feature do
 
       expect(course_page).to_not have_salary_details
 
-      # TODO: Reinstate once financial incentives are confirmed for 2021-22
-      # Current holding copy is displayed in Financial Incentives section
+      expect(course_page.scholarship_amount).to have_content("a scholarship of £2,000")
 
-      # expect(course_page.scholarship_amount).to have_content("a scholarship of £2,000")
+      expect(course_page.bursary_amount).to have_content("a bursary of £4,000")
 
-      # expect(course_page.bursary_amount).to have_content("a bursary of £4,000")
-
-      # expect(course_page.financial_support_details).to have_content("Financial support from the training provider")
+      expect(course_page.financial_support_details).to have_content("Financial support from the training provider")
 
       expect(course_page.required_qualifications).to have_content(
         course.required_qualifications,


### PR DESCRIPTION
### Context
New course financial incentives will be announced on Oct 3.

### Changes proposed in this pull request
This PR reverts this financial incentives holding copy

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review