### PR TITLE
Update error message wording

### DIFF
--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -9,7 +9,7 @@ module ResultFilters
       end
 
       if params[:query].length == 1
-        flash[:error] = [t('location_filter.fields.provider'), t('location_filter.errors.invalid_provider')]
+        flash[:error] = [t('location_filter.fields.provider'), t('location_filter.errors.missing_provider')]
         return redirect_back
       end
 

--- a/app/controllers/result_filters/qualification_controller.rb
+++ b/app/controllers/result_filters/qualification_controller.rb
@@ -10,7 +10,7 @@ module ResultFilters
       if @view.qualification_selected?
         redirect_to results_path(filter_params)
       else
-        flash[:error] = 'Please choose at least one qualification'
+        flash[:error] = I18n.t('qualification_filter.errors.no_option')
         redirect_to qualification_path(filter_params)
       end
     end

--- a/app/helpers/result_filters/location_helper.rb
+++ b/app/helpers/result_filters/location_helper.rb
@@ -5,8 +5,7 @@ module ResultFilters
 
       flash[:error].include?(t('location_filter.fields.provider')) ||
         flash[:error].include?(t('location_filter.errors.blank_provider')) ||
-        flash[:error].include?(t('location_filter.errors.missing_provider')) ||
-        flash[:error].include?(t('location_filter.errors.invalid_provider'))
+        flash[:error].include?(t('location_filter.errors.missing_provider'))
     end
 
     def location_error?

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -19,11 +19,11 @@
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
           <h1 class="govuk-fieldset__heading">Find courses by location or by training provider</h1>
         </legend>
-        <div class="govuk-form-group<%= " govuk-form-group--error" if flash[:error] %>" id="search-options">
+        <div class="govuk-form-group" id="search-options">
           <% if flash[:error] and location_error? === false and provider_error? === false%>
             <p class="govuk-error-message">
               <% if flash[:error].kind_of?(Array) %>
-                <%= flash[:error].first %>
+                <%= flash[:error].last %>
               <% else %>
                 <%= flash[:error] %>
               <% end %>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -18,7 +18,7 @@
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">
           <% if flash[:error] %>
             <span id="qualification-error" class="govuk-error-message">
-              <span class="govuk-visually-hidden">Error:</span> You must make at least one selection
+              <span class="govuk-visually-hidden">Error:</span> <%= flash[:error] %>
             </span>
           <% end %>
           <div class="govuk-checkboxes">

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -8,7 +8,7 @@
         <li>
           <a href="#<%= error_anchor_id %>" data-qa="error__text">
             <% if flash[:error].kind_of?(Array) %>
-              <%= flash[:error].first %>
+              <%= flash[:error].last %>
             <% else %>
               <%= flash[:error] %>
             <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,20 +49,22 @@ en:
     pgde_with_qts: "PGDE with QTS"
   location_filter:
     errors:
-      no_option: "Please choose an option"
-      unknown_location: "We couldn’t find this location, please check your input and try again"
-      missing_location: "Please enter a postcode, city or town in England"
-      missing_provider: "We couldn’t find this provider, please check your information and try again"
-      blank_provider: "You need to add some information"
-      invalid_provider: "Please enter a minimum of two characters"
+      no_option: Select an option to find courses
+      unknown_location: Enter a real city, town or postcode
+      missing_location: Enter a city, town or postcode
+      missing_provider: Enter a real school, university or training provider
+      blank_provider: Enter a school, university or other training provider
     fields:
       location: "Postcode, town or city"
       provider: "Training provider"
   subject_filter:
     errors:
-      no_option: "Please choose at least one subject"
+      no_option: Select at least one subject
+  qualification_filter:
+    errors:
+      no_option: Select at least one qualification
   cookie_preferences:
-    no_option_error: "Please choose an option"
+    no_option_error: Select yes if you accept Google Analytics cookies
     success: "Your cookie preferences have been saved"
   page_titles:
     error_prefix: "Error: "

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -77,7 +77,7 @@ describe 'Location filter', type: :feature do
           filter_page.by_provider.click
           filter_page.find_courses.click
 
-          expect(filter_page).to have_content('You need to add some information')
+          expect(filter_page).to have_content('Enter a school, university or other training provider')
         end
       end
 
@@ -89,7 +89,7 @@ describe 'Location filter', type: :feature do
           filter_page.provider_search.fill_in(with: 'A')
           filter_page.find_courses.click
 
-          expect(filter_page).to have_content('Please enter a minimum of two characters')
+          expect(filter_page).to have_content('Enter a real school, university or training provider')
         end
       end
     end
@@ -160,7 +160,7 @@ describe 'Location filter', type: :feature do
           start_page.load
           start_page.find_courses.click
 
-          expect(start_page).to have_content(/Please choose an option/)
+          expect(start_page).to have_content(/Select an option to find courses/)
         end
       end
 
@@ -171,7 +171,7 @@ describe 'Location filter', type: :feature do
           start_page.load
           start_page.find_courses.click
 
-          expect(start_page).to have_content(/Please choose an option/)
+          expect(start_page).to have_content(/Select an option to find courses/)
         end
       end
     end
@@ -379,7 +379,7 @@ describe 'Location filter', type: :feature do
       filter_page.load
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("There is a problem\nPlease choose an option")
+      expect(filter_page.error.text).to eq("There is a problem\nSelect an option to find courses")
 
       expect(page).to have_current_path(location_path, ignore_query: true)
     end
@@ -390,8 +390,8 @@ describe 'Location filter', type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("There is a problem\nPostcode, town or city")
-      expect(filter_page.location_error.text).to eq('Error: Please enter a postcode, city or town in England')
+      expect(filter_page.error.text).to eq("There is a problem\nEnter a city, town or postcode")
+      expect(filter_page.location_error.text).to eq('Error: Enter a city, town or postcode')
       expect(filter_page).to have_location_query
     end
 
@@ -402,8 +402,8 @@ describe 'Location filter', type: :feature do
 
       filter_page.find_courses.click
 
-      expect(filter_page.error.text).to eq("There is a problem\nPostcode, town or city")
-      expect(filter_page.location_error.text).to eq('Error: We couldn’t find this location, please check your input and try again')
+      expect(filter_page.error.text).to eq("There is a problem\nEnter a real city, town or postcode")
+      expect(filter_page.location_error.text).to eq('Error: Enter a real city, town or postcode')
       expect(filter_page).to have_location_query
       expect(filter_page).to have_unknown_location
     end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -118,8 +118,8 @@ describe 'Provider filter', type: :feature do
       it 'redirects to location page with an error' do
         expect(page).to have_current_path(location_filter_page.url, ignore_query: true)
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq('query' => 'ACME')
-        expect(location_filter_page.error_text.text).to eq('Training provider')
-        expect(location_filter_page.provider_error.text).to eq('Error: We couldn’t find this provider, please check your information and try again')
+        expect(location_filter_page.error_text.text).to eq('Enter a real school, university or training provider')
+        expect(location_filter_page.provider_error.text).to eq('Error: Enter a real school, university or training provider')
       end
     end
   end

--- a/spec/form_objects/result_filters/location_filter_form_spec.rb
+++ b/spec/form_objects/result_filters/location_filter_form_spec.rb
@@ -18,7 +18,7 @@ module ResultFilters
 
         it 'has error' do
           results_filters.valid?
-          expect(results_filters.errors).to eq(['Please choose an option'])
+          expect(results_filters.errors).to eq(['Select an option to find courses'])
         end
 
         it 'has empty params' do
@@ -36,7 +36,7 @@ module ResultFilters
 
         it 'has error' do
           results_filters.valid?
-          expect(results_filters.errors).to eq(['Postcode, town or city', 'We couldn’t find this location, please check your input and try again'])
+          expect(results_filters.errors).to eq(['Postcode, town or city', 'Enter a real city, town or postcode'])
         end
 
         it 'has params' do


### PR DESCRIPTION
@gregknight1 reviewed the error message text across the service, to make them more usable and consistent with the GOV.UK Design System.

### Bonus fix

This also changes the design of the errors within conditionally-revealed fields, to place the red line next to the revealed field only, rather than the whole of the radio fieldset.

#### Before

<img width="744" alt="Screenshot 2021-01-04 at 13 49 39" src="https://user-images.githubusercontent.com/30665/103553391-48a0cc00-4ea5-11eb-9cd1-a5d62983425b.png">

#### After

<img width="771" alt="Screenshot 2021-01-04 at 15 56 24" src="https://user-images.githubusercontent.com/30665/103553519-771ea700-4ea5-11eb-9683-9d774a926806.png">

### Trello card

https://trello.com/c/i8qZkt3C/2818-improve-error-messages-in-find
https://trello.com/c/QitTcgV3/2764-dac-quick-wins