### PR TITLE
Use prepare-matrix action from bat-infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,8 @@ jobs:
     outputs:
       environments: ${{ steps.select-environments.outputs.environments }}
     steps:
-      - name:  Prepare Environment Matrix
-        shell: pwsh
-        id:    select-environments
-        run: |
-          $inputs = '${{ toJson(github.event.inputs) }}' | ConvertFrom-Json -AsHashtable
-          $environments = @('qa', 'staging', 'production') | where { $inputs[$_] -eq 'true' }
-          echo "::set-output name=environments::$(@{ environment = $environments } | ConvertTo-Json -Compress)"
+      - id:   select-environments
+        uses: DFE-Digital/bat-infrastructure/actions/prepare-environment-matrix@main
 
   deploy:
     name: ${{ matrix.environment }} Deployment


### PR DESCRIPTION
Use the reusable action bat-infrastructure for preparing the environment matrix.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
