### PR TITLE
Change PaaS route to use find-postgraduate-teacher-training.service.gov.uk

### DIFF
--- a/config/settings/qa_paas.yml
+++ b/config/settings/qa_paas.yml
@@ -1,0 +1,5 @@
+base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+teacher_training_api:
+  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
+valid_referers:
+  - https://qa.find-postgraduate-teacher-training.education.gov.uk

--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -7,6 +7,10 @@ data cloudfoundry_space space {
   org  = data.cloudfoundry_org.org.id
 }
 
-data cloudfoundry_domain cloudapps_digital {
+data cloudfoundry_domain london_cloudapps_digital {
   name = "london.cloudapps.digital"
+}
+
+data cloudfoundry_domain find_service_gov_uk {
+  name = "find-postgraduate-teacher-training.service.gov.uk"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -26,18 +26,27 @@ resource cloudfoundry_app web_app {
   strategy                   = "blue-green-v2"
   timeout                    = 180
   environment                = local.app_environment_variables
-  routes {
-    route = cloudfoundry_route.web_app_route.id
+  dynamic "routes" {
+    for_each = local.web_app_routes
+    content {
+      route = web_app_routes.value
+    }
   }
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }
 }
 
-resource cloudfoundry_route web_app_route {
-  domain   = data.cloudfoundry_domain.cloudapps_digital.id
+resource cloudfoundry_route web_app_cloudapps_digital_route {
+  domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
+}
+
+resource cloudfoundry_route web_app_service_gov_uk_route {
+  domain   = data.cloudfoundry_domain.find_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.service_gov_uk_host_names["${var.app_environment}"]
 }
 
 resource cloudfoundry_user_provided_service logging {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -32,7 +32,6 @@ variable settings_google_maps_api_key {}
 
 variable logstash_url {}
 
-
 locals {
   web_app_name          = "find-${var.app_environment}"
   web_app_start_command = "bundle exec rails server -b 0.0.0.0"
@@ -52,4 +51,11 @@ locals {
     SETTINGS__GOOGLE__GCP_API_KEY  = var.settings_google_gcp_api_key
     SETTINGS__GOOGLE__MAPS_API_KEY = var.settings_google_maps_api_key
   }
+  service_gov_uk_host_names = {
+    qa      = "qa"
+    staging = "staging"
+    prod    = "www2"
+  }
+  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route.id,
+  cloudfoundry_route.web_app_cloudapps_digital_route.id]
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -7,7 +7,7 @@ terraform {
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.12.4"
+      version = "0.12.6"
     }
     statuscake = {
       source  = "thde/statuscake"


### PR DESCRIPTION
### Context

Use find-postgraduate-teacher-training.service.gov.uk domain name in PaaS routes.

### Changes proposed in this pull request

Terraform config changes to use `find-postgraduate-teacher-training.service.gov.uk` domain.

### Guidance to review

### Trello card
https://trello.com/c/aZejdPCE/2327-configure-custom-domain-for-web-app-in-paas

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
