### PR TITLE
Fix line-height of provider name in results and page titles

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -8,9 +8,9 @@
 
 <div data-module="ga-track-scrolling ga-track-copying">
   <h1 class="govuk-heading-xl">
-    <span class="govuk-!-font-size-36" data-qa="course__provider_name">
+    <span class="govuk-heading-l govuk-!-margin-bottom-0" data-qa="course__provider_name">
       <%= smart_quotes(course.provider.provider_name) %>
-    </span><br>
+    </span>
     <%= course.name_and_code %>
   </h1>
 

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -97,9 +97,9 @@
         <li data-qa="course">
           <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
             <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link search-result-link", rel: "prev", data: { qa: "course__link" } do %>
-              <span data-qa="course__provider_name" class="govuk-!-font-size-19">
+              <span data-qa="course__provider_name" class="govuk-heading-s govuk-!-margin-bottom-0">
                 <%= smart_quotes(course.provider.provider_name) %>
-              </span><br>
+              </span>
               <span data-qa="course__name" class="search-result-link-name govuk-!-font-size-24"><%= course.decorate.display_title %></span>
             <% end %>
           </h3>

--- a/app/webpacker/styles/components/_search-results.scss
+++ b/app/webpacker/styles/components/_search-results.scss
@@ -25,6 +25,10 @@
 .search-result-link {
   text-decoration: none;
 
+  * {
+    color: inherit;
+  }
+
   .search-result-link-name {
     text-decoration: underline;
   }


### PR DESCRIPTION
### Context

In a few places, the line height used for provider names creates weird spacing if/when it wraps onto 2 lines. 

### Changes proposed in this pull request

This change updates the styles, but also removes the `<br>` character that appears after a provider name; torn on whether that’s a good idea or not… captions in the design system don’t use such a line break, for what it’s worth.

| Before | After |
| - | - |
| ![page-title-before](https://user-images.githubusercontent.com/813383/104037332-7ef38980-51cc-11eb-9f0d-1f052bd539d9.png) | ![page-title-after](https://user-images.githubusercontent.com/813383/104038579-34264180-51cd-11eb-902e-f8bf21123332.png)
| ![result-heading-before](https://user-images.githubusercontent.com/813383/104036944-f674e900-51cb-11eb-9294-89d7ef5e5e3d.png) | ![result-heading-after](https://user-images.githubusercontent.com/813383/104038583-35576e80-51cd-11eb-9209-03a92b350c0c.png)

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
