### PR TITLE
Updated heading on find: filter by qualification page

### DIFF
--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -12,7 +12,7 @@
       <%= render "shared/hidden_fields", exclude_keys: ["qualifications"], form: form %>
       <fieldset role="radiogroup" aria-required="true" class="govuk-fieldset">
         <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
-          <h1 class="govuk-fieldset__heading" data-qa="heading">What you will get</h1>
+          <h1 class="govuk-fieldset__heading" data-qa="heading">Choose the qualifications to search for</h1>
         </legend>
 
         <div class="govuk-form-group <%= flash[:error] ? "govuk-form-group--error" : "" %>">

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -14,7 +14,7 @@ describe 'Qualifications filter', type: :feature do
 
     it 'has the correct title and heading' do
       expect(page.title).to have_content('Filter by qualification')
-      expect(page).to have_content('What you will get')
+      expect(page).to have_content('Choose the qualifications to search for')
     end
 
     describe 'back link' do
@@ -101,7 +101,7 @@ describe 'Qualifications filter', type: :feature do
         results_page.load
         results_page.qualifications_filter.link.click
 
-        expect(filter_page.heading.text).to eq('What you will get')
+        expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
 
         filter_page.qts_only.click
         filter_page.find_courses.click
@@ -128,7 +128,7 @@ describe 'Qualifications filter', type: :feature do
         results_page.load
         results_page.qualifications_filter.link.click
 
-        expect(filter_page.heading.text).to eq('What you will get')
+        expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
 
         filter_page.pgde_pgce_with_qts.click
         filter_page.find_courses.click
@@ -155,7 +155,7 @@ describe 'Qualifications filter', type: :feature do
         results_page.load
         results_page.qualifications_filter.link.click
 
-        expect(filter_page.heading.text).to eq('What you will get')
+        expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
 
         filter_page.other.click
         filter_page.find_courses.click
@@ -173,7 +173,7 @@ describe 'Qualifications filter', type: :feature do
         results_page.load
         results_page.qualifications_filter.link.click
 
-        expect(filter_page.heading.text).to eq('What you will get')
+        expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
 
         filter_page.qts_only.click
         filter_page.pgde_pgce_with_qts.click
@@ -206,7 +206,7 @@ describe 'Qualifications filter', type: :feature do
       results_page.load
       results_page.qualifications_filter.link.click
 
-      expect(filter_page.heading.text).to eq('What you will get')
+      expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
       filter_page.find_courses.click
 
       expect(results_page.heading.text).to eq('Teacher training courses')


### PR DESCRIPTION
### Context

Changes to Find were agreed following the bug party & design review.

### Changes proposed in this pull request

Changed the heading from "**What you will get**" to "**Choose the qualifications to search for**".

### Guidance to review

Header preview:
![Screenshot](https://user-images.githubusercontent.com/47917431/104015572-ba7e5b80-51ac-11eb-980a-6cc5056c91d0.png)


### Trello card

https://trello.com/c/lwqKAGF9/2810-dev-find-change-heading-in-filter-by-quals-page

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
