### PR TITLE
Make Find phase banner consistent with Apply

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,9 +50,9 @@
     <div class="govuk-width-container">
       <div class="govuk-phase-banner">
         <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">BETA</strong>
+          <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
           <span class="govuk-phase-banner__text">
-            This is a new service - <%= govuk_link_to "take part in a short survey to tell us what you think", "https://docs.google.com/forms/d/e/1FAIpQLSeOpGpNzX19WUH-Hv0LnZmYKXnHhoLvK0_TH66xP8uNPlSpMw/viewform" %>
+            This is a new service – <%= link_to "give feedback or report a problem", "mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training", class: 'govuk-link govuk-link--no-visited-state' %>
           </span>
         </p>
       </div>


### PR DESCRIPTION
### Context

The Find and Apply Beta banners behave inconsistently. Find prompts users to fill out a Google form and Apply prompts them to raise a support ticket.

Because the services have merged, users don't typically differentiate between them, it doesn't make sense to capture Find satisfaction in a separate Google form. (The inconsistency is also confusing for users who learned to contact support via the Apply beta banner.)

### Changes proposed in this pull request

Updates phase banner text to use the same as that used for Apply (except the email subject references Find service not Apply)

### Guidance to review

### Trello card

https://trello.com/c/RjtSqW9k

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
