### PR TITLE
Authenticate before pulling images from DockerHub

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,8 @@ jobs:
           TF_VAR_paas_password: ${{ secrets[format('CF_PASSWORD_{0}', env.DEPLOY_ENV)] }}
           TF_VAR_paas_logstash_url: ${{ secrets.LOGSTASH_URL }}
           TF_VAR_paas_app_docker_image: ${{ env.DOCKER_IMAGE }}
+          TF_VAR_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          TF_VAR_dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1.1

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -35,6 +35,7 @@ resource cloudfoundry_app web_app {
   service_binding {
     service_instance = cloudfoundry_user_provided_service.logging.id
   }
+  docker_credentials = var.docker_credentials
 }
 
 resource cloudfoundry_route web_app_cloudapps_digital_route {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -18,6 +18,8 @@ variable logstash_url {}
 
 variable app_environment_variables { type = map }
 
+variable docker_credentials { type = map }
+
 locals {
   web_app_name          = "find-${var.app_environment}"
   web_app_start_command = "bundle exec rails server -b 0.0.0.0"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -31,4 +31,5 @@ module paas {
   web_app_memory            = var.paas_web_app_memory
   logstash_url              = var.paas_logstash_url
   app_environment_variables = local.paas_app_environment_variables
+  docker_credentials        = local.docker_credentials
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -18,9 +18,17 @@ variable paas_app_config_file { default = "./workspace_variables/app_config.yml"
 
 variable paas_app_secrets_file { default = "./app_secrets.yml" }
 
+variable dockerhub_username {}
+
+variable dockerhub_password {}
+
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
   app_config                     = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment]
   app_secrets                    = yamldecode(file(var.paas_app_secrets_file))
   paas_app_environment_variables = merge(local.app_config, local.app_secrets)
+  docker_credentials = {
+    username = var.dockerhub_username
+    password = var.dockerhub_password
+  }
 }


### PR DESCRIPTION
### Context

DockerHub requires authentication when pulling images to overcome rate limit restrictions.

### Changes proposed in this pull request

Configure PaaS to authenticate with DockerHub before pulling images.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
