### PR TITLE
Display 404 page when candidate attempts to apply to non-existent course

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -26,5 +26,7 @@ class CoursesController < ApplicationController
     Rails.logger.info("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
 
     redirect_to "https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}"
+  rescue JsonApiClient::Errors::NotFound
+    render template: "errors/not_found", status: :not_found, formats: [:html]
   end
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -4,32 +4,48 @@ RSpec.describe CoursesController do
   let(:provider) { build(:provider) }
   let(:course) { build(:course, provider: provider) }
 
-  before do
-    stub_api_v3_resource(
-      type: Course,
-      params: {
-        recruitment_cycle_year: Settings.current_cycle,
-        provider_code: course.provider_code,
-        course_code: course.course_code,
-      },
-      resources: course,
-      include: %w[provider],
-    )
-  end
-
   describe "#apply" do
-    let(:logger) { double(:logger) }
+    context "when course is found" do
+      let(:logger) { double(:logger) }
 
-    it "redirects to correct apply destination" do
-      get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
-      expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
+      before do
+        stub_api_v3_resource(
+          type: Course,
+          params: {
+            recruitment_cycle_year: Settings.current_cycle,
+            provider_code: course.provider_code,
+            course_code: course.course_code,
+          },
+          resources: course,
+          include: %w[provider],
+        )
+      end
+
+      it "redirects to correct apply destination" do
+        get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+        expect(response).to redirect_to("https://www.apply-for-teacher-training.service.gov.uk/candidate/apply?providerCode=#{course.provider.provider_code}&courseCode=#{course.course_code}")
+      end
+
+      it "writes to log" do
+        allow(Rails).to receive(:logger).and_return(logger)
+        expect(logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
+
+        get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+      end
     end
 
-    it "writes to log" do
-      allow(Rails).to receive(:logger).and_return(logger)
-      expect(logger).to receive(:info).with("Course apply conversion. Provider: #{course.provider.provider_code}. Course: #{course.course_code}")
+    context "when a course is not found" do
+      before do
+        stub_request(
+          :get,
+          "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers/#{course.provider_code}/courses/#{course.course_code}?include=provider",
+        ).to_raise(JsonApiClient::Errors::NotFound)
+      end
 
-      get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+      it "redirects to the not found page" do
+        get :apply, params: { provider_code: course.provider_code, course_code: course.course_code }
+        expect(response.status).to eq(404)
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Possibly some candidates have bookmarked  course apply links for courses that no longer exist. 

### Changes proposed in this pull request
Rescue `JsonApiClient::Errors::NotFound` in `CoursesController#apply` and render the 404 page

### Guidance to review
Fire up the app locally and try to apply to a non-existent course e.g. http://localhost:3002/course/T92/X13DD/apply.
You should be sent to the 404 page. 

### Trello card
https://trello.com/c/FBdYmobu/2490-small-500-error-occurs-when-candidate-attempts-to-apply-to-a-non-existent-course

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [ ] Product review
