### PR TITLE
Use Rails.logger instead of Kernel#warn

### DIFF
--- a/app/services/convert_deprecated_csharp_parameters_service.rb
+++ b/app/services/convert_deprecated_csharp_parameters_service.rb
@@ -21,7 +21,7 @@ class ConvertDeprecatedCsharpParametersService
     end
 
     if have_legacy_params
-      warn 'The user navigated to the results page using the deprecated C# parameterisation scheme' if Rails.env.production?
+      Rails.logger.warn('The user navigated to the results page using the deprecated C# parameterisation scheme') if Rails.env.production?
       return { deprecated: true, parameters: params_hash }
     end
 


### PR DESCRIPTION
### Context
- `Kernel#warn` was being used to log the deprecated c# parameters message, which bypasses JSONification (presumably being preformed by SemanticLogger), and triggering an error with LogStashLogger.

### Changes proposed in this pull request
- Use `Rails.logger` instead of `Kernel#warn`

### Trello card
https://trello.com/c/2ZYRIiEs/2773-deprecated-c-parameters-errors-showing-up-in-logit

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
