### PR TITLE
Authenticate with DockerHub

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -173,6 +173,27 @@
     "skylightEnable":{
       "defaultValue": false,
       "type": "bool"
+    },
+    "dockerRegistryUrl": {
+      "type": "string",
+      "defaultValue": "https://index.docker.io",
+      "metadata": {
+          "description": "URL of the docker registry, eg: https://index.docker.io"
+      }
+    },
+    "dockerRegistryUsername": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Username to login to the docker registry"
+      }
+    },
+    "dockerRegistryPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+          "description": "Password to login to the docker registry"
+      }
     }
   },
   "variables": {
@@ -335,6 +356,18 @@
               {
                 "name": "SETTINGS__DISPLAY_APPLY_BUTTON",
                 "value":  "[parameters('settingsDisplayApplyButton')]"
+              },
+              {
+                "name": "DOCKER_REGISTRY_SERVER_URL",
+                "value": "[parameters('dockerRegistryUrl')]"
+              },
+              {
+                  "name": "DOCKER_REGISTRY_SERVER_USERNAME",
+                  "value": "[parameters('dockerRegistryUsername')]"
+              },
+              {
+                  "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
+                  "value": "[parameters('dockerRegistryPassword')]"
               }
             ]
           },


### PR DESCRIPTION
### Context
see https://azure.github.io/AppService/2020/10/15/Docker-Hub-authenticated-pulls-on-App-Service.html

### Changes proposed in this pull request
Authenticate with DockerHub registry when starting Azure App Service.

Change has been tested in Apply and Find QA.

### Guidance to review

### Trello card
https://trello.com/c/9hLZbutC/2429-find-pipeline-and-arm-template-changes-to-include-dockerhub-credentials-to-overcome-rate-limit

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
