### PR TITLE
WIP: Browser back button bug

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -10,9 +10,11 @@ import initAutocomplete from "scripts/autocomplete";
 import toggle from "scripts/toggle";
 import { loadAnalytics } from "scripts/analytics.js";
 import initCookieBanner from "scripts/cookie-banner";
+import refreshStartPage from "scripts/refresh-start-page";
 
 initAll();
 
+refreshStartPage();
 window.initLocationsMap = initLocationsMap;
 
 const $backLink = document.querySelector('[data-module="back-link"]');

--- a/app/webpacker/scripts/refresh-start-page.js
+++ b/app/webpacker/scripts/refresh-start-page.js
@@ -1,0 +1,6 @@
+const refreshStartPage = () => {
+    if (window.location.pathname === '/' && performance.navigation.type === 2) {
+        location.reload(true);
+    }
+}
+export default refreshStartPage;


### PR DESCRIPTION
### Context
Please see Trello card with description and instructions for replicating the bug: https://trello.com/c/GG6ZLJAr/1979-dev-going-back-to-location-filter-on-results-page

### Findings

When the user clicks the back button all the way back to the start of the search, the `flash[:start_wizard]` param is not being set in the [LocationsController](https://github.com/DFE-Digital/find-teacher-training/blob/master/app/controllers/result_filters/location_controller.rb#L9) as a hard refresh does not occur. As a result, a subsequent search [redirects straight to the results page](https://github.com/DFE-Digital/find-teacher-training/blob/master/app/controllers/result_filters/location_controller.rb#L71) rather than via the subjects form. 

### Hacking a solution

You will see in the changes files it's possible to detect whether a user has arrived at a given page by checking `performance.navigation.type`. [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigation)

Whilst this does fix the issue, as the page loads the radio button is briefly selected before becoming deselected.

### Questions

Part of me thinks that this is not a major bug but if it considered important, we will need a better solution than the one I have proposed.

It's possible also to see if delaying fixing is an option, in the event @paulrobertlloyd wishes to make significant changes to the app and  it's flows.



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
