### PR TITLE
Use same number of instances on staging as production

### DIFF
--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -1,5 +1,5 @@
 # PaaS
 paas_sso_code          = ""
 paas_app_environment   = "staging"
-paas_web_app_instances = 1
+paas_web_app_instances = 2
 paas_web_app_memory    = 512


### PR DESCRIPTION
### Context

Staging and production should be as similar as possible, to make sure the environments don't differ in subtle ways.

### Changes proposed in this pull request

Up the number of instances on staging to 2, like prod.

### Guidance to review

OK?

### Trello card

N/A

