### PR TITLE
Use cf terraform provider v0.12.6

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
-      version = "0.12.4"
+      version = "0.12.6"
     }
   }
 }


### PR DESCRIPTION
### Context

Terraform config uses 0.12.6, change the PaaS module to use the same version.

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
