### PR TITLE
COMMIT_SHA as a docker build argument

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: ${{ env.DOCKERHUB_REPOSITORY }}
           tags: ${{ format('paas-{0}', github.sha) }}
+          build_args: COMMIT_SHA=${{ github.sha }}
 
       - name: Set Environment variable
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ruby:2.6.5-alpine
+ARG COMMIT_SHA
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
@@ -23,6 +24,8 @@ ADD yarn.lock $APP_HOME/yarn.lock
 RUN yarn install --frozen-lockfile
 
 ADD . $APP_HOME/
+
+ENV SHA=${COMMIT_SHA}
 
 RUN bundle exec rake assets:precompile
 

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -15,7 +15,7 @@ class HeartbeatController < ActionController::API
   end
 
   def sha
-    render json: { sha: commit_sha }
+    render json: { sha: ENV["SHA"] }
   end
 
 private
@@ -25,13 +25,5 @@ private
     response.success?
   rescue StandardError
     false
-  end
-
-  def commit_sha
-    File.read(commit_sha_path).strip
-  end
-
-  def commit_sha_path
-    Rails.root.join(Settings.commit_sha_file)
   end
 end

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ steps:
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=IMAGE_NAME_WITH_TAG;]$IMAGE_NAME_WITH_TAG"
     echo '$(System.PullRequest.SourceBranch)'> $(build.artifactstagingdirectory)/prbranch.info
-    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: docker pull $(IMAGE_NAME):latest || true
@@ -33,7 +32,7 @@ steps:
     command: Build an image
     imageName: $(IMAGE_NAME)
     dockerFile: Dockerfile
-    arguments: '--cache-from $(IMAGE_NAME):latest'
+    arguments: '--cache-from $(IMAGE_NAME):latest --build-arg COMMIT_SHA=$(Build.SourceVersion)'
     addDefaultLabels: false
 
 - task: Docker@1

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,6 @@ logstash:
   port: # Our port here
   ssl_enable: true
 log_level: info
-commit_sha_file: COMMIT_SHA
 cycle_has_ended:
 cycle_ending_soon:
 display_apply_button: true

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -11,11 +11,9 @@ describe "heartbeat requests" do
 
   describe "GET /sha" do
     around :each do |example|
-      File.open("COMMIT_SHA", "w") { |f| f.write "some-sha" }
+      ENV["SHA"] = "some-sha"
 
       example.run
-
-      File.delete("COMMIT_SHA")
     end
 
     it "returns sha" do


### PR DESCRIPTION
### Changes proposed in this pull request
GET `/sha` to work on PaaS
Set COMMIT_SHA as a docker build arg.
Read `SHA` from env var instead of file.

### Trello card

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
