### PR TITLE
Split build & deploy jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build & Deploy to PaaS
+name: Build
 
 on:
   push:
@@ -51,31 +51,12 @@ jobs:
         env:
           GIT_BRANCH: ${{ github.ref }}
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
-
-      - name: Use Terraform v0.13.3
-        uses: hashicorp/setup-terraform@v1.2.0
-        with:
-          terraform_version: 0.13.3
-
-      - name: Terraform init
-        run: |
-          terraform init -backend-config=workspace_variables/qa_backend.tfvars
-        working-directory: terraform
-        env:
-          ARM_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
       
-      - name: Terraform plan & apply
+      - name: Trigger QA Deployment
+        if: ${{ success() }}
         run: |
-          terraform plan -var-file workspace_variables/qa.tfvars -out tfplan
-          terraform apply -auto-approve -input=false "tfplan"
-        working-directory: terraform
-        env:
-          ARM_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
-          TF_VAR_paas_user: ${{ secrets.CF_USER }}
-          TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
-          TF_VAR_paas_secret_key_base: ${{ secrets.SECRET_KEY_BASE }}
-          TF_VAR_paas_sentry_dsn: ${{ secrets.SENTRY_DSN }}
-          TF_VAR_paas_settings_google_gcp_api_key: ${{ secrets.GOOGLE_GCP_API_KEY }}
-          TF_VAR_paas_settings_google_maps_api_key: ${{ secrets.GOOGLE_MAPS_API_KEY }}
-          TF_VAR_paas_logstash_url: ${{ secrets.LOGSTASH_URL }}
-          TF_VAR_paas_app_docker_image: ${{ format('{0}:paas-{1}', env.DOCKERHUB_REPOSITORY, github.sha) }}
+          curl -X POST \
+               -H "Accept: application/vnd.github.v3+json" \
+               -H "Authorization: Bearer ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}" \
+               https://api.github.com/repos/DFE-Digital/find-teacher-training/deployments \
+               -d '{"ref":"${{ github.sha }}", "environment": "qa", "required_contexts": []}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   deploy:
     name: deploy ${{ github.event.deployment.environment }}
+    if: ${{ !startsWith(github.event.deployment.environment, 'bat-find-pr') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -64,3 +65,12 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}" \
             https://api.github.com/repos/DFE-Digital/find-teacher-training/deployments/$deployment_id/statuses \
             -d '{"state": "'$deployment_status'"}'
+
+      - name: Trigger Smoke Tests
+        if: ${{ success() }}
+        run: |
+          curl -X POST \
+            https://api.github.com/repos/DFE-Digital/find-teacher-training-tests/actions/workflows/smoke-tests.yml/dispatches \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}" \
+            -d '{"ref": "refs/heads/master", "inputs": {"environment": "${{ env.DEPLOY_ENV }}"} }'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+name: Deploy to PaaS
+
+on:
+  deployment
+
+jobs:
+  deploy:
+    name: deploy ${{ github.event.deployment.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Environment variable
+        run: |
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
+          echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
+        env:
+          DOCKER_IMAGE: ${{ format('dfedigital/find-teacher-training:paas-{0}', github.event.deployment.ref) }}
+          DEPLOY_ENV: ${{ github.event.deployment.environment }}
+
+      - name: Use Terraform v0.13.3
+        uses: hashicorp/setup-terraform@v1.2.0
+        with:
+          terraform_version: 0.13.3
+
+      - name: Terraform init
+        run: |
+          terraform init -backend-config=workspace_variables/${{ env.DEPLOY_ENV }}_backend.tfvars
+        working-directory: terraform
+        env:
+          ARM_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+      
+      - name: Terraform plan & apply
+        id: terraform_deploy
+        run: |
+          terraform plan -var-file workspace_variables/${{ env.DEPLOY_ENV }}.tfvars -out tfplan
+          terraform apply -auto-approve -input=false "tfplan"
+        working-directory: terraform
+        env:
+          ARM_ACCESS_KEY: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY }}
+          TF_VAR_paas_user: ${{ secrets.CF_USER }}
+          TF_VAR_paas_password: ${{ secrets.CF_PASSWORD }}
+          TF_VAR_paas_secret_key_base: ${{ secrets.SECRET_KEY_BASE }}
+          TF_VAR_paas_sentry_dsn: ${{ secrets.SENTRY_DSN }}
+          TF_VAR_paas_settings_google_gcp_api_key: ${{ secrets.GOOGLE_GCP_API_KEY }}
+          TF_VAR_paas_settings_google_maps_api_key: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+          TF_VAR_paas_logstash_url: ${{ secrets.LOGSTASH_URL }}
+          TF_VAR_paas_app_docker_image: ${{ env.DOCKER_IMAGE }}
+
+      - name: Post Deployment Status
+        run: |
+          current_deployment=$(curl -s -X GET -H "Authorization: Bearer ${{ github.token }}" 'https://api.github.com/repos/DFE-Digital/find-teacher-training/deployments?ref=${{ github.event.deployment.ref }}&environment=${{ github.event.deployment.environment }}')
+          deployment_id=$(echo $current_deployment | jq '.[0].id')
+
+          deployment_status="failure"
+          if [ "${{ steps.terraform_deploy.outcome }}" == "success" ];
+          then
+            deployment_status="success"
+          fi
+ 
+          curl -s -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}" \
+            https://api.github.com/repos/DFE-Digital/find-teacher-training/deployments/$deployment_id/statuses \
+            -d '{"state": "'$deployment_status'"}'


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

Split build and deploy jobs into separate actions, 
Deploy job can be reused for all 3 envs.
Trigger smoke tests after deploy action completes.

### Guidance to review

### Trello card
https://trello.com/c/Zn65eEdu/2349-paas-move-cypress-test-triggers-pipeline-to-github-actions

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
