### PR TITLE
revert duration/duration_ms formatting for logstash

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,9 +1,5 @@
 if Settings.logstash.host && Settings.logstash.port
   logstash_formatter = proc do |event|
-    # The value here appears to break logging to logstash / elasticsearch
-    event["duration"] = event["duration_ms"]
-    event["duration_ms"] = nil
-
     # For some reason logstash / elasticsearch drops events where the payload
     # is a hash. These are more conveniently accessed at the top level of the
     # event, anyway, so we move it there.


### PR DESCRIPTION
Turns out this approach was not compatible with the standard way of logging and
can result in breaking the indexing for the 'duration' field, breaking
aggregation and other operations reliant on the 'duration' field. The correct
approach is to leave 'duration_ms', fix any discrepencies in the logit filters
to ensure that it's indexed as a number, and then use 'duration_ms' for
aggregation.

### Context

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
