### PR TITLE
Add 'Error: ' prefix to page titles when error present

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -30,6 +30,10 @@ module ViewHelper
     mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class
   end
 
+  def title_with_error_prefix(title, error)
+    "#{t('page_titles.error_prefix') if error}#{title}"
+  end
+
 private
 
   def prepend_css_class(css_class, current_class)

--- a/app/views/cookie_preferences/new.html.erb
+++ b/app/views/cookie_preferences/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Cookies" %>
+<%= content_for :page_title, title_with_error_prefix("Cookies", flash[:error].present?) %>
 
 <div class="govuk-width-container">
   <h1 class="govuk-heading-xl">Cookies</h1>

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Find courses by location or by training provider" %>
+<%= content_for :page_title, title_with_error_prefix("Find courses by location or by training provider", flash[:error].present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Filter by qualification" %>
+<%= content_for :page_title, title_with_error_prefix("Filter by qualification", flash[:error].present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>

--- a/app/views/result_filters/study_type/new.html.erb
+++ b/app/views/result_filters/study_type/new.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Filter by study type" %>
+<%= content_for :page_title, title_with_error_prefix("Filter by study type", flash[:error].present?) %>
 
 <% content_for :before_content do %>
   <%= govuk_back_link_to(results_path(@results_filter_query_parameters), "Back to search results") %>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "Find course by subject" %>
+<%= content_for :page_title, title_with_error_prefix("Find course by subject", flash[:error].present?) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -64,3 +64,5 @@ en:
   cookie_preferences:
     no_option_error: "Please choose an option"
     success: "Your cookie preferences have been saved"
+  page_titles:
+    error_prefix: "Error: "


### PR DESCRIPTION
This follows the [Design System guidance](https://design-system.service.gov.uk/components/error-summary/) to add a prefix to page titles when there is a validation error so that screen readers read it out as soon as possible.

Implementation [copied](https://github.com/DFE-Digital/apply-for-teacher-training/blob/master/app/helpers/view_helper.rb#L65-L67) from Apply for teacher training codebase.

### Trello card

https://trello.com/c/QitTcgV3/2764-dac-quick-wins