### PR TITLE
Make terraform settings vars consistent with other envs

### DIFF
--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -6,5 +6,5 @@ paas_web_app_instances             = 1
 paas_web_app_memory                = 512
 paas_sentry_dsn                    = ""
 paas_settings_cycle_ending_soon    = false
-paas_settings_cycle_has_ended      = true
-paas_settings_display_apply_button = false
+paas_settings_cycle_has_ended      = false
+paas_settings_display_apply_button = true


### PR DESCRIPTION
### Context

Set values for `SETTINGS__` variables in PaaS to the same defaults as in Azure.

### Changes proposed in this pull request

Change `SETTINGS__` vars to have same values as they are in Azure.

### Guidance to review

### Trello card

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
