### PR TITLE
2378 - Turn off University search results boosting

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -401,7 +401,7 @@ private
       base_query = base_query.where("latitude" => latitude)
       base_query = base_query.where("longitude" => longitude)
       base_query = base_query.where("radius" => radius_to_query)
-      base_query = base_query.where(expand_university: true)
+      base_query = base_query.where(expand_university: Settings.expand_university)
     end
 
     base_query = base_query.where("provider.provider_name" => provider) if provider.present?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ teacher_training_api:
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
 current_cycle: 2021
+expand_university: false # When true HEI institutions have search radii increased. See https://bat-design-history.netlify.app/find-teacher-training/search-results-locations/
 google:
   maps_api_key: replace_me
   maps_api_url: https://maps.googleapis.com/maps/api/staticmap

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -104,7 +104,7 @@ feature "Location filter", type: :feature do
             "filter[latitude]" => "51.4980188",
             "filter[radius]" => "50",
             "sort" => "distance",
-            "filter[expand_university]" => true,
+            "filter[expand_university]" => false,
           ),
         )
         .to_return(
@@ -327,7 +327,7 @@ feature "Location filter", type: :feature do
             "filter[latitude]" => "51.4980188",
             "filter[radius]" => "50",
             "sort" => "distance",
-            "filter[expand_university]" => true,
+            "filter[expand_university]" => false,
           ),
         )
         .to_return(

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -70,7 +70,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
-        "filter[expand_university]" => true,
+        "filter[expand_university]" => false,
       ),
     )
   end
@@ -83,7 +83,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
-        "filter[expand_university]" => true,
+        "filter[expand_university]" => false,
       ),
     )
   end
@@ -95,7 +95,7 @@ describe "Suggested salary searches" do
         "filter[latitude]" => 51.4980188,
         "filter[longitude]" => -0.1300436,
         "filter[radius]" => radius,
-        "filter[expand_university]" => true,
+        "filter[expand_university]" => false,
       ),
     )
   end

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -20,7 +20,12 @@ feature "suggested searches", type: :feature do
 
   def results_page_request(radius:, results_to_return:)
     stub_request(:get, courses_url)
-      .with(query: base_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius, "filter[expand_university]" => true))
+      .with(query: base_parameters.merge(
+        "filter[latitude]" => 51.4980188,
+        "filter[longitude]" => -0.1300436,
+        "filter[radius]" => radius,
+        "filter[expand_university]" => false,
+      ))
       .to_return(
         body: course_fixture_for(results: results_to_return),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },
@@ -38,7 +43,12 @@ feature "suggested searches", type: :feature do
 
   def suggested_search_count_request(radius:, results_to_return:)
     stub_request(:get, courses_url)
-      .with(query: suggested_search_count_parameters.merge("filter[latitude]" => 51.4980188, "filter[longitude]" => -0.1300436, "filter[radius]" => radius, "filter[expand_university]" => true))
+      .with(query: suggested_search_count_parameters.merge(
+        "filter[latitude]" => 51.4980188,
+        "filter[longitude]" => -0.1300436,
+        "filter[radius]" => radius,
+        "filter[expand_university]" => false,
+      ))
       .to_return(
         body: course_fixture_for(results: results_to_return),
         headers: { "Content-Type": "application/vnd.api+json; charset=utf-8" },


### PR DESCRIPTION
### Context
- Some providers have reported being confused by the ‘boosting’ of HEI search results, whereby their search radius is decreased and promoted higher up in search results.
- Decision has been made to turn this off for now with a view to fixing and turning on again later 🤞 


### Changes proposed in this pull request
- Temporarily stop asking the API to increase the radius of HEIs (aka universities)
- Create a flag in settings to easily switch this functionality on / off

### Guidance to review

### Trello card

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
