### PR TITLE
Optimise Dockerfile and Use buildx in build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 log
 tmp
+.git/
+.github/
+terraform/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 env:
-  DOCKERHUB_REPOSITORY: dfedigital/find-teacher-training
+  DOCKER_IMAGE: dfedigital/find-teacher-training
 
 jobs:
   build:
@@ -24,20 +24,33 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1.1.1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          repository: ${{ env.DOCKERHUB_REPOSITORY }}
-          tags: ${{ github.sha }}
-          build_args: COMMIT_SHA=${{ github.sha }}
 
-      - name: Set Environment variable
-        run: |
-          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
-        env:
-          DOCKER_IMAGE: ${{ format('{0}:{1}', env.DOCKERHUB_REPOSITORY, github.sha) }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          tags: ${{ env.DOCKER_IMAGE}}:${{ github.sha }}
+          push: true
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-to:   type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          build-args: COMMIT_SHA=${{ github.sha }}
 
       - name: Run ruby linter
         run: make rubocop


### PR DESCRIPTION
### Context
Current docker image size is ~600MB, also there is no caching of the layers in the build pipelines.

### Changes proposed in this pull request

Optimise Docker image (introduce layers), this reduces the image size to ~190 MB.
Build time is now ~2.5 mins from 3.5min earlier (without cache).
Use buildx cache in build

### Guidance to review

### Trello card
https://trello.com/c/pIhqYRLf/2703-find-optimise-dockerfile-use-cache-in-github-actions-workflow

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
- [x] Product review
