### PR TITLE
Remove unused CSS style

### DIFF
--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -25,15 +25,6 @@ $govuk-image-url-function: frontend-image-url;
 @import "patterns/pagination";
 @import "patterns/text-ellipsis";
 
-
-.override-button-default {
-  background: none !important;
-  border: none;
-  padding: 0 !important;
-  text-decoration: underline;
-  cursor: pointer;
-}
-
 .govuk-checkboxes__label-text {
   display: block;
   font-weight: bold;


### PR DESCRIPTION
The `.override-button-default` class was added in 70c36ec953f5c12d69670f3fae3a6651ead79dea to style a button as a link, but this got removed in 95559a9a4e9019c1205c00c787ab0a9350b311a6 and so is no longer needed.