### PR TITLE
Updating the loan link wording on the find course by subject page

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -11,7 +11,7 @@
       <p class="govuk-body">Select the subjects you want to teach.</p>
       <h2 class="govuk-heading-m">Get financial support</h2>
       <p class="govuk-body">You’ll have to pay a fee for most courses. You can get financial support to cover this, and to help with your living costs while you study. The amount of financial support available to you will depend on the subject you choose.</p>
-      <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "postgraduate loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
+      <p class="govuk-body">Visit Get Into Teaching to find out more about <%= govuk_link_to "loans", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/postgraduate-loans" %>, <%= govuk_link_to "bursaries and scholarships", "https://getintoteaching.education.gov.uk/funding-and-salary/overview" %>, and <%= govuk_link_to "funding by subject", "https://getintoteaching.education.gov.uk/funding-and-salary/overview/funding-by-subject" %>.</p>
 
       <h2 class="govuk-heading-m">Find out about Subject knowledge enhancement courses</h2>
       <p class="govuk-body">


### PR DESCRIPTION
### Context

On the find courses by subject page in Find, under the heading 'Get financial support' there is a link to GiT called 'postgraduate loans'

In the bug party it was identified that this link takes the user to a page in GiT that does not mention 'postgraduate' loans.

### Changes proposed in this pull request

Changed the link text from "**postgraduate loans**" to "**loans**".

### Guidance to review

Updated link:
![Screenshot](https://user-images.githubusercontent.com/47917431/104045746-ea425900-51d6-11eb-9c46-de2b454bafee.png)


### Trello card

https://trello.com/c/M23yDpb9/2811-dev-find-change-link-text-in-get-financial-support

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
