### PR TITLE
Use correct routes identifier inside for_each

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -29,7 +29,7 @@ resource cloudfoundry_app web_app {
   dynamic "routes" {
     for_each = local.web_app_routes
     content {
-      route = web_app_routes.value
+      route = routes.value
     }
   }
   service_binding {


### PR DESCRIPTION
Fix usage of `routes` inside `for_each` block