### PR TITLE
Send a Sentry error when an error is returned in the body of the gcp response

### DIFF
--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -9,10 +9,12 @@ class LocationSuggestion
 
       response = get("#{Settings.google.places_api_path}?#{query.to_query}")
 
-      if response.success?
+      if response["predictions"].present?
         JSON.parse(response.body)["predictions"]
           .map(&format_prediction)
           .take(5)
+      elsif response["error_message"].present?
+        Raven.send_event(error_message: response["error_message"])
       end
     end
 


### PR DESCRIPTION
### Context

At the moment, when the locations autocomplete fails, it fails silently. This is because GCP returns errors in the body (see image).

![image](https://user-images.githubusercontent.com/42515961/99292480-2c839580-2839-11eb-9edb-5990514ff041.png)

### Changes proposed in this pull request

- Check the body for an error_message. If one is present, then send a Sentry error with the GCP error_message.

### Trello card

https://trello.com/c/fH1nK2ko/2498-log-sentry-error-when-autocomplete-fails

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
