### PR TITLE
Redirect University of Boltons courses to Apply's sign up page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,14 +25,9 @@ class CoursesController < ApplicationController
 
     Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
 
-    # If course provider is University of Bolton and Maths or Computing
-    if course.provider.provider_code == "8N5" && (course.course_code == "V595" || course.course_code == "Y710")
-      case course.course_code
-      when "V595"
-        redirect_to "https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1101-D&code2=0001"
-      when "Y710"
-        redirect_to "https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1100-D&code2=0001"
-      end
+    # If course provider is University of Bolton
+    if course.provider.provider_code == "8N5"
+      redirect_to "https://www.apply-for-teacher-training.service.gov.uk/candidate/account?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
     else
       redirect_to "https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
     end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -7,7 +7,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/courses_controller.rb",
-      "line": 37,
+      "line": 32,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(\"https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
       "render_path": null,
@@ -19,8 +19,28 @@
       "user_input": "Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code",
       "confidence": "High",
       "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "c073e6f06f02705207d657718febbff481aa5b0ac08648aa35fecabc47f8b2b5",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/courses_controller.rb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(\"https://www.apply-for-teacher-training.service.gov.uk/candidate/account?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CoursesController",
+        "method": "apply"
+      },
+      "user_input": "Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code",
+      "confidence": "High",
+      "note": ""
     }
   ],
-  "updated": "2020-07-20 13:45:35 +0100",
-  "brakeman_version": "4.8.2"
+  "updated": "2020-10-29 14:51:03 +0000",
+  "brakeman_version": "4.10.0"
 }

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe CoursesController do
       let(:provider) { build(:provider, provider_code: "8N5") }
       let(:course) { build(:course, course_code: "V595", provider: provider) }
 
-      it "redirects to University of Bolton's applications service" do
+      it "redirects to the apply create account page" do
         get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
-        expect(response).to redirect_to("https://evision.bolton.ac.uk/urd/sits.urd/run/siw_ipp_lgn.login?process=siw_ipp_app&code1=1101-D&code2=0001")
+        expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/account?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
       end
     end
 


### PR DESCRIPTION
### Context

The University of Bolton are only using Apply to manage applications for their courses this year.

Due to this, we should skip the Apply on Apply or UCAS page. This means the candidate should be sent to Apply's sign up page. 

### Changes proposed in this pull request

- Send candidates for UOB's courses to the Apply Sign up page

### Guidance to review

Do you think we should have a before action on Apply to ensure candidates can't access the Apply on Apply/UCAS page in the Apply application? Or is that overkill?

### Trello card

https://trello.com/c/4OiUSedJ/2323-dev-divert-course-pages-for-bolton

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
