### PR TITLE
Bugfix: error summary link to first checkbox

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render partial: "shared/error_message", locals: { error_anchor_id: "subject1" } %>
+    <%= render partial: "shared/error_message", locals: { error_anchor_id: "subject00" } %>
 
     <%= form_with(url: subject_path, method: :post, data: { "ga-event-form" => "Subject" }) do |f| %>
       <%= render "shared/hidden_fields", exclude_keys: %w(subjects senCourses), form: f %>


### PR DESCRIPTION
(Looks like the ID change at some point, but the error summary link wasn't updated.)

There's arguably still an error in that, if the "Primary" accordion section isn't open, then the link doesn't work, and also that the checkboxes themselves aren't shown as being in an error state, with a red line to the left and so on. However if the link was to open the accordion section automatically, then that might be confusing or unexpected, especially for users of assistive technology.

Another alternative considered was to remove the link altogether and just display the text, but this displays as black by default, and the [Design System guidance](https://design-system.service.gov.uk/components/error-summary/) strongly suggests always containing a link, and linking to the first checkbox.

Probably this form needs a wider design review, which can happen at a future date.

## Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins