### PR TITLE
Change default search results (vacancies)

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -43,7 +43,7 @@ class ResultsView
   end
 
   def hasvacancies?
-    return true if query_parameters['hasvacancies'].nil?
+    return false if query_parameters['hasvacancies'].nil?
 
     query_parameters['hasvacancies'] == 'true'
   end
@@ -122,10 +122,6 @@ class ResultsView
 
   def provider_filter?
     query_parameters['l'] == '3'
-  end
-
-  def vacancy_filter?
-    query_parameters['hasvacancies'] == 'false'
   end
 
   def sort_by_distance?

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -135,12 +135,10 @@
                 <%= smart_quotes(course.provider.decorate.short_address) %>
               </dd>
             <% end %>
-            <% if @results_view.vacancy_filter?  %>
-              <dt class="govuk-list--description__label">Vacancies</dt>
-              <dd data-qa="course__has_vacancies">
-                <%= course.decorate.has_vacancies? %>
-              </dd>
-            <% end %>
+            <dt class="govuk-list--description__label">Vacancies</dt>
+            <dd data-qa="course__has_vacancies">
+              <%= course.decorate.has_vacancies? %>
+            </dd>
           </dl>
         </li>
       <% end %>

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -52,7 +52,7 @@ describe 'Search results', type: :feature do
         expect(first_course.accrediting_provider.text).to eq('University of Brighton')
         expect(first_course.funding_options.text).to eq('Student finance if you’re eligible')
         expect(first_course.main_address.text).to eq('Hove Park School, Hangleton Way, Hove, East Sussex, BN3 8AA')
-        expect(first_course).not_to have_show_vacanices
+        expect(first_course).to have_show_vacancies
       end
     end
   end

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -38,7 +38,7 @@ describe 'Funding filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'true',
+            'hasvacancies' => 'false',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -193,7 +193,7 @@ describe 'Location filter', type: :feature do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'true',
+          'hasvacancies' => 'false',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -35,7 +35,7 @@ describe 'Qualifications filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'true',
+            'hasvacancies' => 'false',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -55,7 +55,7 @@ describe 'Study type filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'true',
+            'hasvacancies' => 'false',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -205,7 +205,7 @@ describe 'Subject filter', type: :feature do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'true',
+          'hasvacancies' => 'false',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -35,7 +35,7 @@ describe 'Vacancy filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'true',
+            'hasvacancies' => 'false',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',
@@ -71,7 +71,7 @@ describe 'Vacancy filter', type: :feature do
     it 'lists only courses with vacancies' do
       results_page.load
 
-      expect(results_page.vacancies_filter.vacancies.text).to eq('Only courses with vacancies')
+      expect(results_page.vacancies_filter.vacancies.text).to eq('Courses with and without vacancies')
       expect(results_page.courses.count).to eq(10)
     end
   end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -55,7 +55,7 @@ describe 'results', type: :feature do
 
     it 'has vacancies filter' do
       expect(results_page.vacancies_filter.subheading).to have_content('Vacancies:')
-      expect(results_page.vacancies_filter.vacancies).to have_content('Only courses with vacancies')
+      expect(results_page.vacancies_filter.vacancies).to have_content('Courses with and without vacancies')
       expect(results_page.vacancies_filter.link).to have_content('Change vacancies')
     end
 
@@ -68,7 +68,7 @@ describe 'results', type: :feature do
       expect(location_filter_uri.path).to eq('/results/filter/location')
       expect(Rack::Utils.parse_nested_query(location_filter_uri.query)).to eq({
         'fulltime' => 'false',
-        'hasvacancies' => 'true',
+        'hasvacancies' => 'false',
         'parttime' => 'false',
         'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
         'senCourses' => 'false',
@@ -94,7 +94,7 @@ describe 'results', type: :feature do
   end
 
   describe 'filters defaults with query string' do
-    let(:params) { { fulltime: 'false', parttime: 'false', hasvacancies: 'true' } }
+    let(:params) { { fulltime: 'false', parttime: 'false', hasvacancies: 'false' } }
 
     it 'has study type filter' do
       expect(results_page.study_type_filter.subheading).to have_content('Study type:')
@@ -105,7 +105,7 @@ describe 'results', type: :feature do
 
     it 'has vacancies filter' do
       expect(results_page.vacancies_filter.subheading).to have_content('Vacancies:')
-      expect(results_page.vacancies_filter.vacancies).to have_content('Only courses with vacancies')
+      expect(results_page.vacancies_filter.vacancies).to have_content('Courses with and without vacancies')
       expect(results_page.vacancies_filter.link).to have_content('Change vacancies')
     end
 
@@ -234,7 +234,7 @@ describe 'results', type: :feature do
           qualifications: %w[QtsOnly PgdePgceWithQts Other],
           fulltime: 'false',
           parttime: 'false',
-          hasvacancies: 'true',
+          hasvacancies: 'false',
           senCourses: 'false',
         }
       end
@@ -244,7 +244,7 @@ describe 'results', type: :feature do
         expect(location_filter_uri.path).to eq('/results')
         expect(Rack::Utils.parse_nested_query(location_filter_uri.query)).to eq({
           'fulltime' => 'false',
-          'hasvacancies' => 'true',
+          'hasvacancies' => 'false',
           'l' => '2',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
@@ -266,7 +266,7 @@ describe 'results', type: :feature do
         subjects: '1,2,3',
         fulltime: 'False',
         parttime: 'False',
-        hasvacancies: 'True',
+        hasvacancies: 'False',
         senCourses: 'False',
         funding: '15',
       }
@@ -280,7 +280,7 @@ describe 'results', type: :feature do
       expect(results_page.study_type_filter.parttime).to have_content('Part time (18 - 24 months)')
       expect(results_page.qualifications_filter).to have_content('All qualifications')
       expect(results_page.funding_filter).to have_with_or_without_salary
-      expect(results_page.vacancies_filter).to have_content('Only courses with vacancies')
+      expect(results_page.vacancies_filter).to have_content('Courses with and without vacancies')
     end
   end
 end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -15,7 +15,7 @@ module PageObjects
         element :accrediting_provider, '[data-qa="course__accrediting_provider"]'
         element :funding_options, '[data-qa="course__funding_options"]'
         element :main_address, '[data-qa="course__main_address"]'
-        elements :show_vacanices, '[data-qa="course__has_vacancies"]'
+        elements :show_vacancies, '[data-qa="course__has_vacancies"]'
       end
 
       class SubjectsSection < SitePrism::Section

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -1,6 +1,6 @@
 def results_page_parameters(parameters = {})
   {
-    'filter[has_vacancies]' => 'true',
+    'filter[has_vacancies]' => 'false',
     'include' => 'site_statuses.site,provider,subjects',
     'page[page]' => 1,
     'page[per_page]' => 10,

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -8,18 +8,8 @@ describe ResultsView do
       'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
       'fulltime' => false,
       'parttime' => false,
-      'hasvacancies' => true,
+      'hasvacancies' => false,
       'senCourses' => false,
-    }
-  end
-
-  let(:default_query_parameters) do
-    {
-      'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
-      'fulltime' => 'false',
-      'parttime' => 'false',
-      'hasvacancies' => 'true',
-      'senCourses' => 'false',
     }
   end
 
@@ -104,10 +94,13 @@ describe ResultsView do
   end
 
   describe 'filter_path_with_unescaped_commas' do
-    subject(:results_view) { described_class.new(query_parameters: default_query_parameters).filter_path_with_unescaped_commas('/test') }
+    subject(:results_view) { described_class.new(query_parameters: default_output_parameters).filter_path_with_unescaped_commas('/test') }
 
     it 'appends an unescaped querystring to the passed path' do
-      allow(UnescapedQueryStringService).to receive(:call).with(base_path: '/test', parameters: default_output_parameters)
+      allow(UnescapedQueryStringService).to receive(:call).with(
+        base_path: '/test',
+        parameters: default_output_parameters,
+      )
         .and_return('test_result')
       expect(results_view).to eq('test_result')
     end
@@ -382,22 +375,6 @@ describe ResultsView do
       let(:parameter_hash) { { 'l' => '2' } }
 
       it { is_expected.to be(false) }
-    end
-  end
-
-  describe '#vacancy_filter?' do
-    subject { described_class.new(query_parameters: parameter_hash).vacancy_filter? }
-
-    context 'when hasvacancies param is set to true' do
-      let(:parameter_hash) { { 'hasvacancies' => 'true' } }
-
-      it { is_expected.to be(false) }
-    end
-
-    context 'when hasvacancies param is set to false' do
-      let(:parameter_hash) { { 'hasvacancies' => 'false' } }
-
-      it { is_expected.to be(true) }
     end
   end
 


### PR DESCRIPTION
### Context
```
As a… user of Find
I need to... see all course with and without vacancies
So that... I can see the full range of courses and providers available in my area
```

### Changes proposed in this pull request
- When searching we now display courses with or without vacancies by default
- Always display whether a course has vacancies or not in the course results summary

### Guidance to review
- Run any search and you will see the search results include courses with and without vacancies
- Regardless of whether you run a search or filter the search by 'vacancies' each course results summary will display a row indicating whether it has vacancies or not

### Trello card
https://trello.com/c/LBpLaXJ2/2693-%F0%9F%97%BA-dev-start-by-showing-all-course-with-and-without-vacancies-by-default

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
