### PR TITLE
Bugfix: fieldset legend spacing

### DIFF
--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -17,7 +17,7 @@
       <%= render "shared/hidden_previous_fields", form: form %>
       <fieldset class="govuk-fieldset" role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-heading-xl">Find courses by location or by training provider</h1>
+          <h1 class="govuk-fieldset__heading">Find courses by location or by training provider</h1>
         </legend>
         <div class="govuk-form-group<%= " govuk-form-group--error" if flash[:error] %>" id="search-options">
           <% if flash[:error] and location_error? === false and provider_error? === false%>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -11,8 +11,8 @@
     <%= form_with url: qualification_path, method: :post, data: { "ga-event-form" => "Qualification" } do |form| %>
       <%= render "shared/hidden_fields", exclude_keys: ["qualifications"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-        <legend>
-          <h1 class="govuk-heading-xl" data-qa="heading">What you will get</h1>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading" data-qa="heading">What you will get</h1>
         </legend>
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -10,8 +10,8 @@
     <%= form_with url: studytype_path, method: :post do |form| %>
       <%= render "shared/hidden_fields", exclude_keys: ["fulltime", "parttime"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
-        <legend>
-          <h1 class="govuk-heading-xl" data-qa="heading">Study type</h1>
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+          <h1 class="govuk-fieldset__heading" data-qa="heading">Study type</h1>
         </legend>
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">

--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -10,7 +10,7 @@
       <%= render "shared/hidden_fields", exclude_keys: ["hasvacancies"], form: form %>
       <fieldset class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-heading-xl" data-qa="heading">Find courses by vacancies</h1>
+          <h1 class="govuk-fieldset__heading" data-qa="heading">Find courses by vacancies</h1>
         </legend>
 
         <div class="govuk-form-group">


### PR DESCRIPTION
This fixes the fieldset legends, to make sure that they have spacing below them.

## Before

<img width="698" alt="Screenshot 2020-12-07 at 15 42 07" src="https://user-images.githubusercontent.com/30665/101371624-e0110000-38a2-11eb-8527-c45e74102f26.png">

<img width="584" alt="Screenshot 2020-12-07 at 15 42 37" src="https://user-images.githubusercontent.com/30665/101371645-e606e100-38a2-11eb-804b-567c7a451b83.png">

## After

<img width="727" alt="Screenshot 2020-12-07 at 15 42 20" src="https://user-images.githubusercontent.com/30665/101371668-ec955880-38a2-11eb-98a8-1ac83994cc8f.png">

<img width="608" alt="Screenshot 2020-12-07 at 15 42 29" src="https://user-images.githubusercontent.com/30665/101371683-f1f2a300-38a2-11eb-88f3-87f9b249cdad.png">

