### PR TITLE
Adding smoke-tests manual dispatch workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,32 @@
+name: Smoke Tests Manual
+on: 
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment to run tests against (qa, staging or production)'
+        required: true
+
+jobs:
+  smoke_tests:
+    name: smoke-tests-${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+        with:
+          repository: DFE-Digital/find-teacher-training-tests
+          ref: refs/heads/master
+          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+
+      - name: Set Environment variable
+        run: |
+          echo "RAILS_ENV=$RAILS_ENV" >> $GITHUB_ENV
+          echo "CYPRESS_ENVIRONMENT=$RAILS_ENV" >> $GITHUB_ENV
+        env:
+          RAILS_ENV: ${{ github.event.inputs.environment }}
+
+      - name: Cypress Run against ${{ github.event.inputs.environment }}
+        id: cypress_run
+        run: |
+          npm install
+          npx cypress run


### PR DESCRIPTION
Checkout find-teacher-training-tests and run the smoke tests workflow in find-teacher-training repo

### Changes proposed in this pull request
Create a manual dispatch workflow to run smoke tests for different environments.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
