### PR TITLE
Use prod Teacher training API url across all Find envs

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,5 +1,5 @@
-base_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
+base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.publish-teacher-training-courses.service.gov.uk
 valid_referers:
-  - https://www.qa.find-postgraduate-teacher-training.education.gov.uk
+  - https://qa.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/qa_paas.yml
+++ b/config/settings/qa_paas.yml
@@ -1,5 +1,0 @@
-base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
-teacher_training_api:
-  base_url: https://api.qa.publish-teacher-training-courses.service.gov.uk
-valid_referers:
-  - https://qa.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/research.yml
+++ b/config/settings/research.yml
@@ -1,3 +1,0 @@
-base_url: https://s121d03-research-find-as.azurewebsites.net
-teacher_training_api:
-  base_url: https://s121d03-research-ttapi-as.azurewebsites.net

--- a/config/settings/rollover.yml
+++ b/config/settings/rollover.yml
@@ -1,3 +1,0 @@
-base_url: https://s121d04-rollover-find-as.azurewebsites.net
-teacher_training_api:
-  base_url: https://s121d04-rollover-ttapi-as.azurewebsites.net

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,5 +1,5 @@
-base_url: https://www.staging.find-postgraduate-teacher-training.service.gov.uk
+base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api.staging.publish-teacher-training-courses.service.gov.uk
+  base_url: https://api.publish-teacher-training-courses.service.gov.uk
 valid_referers:
-  - https://www.staging.find-postgraduate-teacher-training.education.gov.uk
+  - https://staging.find-postgraduate-teacher-training.education.gov.uk


### PR DESCRIPTION
### Changes proposed in this pull request

Use the prod url for teacher training API, similar to Apply.
Remove not in use environment settings.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
