### PR TITLE
Add feedback component which redirects candidates to apply

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,14 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 def ruby_version
-    tool_versions_file = File.join(__dir__, '.tool-versions')
-    ruby_version = IO.foreach(tool_versions_file, "\n") do |tool_version| 
-            tool = Hash[*tool_version.split(' ')]
-            break tool['ruby'] if tool['ruby']
-    end
+  tool_versions_file = File.join(__dir__, '.tool-versions')
+  ruby_version = IO.foreach(tool_versions_file, "\n") do |tool_version|
+    tool = Hash[*tool_version.split(' ')]
+    break tool['ruby'] if tool['ruby']
+  end
 end
 
-ruby "#{ruby_version()}"
+ruby ruby_version.to_s
 
 gem 'pkg-config', '~> 1.4.4'
 
@@ -80,7 +80,7 @@ gem 'rubypants'
 gem 'skylight'
 
 # Allows the creation of components which encapsulate and test logic in views
-gem "view_component"
+gem 'view_component'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/app/components/feedback_component.html.erb
+++ b/app/components/feedback_component.html.erb
@@ -4,7 +4,7 @@
 
       <%= govuk_link_to(
         'How can we improve this page? (Opens in a new tab)',
-          "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&find_controller=#{@controller}",
+          "https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=#{@path}&find_controller=#{@controller}",
         class: 'govuk-!-margin-top-4',
         data: { qa:'feedback-link' },
         target: '_blank',

--- a/app/components/feedback_component.html.erb
+++ b/app/components/feedback_component.html.erb
@@ -4,7 +4,7 @@
 
       <%= govuk_link_to(
         'How can we improve this page? (Opens in a new tab)',
-          "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&original_controller=#{@original_controller}",
+          "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&find_controller=#{@controller}",
         class: 'govuk-!-margin-top-4',
         data: { qa:'feedback-link' },
         target: '_blank',

--- a/app/components/feedback_component.html.erb
+++ b/app/components/feedback_component.html.erb
@@ -1,0 +1,15 @@
+<div class="govuk-width-container">
+  <div class="app-feedback__container">
+    <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
+
+      <%= link_to(
+        'How can we improve this section? (Opens in a new tab)',
+          "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&original_controller=#{@original_controller}",
+        class: 'govuk-!-margin-top-4 govuk-link',
+        data: { qa:'feedback-link' },
+        target: '_blank',
+        rel: 'noopener'
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/components/feedback_component.html.erb
+++ b/app/components/feedback_component.html.erb
@@ -2,10 +2,10 @@
   <div class="app-feedback__container">
     <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
 
-      <%= link_to(
+      <%= govuk_link_to(
         'How can we improve this section? (Opens in a new tab)',
           "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&original_controller=#{@original_controller}",
-        class: 'govuk-!-margin-top-4 govuk-link',
+        class: 'govuk-!-margin-top-4',
         data: { qa:'feedback-link' },
         target: '_blank',
         rel: 'noopener'

--- a/app/components/feedback_component.html.erb
+++ b/app/components/feedback_component.html.erb
@@ -3,7 +3,7 @@
     <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-4">
 
       <%= govuk_link_to(
-        'How can we improve this section? (Opens in a new tab)',
+        'How can we improve this page? (Opens in a new tab)',
           "https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=#{@path}&original_controller=#{@original_controller}",
         class: 'govuk-!-margin-top-4',
         data: { qa:'feedback-link' },

--- a/app/components/feedback_component.rb
+++ b/app/components/feedback_component.rb
@@ -1,10 +1,10 @@
 class FeedbackComponent < ViewComponent::Base
   include ViewHelper
 
-  attr_reader :path, :original_controller
+  attr_reader :path, :controller
 
-  def initialize(path:, original_controller:)
+  def initialize(path:, controller:)
     @path = path
-    @original_controller = original_controller
+    @controller = controller
   end
 end

--- a/app/components/feedback_component.rb
+++ b/app/components/feedback_component.rb
@@ -1,0 +1,10 @@
+class FeedbackComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :path, :original_controller
+
+  def initialize(path:, original_controller:)
+    @path = path
+    @original_controller = original_controller
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,4 +17,8 @@ class ApplicationController < ActionController::Base
 
     payload[:request_id] = RequestStore.store[:request_id]
   end
+
+  def render_feedback_component
+    @render_feedback_component = true
+  end
 end

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,8 @@
 class CoursesController < ApplicationController
   decorates_assigned :course
 
+  before_action :render_feedback_component, only: :show
+
   def show
     @course = Course
       .includes(:subjects)

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,6 @@
 class ResultsController < ApplicationController
+  before_action :render_feedback_component
+
   def index
     service = DeprecatedParametersService.new(parameters: request.query_parameters)
     if service.deprecated?

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -3,12 +3,16 @@ module ViewHelper
     mail_to(email, name, html_options.merge(class: 'govuk-link'), &block)
   end
 
-  def govuk_link_to(body, url = body, html_options = { class: 'govuk-link' })
-    link_to body, url, html_options
+  def govuk_link_to(body, url, html_options = {}, &_block)
+    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
+
+    return link_to(url, html_options) { yield } if block_given?
+
+    link_to(body, url, html_options)
   end
 
   def govuk_back_link_to(url, link_text = 'Back')
-    govuk_link_to(link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' })
+    link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
   end
 
   def permitted_referrer?
@@ -24,5 +28,15 @@ module ViewHelper
 
   def bat_contact_mail_to(name = nil, subject: nil, link_class: 'govuk-link')
     mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class
+  end
+
+private
+
+  def prepend_css_class(css_class, current_class)
+    if current_class
+      current_class.prepend("#{css_class} ")
+    else
+      css_class
+    end
   end
 end

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -4,8 +4,5 @@
 <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
 <p class="govuk-body">Register with <%= link_to 'Get Into Teaching', 'https://getintoteaching.education.gov.uk/user/register', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
 
-<h4 class="govuk-heading-m">Website support</h4>
-<p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>
-
 <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
 <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -72,6 +72,15 @@
       </main>
     </div>
 
+    <% if @render_feedback_component %>
+      <%= render(
+        FeedbackComponent.new(
+          path: request.env['PATH_INFO'],
+          original_controller: params[:controller],
+        )
+      ) %>
+    <% end %>
+
     <footer class="govuk-footer govuk-!-display-none-print" role="contentinfo">
       <div class="govuk-width-container">
         <div class="govuk-footer__meta">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,7 +76,7 @@
       <%= render(
         FeedbackComponent.new(
           path: request.env['PATH_INFO'],
-          original_controller: params[:controller],
+          controller: params[:controller],
         )
       ) %>
     <% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -10,7 +10,7 @@
         <li data-qa="provider_suggestion">
           <%= govuk_link_to "#{provider.provider_name} (#{provider.provider_code})",
             results_path(filter_params_without_previous_parameters.merge(query: provider.provider_name)),
-            { class: "govuk-link", data: { qa: "provider_suggestion__link" } }
+            { data: { qa: "provider_suggestion__link" } }
           %>
         </li>
       <% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -18,6 +18,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/toggle";
 @import "components/list";
 @import "components/search-results";
+@import "components/feedback";
 @import "patterns/course-parts";
 @import "patterns/success-summary";
 @import "patterns/definition-list";

--- a/app/webpacker/styles/components/_feedback.scss
+++ b/app/webpacker/styles/components/_feedback.scss
@@ -1,0 +1,10 @@
+.app-feedback__container {
+  @include govuk-clearfix;
+  align-items: center;
+  background-color: govuk-colour("light-grey");
+  box-sizing: border-box;
+  flex-wrap: wrap;
+  outline: 0;
+  padding: govuk-spacing(2) govuk-spacing(5);
+  min-height: 80px;
+}

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -238,7 +238,7 @@ describe 'Course show', type: :feature do
 
       expect(course_page).to have_training_location_guidance
 
-      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/course/T92/X130&find_controller=courses")
+      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/course/T92/X130&find_controller=courses")
     end
 
     context 'End of cycle' do

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -237,6 +237,8 @@ describe 'Course show', type: :feature do
       expect(course_page).not_to have_end_of_cycle_notice
 
       expect(course_page).to have_training_location_guidance
+
+      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/course/T92/X130&original_controller=courses")
     end
 
     context 'End of cycle' do

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -238,7 +238,7 @@ describe 'Course show', type: :feature do
 
       expect(course_page).to have_training_location_guidance
 
-      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/course/T92/X130&find_controller=courses")
+      expect(course_page.feedback_link[:href]).to eq('https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/course/T92/X130&find_controller=courses')
     end
 
     context 'End of cycle' do

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -238,7 +238,7 @@ describe 'Course show', type: :feature do
 
       expect(course_page).to have_training_location_guidance
 
-      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/course/T92/X130&original_controller=courses")
+      expect(course_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/course/T92/X130&find_controller=courses")
     end
 
     context 'End of cycle' do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -87,6 +87,10 @@ describe 'results', type: :feature do
         )
       expect(results_page.subjects_filter.extra_subjects.text).to eq('and 37 more...')
     end
+
+    it "renders the feedback component" do
+      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/results&original_controller=results")
+    end
   end
 
   describe 'filters defaults with query string' do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -89,7 +89,7 @@ describe 'results', type: :feature do
     end
 
     it "renders the feedback component" do
-      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/results&find_controller=results")
+      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/results&find_controller=results")
     end
   end
 

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -89,7 +89,7 @@ describe 'results', type: :feature do
     end
 
     it "renders the feedback component" do
-      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/results&original_controller=results")
+      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/find-feedback?path=/results&find_controller=results")
     end
   end
 

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -88,8 +88,8 @@ describe 'results', type: :feature do
       expect(results_page.subjects_filter.extra_subjects.text).to eq('and 37 more...')
     end
 
-    it "renders the feedback component" do
-      expect(results_page.feedback_link[:href]).to eq("https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/results&find_controller=results")
+    it 'renders the feedback component' do
+      expect(results_page.feedback_link[:href]).to eq('https://www.apply-for-teacher-training.service.gov.uk/candidate/find-feedback?path=/results&find_controller=results')
     end
   end
 

--- a/spec/site_prism/page_objects/page/course.rb
+++ b/spec/site_prism/page_objects/page/course.rb
@@ -46,6 +46,7 @@ module PageObjects
       element :back_link, '[data-qa=page-back]'
       element :end_of_cycle_notice, '[data-qa=course__end_of_cycle_notice]'
       element :training_location_guidance, '[data-qa=course__training_location_guidance]'
+      element :feedback_link, "[data-qa=feedback-link]"
     end
   end
 end

--- a/spec/site_prism/page_objects/page/course.rb
+++ b/spec/site_prism/page_objects/page/course.rb
@@ -46,7 +46,7 @@ module PageObjects
       element :back_link, '[data-qa=page-back]'
       element :end_of_cycle_notice, '[data-qa=course__end_of_cycle_notice]'
       element :training_location_guidance, '[data-qa=course__training_location_guidance]'
-      element :feedback_link, "[data-qa=feedback-link]"
+      element :feedback_link, '[data-qa=feedback-link]'
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -106,6 +106,7 @@ module PageObjects
       section :sort_form, SortFormSection, '[data-qa="sort-form"]'
 
       element :sorted_by_distance, '.search-results-header', text: 'Sorted by distance'
+      element :feedback_link, "[data-qa=feedback-link]"
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -106,7 +106,7 @@ module PageObjects
       section :sort_form, SortFormSection, '[data-qa="sort-form"]'
 
       element :sorted_by_distance, '.search-results-header', text: 'Sorted by distance'
-      element :feedback_link, "[data-qa=feedback-link]"
+      element :feedback_link, '[data-qa=feedback-link]'
     end
   end
 end


### PR DESCRIPTION
### Context

We don't have a good mechanism for candidates to provide feedback for the Find service. 

This PR adds a FeedbackComponent which renders on the courses show and results page.

It links to an Apply endpoint and opens in a new tab.

### Changes proposed in this pull request

- Add the component
- Add tests
- A bit of a refactor of the view helper

### Guidance to review

Does this all seem reasonable?

### Trello card

https://trello.com/c/DrnKcnnW/2466-%F0%9F%93%9D-%F0%9F%8F%88-dev-football-add-feedback-prompt-find

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
