### PR TITLE
Correct refs for deployments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
+      - uses: softprops/turnstyle@v1
+        name: Wait for other runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           step: start
           token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           env: ${{ github.event.inputs.environment }}
+          ref: ${{ github.event.inputs.sha }}
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -90,7 +91,7 @@ jobs:
           intervalSeconds: 15
 
       - name: Trigger ${{ env.NEXT_ENV }} Deployment
-        if: ${{ steps.wait_for_smoke_tests.outputs.conclusion == 'success' && env.NEXT_ENV != '' }}
+        if: ${{ steps.wait_for_smoke_tests.outputs.conclusion == 'success' && env.NEXT_ENV != '' && github.ref == 'refs/heads/master' }}
         uses: benc-uk/workflow-dispatch@v1.1
         with:
           workflow: Deploy to PaaS
@@ -106,3 +107,4 @@ jobs:
           env: ${{ github.event.inputs.environment }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          ref: ${{ github.event.inputs.sha }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,6 +11,11 @@ jobs:
     name: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - uses: softprops/turnstyle@v1
+        name: Wait for other runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v2.3.3
         with:


### PR DESCRIPTION
### Context

Deployments under [https://github.com/DFE-Digital/find-teacher-training/deployments] was always showing the HEAD ref of master branch, which was not correct.

### Changes proposed in this pull request

Tag deployment with the correct commit sha.

Also add turnstyle action on smoke-tests and build workflow to run the workflows sequentially. 

### Guidance to review

### Trello card

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
