### PR TITLE
Fix 'suggested search' link bug

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -375,7 +375,10 @@ private
   end
 
   def course_counter(radius_to_check: nil, include_salary: true)
-    course_query(include_location: radius_to_check.present?, radius_to_query: radius_to_check, include_salary: include_salary).all.meta['count']
+    course_query = course_query(include_location: radius_to_check.present?, radius_to_query: radius_to_check, include_salary: include_salary)
+    course_query = course_query.order(:distance) if sort_by_distance?
+
+    course_query.all.meta['count']
   end
 
   def course_query(include_location:, radius_to_query: radius, include_salary: true)

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -8,7 +8,7 @@ describe 'suggested searches', type: :feature do
 
   def suggested_search_count_parameters
     base_parameters.reject do |k, _v|
-      ['page[page]', 'page[per_page]', 'sort'].include?(k)
+      ['page[page]', 'page[per_page]'].include?(k)
     end
   end
 


### PR DESCRIPTION
### Context
- A 'suggested search' link is presented to the user when their search query returns no results.
- It is possible for the course count in the search link to be incorrect in instances where the original search query was filtered by location and a course contained multiple sites. This is because distance queries will de-dup courses with multiple sites (reducing the total count). See https://github.com/DFE-Digital/teacher-training-api/blob/master/app/services/course_search_service.rb#L108
- To see this bug in action [view this search query on Find](https://www.find-postgraduate-teacher-training.service.gov.uk/results?fulltime=false&funding=8&hasvacancies=false&l=1&lat=51.553515&lng=-0.1579151&loc=Mansfield+Rd%2C+London+NW3+2HN%2C+UK&lq=NW3+2HN&parttime=true&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&rad=50&senCourses=false&sortby=2&subjects%5B%5D=5). Note the suggested search link contains a course count of '6'. When you click on the suggested search link you will see only '5' courses in the results.

### Changes proposed in this pull request
- This fix amends the `#course_counter` method to send a 'sort by distance' param to the API so that the course count displayed in the suggested search link matches the total courses that are returned when the suggested search link is clicked

### Guidance to review
- Run the same search query above locally. You should see that the course count in the suggested search link is now '5'

### Trello card
https://trello.com/c/H2cH3Bk6/2739-results-off-by-one

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
- [ ] Product review
