### PR TITLE
Specify ruby version directly in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-def ruby_version
-  ruby_version = IO.foreach('.tool-versions', "\n") do |tool_version|
-    tool = Hash[*tool_version.split(' ')]
-    break tool['ruby'] if tool['ruby']
-  end
-end
-
-ruby ruby_version.to_s
+ruby '2.7.2'
 
 gem 'pkg-config', '~> 1.4.4'
 

--- a/bin/ruby-version
+++ b/bin/ruby-version
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+APP_ROOT = File.expand_path("..", __dir__)
+
+def ruby_version
+    tool_versions_file = File.join(APP_ROOT, '.tool-versions')
+    ruby_version = IO.foreach(tool_versions_file, "\n") do |tool_version| 
+            tool = Hash[*tool_version.split(' ')]
+            break tool['ruby'] if tool['ruby']
+    end
+end
+
+puts ruby_version


### PR DESCRIPTION
Dependabot is unable to find the .tool-versions
file when evaluating the Gemfile.

Moving ruby-version script inside bin

