### PR TITLE
Move CSS into component partials

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -50,7 +50,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Contents</h2>
-      <ul class="govuk-list govuk-list--dash course-contents govuk-!-margin-bottom-8">
+      <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
         <% if course.about_course.present? %>
           <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
         <% end %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -16,6 +16,8 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/map";
 @import "components/accordion";
 @import "components/toggle";
+@import "components/list";
+@import "components/search-results";
 @import "patterns/course-parts";
 @import "patterns/success-summary";
 @import "patterns/definition-list";
@@ -23,132 +25,6 @@ $govuk-image-url-function: frontend-image-url;
 @import "patterns/pagination";
 @import "patterns/text-ellipsis";
 
-.govuk-list--dash {
-  margin-bottom: govuk-spacing(8);
-  padding-left: govuk-spacing(3);
-
-  li {
-    position: relative;
-
-    &:before {
-      color: govuk-colour("dark-grey");
-      content: "\2013";
-      left: -16px;
-      position: absolute;
-      top: 0;
-    }
-  }
-}
-
-.app-google-map {
-  display: none;
-
-  .js-enabled & {
-    display: block;
-    margin-bottom: govuk-spacing(6);
-    padding-bottom: 66.6%;
-    width: 100%;
-  }
-}
-
-.govuk-list li > .govuk-body:last-child {
-  margin-bottom: 0;
-}
-
-// Search results view
-.search-results-filters {
-  display: block;
-}
-
-.search-results {
-  border-top: 1px solid $govuk-border-colour;
-
-  > li {
-    @include govuk-responsive-padding(4, "top");
-    @include govuk-responsive-padding(4, "bottom");
-    border-bottom: 1px solid $govuk-border-colour;
-    margin: 0;
-  }
-
-  &__count {
-    float: left;
-  }
-
-  &__new-search {
-    float: right;
-  }
-}
-
-.search-result-link {
-  text-decoration: none;
-
-  .search-result-link-name {
-    text-decoration: underline;
-  }
-}
-
-.search-results-header {
-  border-top: 1px solid $govuk-border-colour;
-  padding-bottom: govuk-spacing(2);
-
-  @include govuk-media-query($from: desktop) {
-    padding-top: govuk-spacing(2);
-  }
-
-  &__cta {
-    margin: govuk-spacing(1) 0;
-    display: none;
-
-    .js-enabled & {
-      display: block;
-    }
-  }
-
-  .govuk-form {
-    @include mq($from: desktop) {
-      text-align: right;
-    }
-  }
-
-  .govuk-form-group {
-    clear: both;
-    display: inline-block;
-    margin-bottom: 0;
-    margin-top: govuk-spacing(2);
-
-    @include mq($from: desktop) {
-      margin: 0;
-    }
-  }
-
-  .govuk-button {
-    float: right;
-    margin: govuk-spacing(2) 0 0 0;
-
-    @include mq($from: desktop) {
-      margin: 0 0 0 govuk-spacing(2);
-    }
-
-    .js-enabled & {
-      display: none;
-    }
-  }
-
-  select {
-    width: 100%;
-
-    @include mq($from: desktop) {
-      width: 220px;
-    }
-  }
-
-  .sortedby-label {
-    @include mq($from: desktop) {
-      display: inline;
-      margin-right: 0.5em;
-    }
-  }
-}
 
 .override-button-default {
   background: none !important;

--- a/app/webpacker/styles/components/_list.scss
+++ b/app/webpacker/styles/components/_list.scss
@@ -1,0 +1,21 @@
+
+.app-list--dash {
+  margin-bottom: govuk-spacing(8);
+  padding-left: govuk-spacing(3);
+
+  li {
+    position: relative;
+
+    &:before {
+      color: govuk-colour("dark-grey");
+      content: "\2013";
+      left: -16px;
+      position: absolute;
+      top: 0;
+    }
+  }
+}
+
+.govuk-list li > .govuk-body:last-child {
+  margin-bottom: 0;
+}

--- a/app/webpacker/styles/components/_map.scss
+++ b/app/webpacker/styles/components/_map.scss
@@ -105,3 +105,14 @@
     margin-bottom: -10px;
   }
 }
+
+.app-google-map {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+    margin-bottom: govuk-spacing(6);
+    padding-bottom: 66.6%;
+    width: 100%;
+  }
+}

--- a/app/webpacker/styles/components/_search-results.scss
+++ b/app/webpacker/styles/components/_search-results.scss
@@ -1,0 +1,94 @@
+// Search results view
+.search-results-filters {
+  display: block;
+}
+
+.search-results {
+  border-top: 1px solid $govuk-border-colour;
+
+  > li {
+    @include govuk-responsive-padding(4, "top");
+    @include govuk-responsive-padding(4, "bottom");
+    border-bottom: 1px solid $govuk-border-colour;
+    margin: 0;
+  }
+
+  &__count {
+    float: left;
+  }
+
+  &__new-search {
+    float: right;
+  }
+}
+
+.search-result-link {
+  text-decoration: none;
+
+  .search-result-link-name {
+    text-decoration: underline;
+  }
+}
+
+.search-results-header {
+  border-top: 1px solid $govuk-border-colour;
+  padding-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($from: desktop) {
+    padding-top: govuk-spacing(2);
+  }
+
+  &__cta {
+    margin: govuk-spacing(1) 0;
+    display: none;
+
+    .js-enabled & {
+      display: block;
+    }
+  }
+
+  .govuk-form {
+    @include mq($from: desktop) {
+      text-align: right;
+    }
+  }
+
+  .govuk-form-group {
+    clear: both;
+    display: inline-block;
+    margin-bottom: 0;
+    margin-top: govuk-spacing(2);
+
+    @include mq($from: desktop) {
+      margin: 0;
+    }
+  }
+
+  .govuk-button {
+    float: right;
+    margin: govuk-spacing(2) 0 0 0;
+
+    @include mq($from: desktop) {
+      margin: 0 0 0 govuk-spacing(2);
+    }
+
+    .js-enabled & {
+      display: none;
+    }
+  }
+
+  select {
+    width: 100%;
+
+    @include mq($from: desktop) {
+      width: 220px;
+    }
+  }
+
+  .sortedby-label {
+    @include mq($from: desktop) {
+      display: inline;
+      margin-right: 0.5em;
+    }
+  }
+}


### PR DESCRIPTION
This moves some CSS which was in `application.scss` into separate partials, named after their components.

`govuk-list--dash` is renamed to `app-list--dash` to follow the [Design System convention](https://design-system.service.gov.uk/get-started/extending-and-modifying-components/) that the `govuk-` prefix is changed to `app-` for app-specific modifiers.