### PR TITLE
Lighter background colour for filters to increase contrast for text links

### DIFF
--- a/app/webpacker/styles/components/_toggle.scss
+++ b/app/webpacker/styles/components/_toggle.scss
@@ -1,7 +1,7 @@
 .govuk-toggle__link {
   @include govuk-font($size: 19, $weight: 'bold');
   @include govuk-responsive-margin(6, "bottom");
-  background-color: darken(govuk-colour("light-grey"), 5%);
+  background-color: govuk-colour("light-grey");
   background-image: url('../images/option-select-toggle-sprite.png');
   background-position: right -75px;
   background-repeat: no-repeat;

--- a/app/webpacker/styles/patterns/_filters.scss
+++ b/app/webpacker/styles/patterns/_filters.scss
@@ -1,7 +1,7 @@
 .filter-form {
   @include govuk-font($size: 19);
   @include govuk-responsive-margin(4, "bottom");
-  background-color: darken(govuk-colour("light-grey"), 5%);
+  background-color: govuk-colour("light-grey");
   padding: 8px;
 
   &__title {
@@ -21,7 +21,7 @@
 
     li {
       background-color: govuk-colour("white");
-      border-bottom: 2px solid darken(govuk-colour("light-grey"), 5%);
+      border-bottom: 2px solid govuk-colour("light-grey");
       margin: 0;
       padding: 8px;
       // New transport baseline is slightly higher, compensate with smaller padding


### PR DESCRIPTION
### Context

The DAC December 2020 audit reported issues with the contrast of links in the search filters. 

### Changes proposed in this pull request

Changed the background colour to use the standard `light-grey` colour from the design system and that we use elsewhere, such as in navigation bars and in the footer.

### Guidance to review

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/813383/103012769-f8844a00-4533-11eb-8af7-72dbe5fe434b.png) | ![after](https://user-images.githubusercontent.com/813383/103012764-f6ba8680-4533-11eb-8290-9e02e1e8efb0.png)

### Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
