### PR TITLE
Ensure form does not use C# legacy boolean values

### DIFF
--- a/app/views/result_filters/vacancy/new.html.erb
+++ b/app/views/result_filters/vacancy/new.html.erb
@@ -19,7 +19,7 @@
               <%=
                 form.radio_button(
                   :hasvacancies,
-                  "True",
+                  true,
                   class: "govuk-radios__input",
                   data: { qa: "with_vacancies" },
                   checked: params[:hasvacancies] == "true" || params[:hasvacancies].blank?
@@ -32,7 +32,7 @@
               <%=
                 form.radio_button(
                   :hasvacancies,
-                  "False",
+                  false,
                   class: "govuk-radios__input",
                   data: { qa: "with_and_without_vacancies" },
                   checked: params[:hasvacancies] == "false"


### PR DESCRIPTION
### Context
- Followup to https://github.com/DFE-Digital/find-teacher-training/pull/586
- The C# 'legacy params warning' was firing because the 'has_vacancies' form was using legacy boolean values


### Changes proposed in this pull request
- Change form to use Ruby boolean values

### Trello card
https://trello.com/c/2ZYRIiEs/2773-deprecated-c-parameters-errors-showing-up-in-logit

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
