### PR TITLE
Course page: school/teaching placements header text & location changed

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -125,9 +125,9 @@ class CourseDecorator < Draper::Decorator
 
   def placements_heading
     if further_education?
-      'How teaching placements work'
+      'Teaching placements'
     else
-      'How school placements work'
+      'School placements'
     end
   end
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -54,11 +54,11 @@
         <% if course.about_course.present? %>
           <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
         <% end %>
-        <% if course.interview_process.present? %>
-          <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
-        <% end %>
         <% if course.how_school_placements_work.present? %>
           <li><%= link_to course.placements_heading, '#section-schools', class: 'govuk-link' %></li>
+        <% end %>
+        <% if course.interview_process.present? %>
+          <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
         <% end %>
         <% if course.has_fees? %>
           <li><%= link_to 'Fees', '#section-fees', class: 'govuk-link' %></li>
@@ -82,12 +82,12 @@
         <%= render partial: 'courses/about_course' %>
       <% end %>
 
-      <% if course.interview_process.present? %>
-        <%= render partial: 'courses/interview_process' %>
-      <% end %>
-
       <% if course.how_school_placements_work.present? %>
         <%= render partial: 'courses/about_schools' %>
+      <% end %>
+
+      <% if course.interview_process.present? %>
+        <%= render partial: 'courses/interview_process' %>
       <% end %>
 
       <% if course.has_fees? %>

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -401,7 +401,7 @@ describe CourseDecorator do
       let(:course) { build(:course) }
 
       it 'returns school placement' do
-        expect(decorated_course.placements_heading).to eq('How school placements work')
+        expect(decorated_course.placements_heading).to eq('School placements')
       end
     end
 
@@ -409,7 +409,7 @@ describe CourseDecorator do
       let(:course) { build(:course, :further_education) }
 
       it 'returns teaching placement' do
-        expect(decorated_course.placements_heading).to eq('How teaching placements work')
+        expect(decorated_course.placements_heading).to eq('Teaching placements')
       end
     end
   end


### PR DESCRIPTION
### Context

When we conducted a design review of Find, we believed the ordering of information and the headings used could be improved, particularly that around locations and placements.

### Changes proposed in this pull request

On the course details page the 'How do school/teaching placements work' heading is changed to 'School/Teaching placements'

And the 'School/Teaching placements' heading and content is moved to between 'About this course' and 'Interview process'

### Guidance to review
New location & text:
![Screenshot](https://user-images.githubusercontent.com/47917431/104181760-3ecc1b00-5407-11eb-8558-534f9c8828fb.png)

### Trello card

https://trello.com/c/iCTm6hlM/2761-%F0%9F%97%BA-dev-find-content-chg-to-school-placements-on-course-dets

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
