### PR TITLE
Use standard title for error summaries

### DIFF
--- a/app/views/cookie_preferences/_error_message.html.erb
+++ b/app/views/cookie_preferences/_error_message.html.erb
@@ -1,7 +1,7 @@
 <% if flash[:error] %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
-      You’ll need to correct some information.
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -1,7 +1,7 @@
 <% if flash[:error] %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error" data-qa="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
-      You’ll need to correct some information.
+      There is a problem
     </h2>
     <div class="govuk-error-summary__body">
       <ul class="govuk-list govuk-error-summary__list">

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -379,7 +379,7 @@ describe 'Location filter', type: :feature do
       filter_page.load
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPlease choose an option")
+      expect(filter_page.error.text).to eq("There is a problem\nPlease choose an option")
 
       expect(page).to have_current_path(location_path, ignore_query: true)
     end
@@ -390,7 +390,7 @@ describe 'Location filter', type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPostcode, town or city")
+      expect(filter_page.error.text).to eq("There is a problem\nPostcode, town or city")
       expect(filter_page.location_error.text).to eq('Error: Please enter a postcode, city or town in England')
       expect(filter_page).to have_location_query
     end
@@ -402,7 +402,7 @@ describe 'Location filter', type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("You’ll need to correct some information.\nPostcode, town or city")
+      expect(filter_page.error.text).to eq("There is a problem\nPostcode, town or city")
       expect(filter_page.location_error.text).to eq('Error: We couldn’t find this location, please check your input and try again')
       expect(filter_page).to have_location_query
       expect(filter_page).to have_unknown_location


### PR DESCRIPTION
### Context

The DAC December 2020 audit pointed out that we are using titles for error summaries that go against the GDS recommendation.

### Changes proposed in this pull request

Changed all occurrences of `You’ll need to correct some information.` to `There is a problem`.

### Guidance to review

### Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
