### PR TITLE
Update link in privacy policy

### DIFF
--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -34,7 +34,7 @@
       </ul>
 
       <p class="govuk-body">
-        You can <a href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights" class="govuk-link">find out more about your data protection rights</a> on the Information Commissioner’s website.
+        You can find more information about how we handle personal data in our <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link">personal information charter</a>.
       </p>
 
       <h2 class="govuk-heading-l">The right to lodge a complaint</h2>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -34,7 +34,8 @@
       </ul>
 
       <p class="govuk-body">
-        You can find more information about how we handle personal data in our <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter" class="govuk-link">personal information charter</a>.
+        You can find more information about how we handle personal data in our
+        <%= govuk_link_to('personal information charter', 'https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter') %>.
       </p>
 
       <h2 class="govuk-heading-l">The right to lodge a complaint</h2>


### PR DESCRIPTION
### Context

The link to the ICO Web site points to a page that no longer exists.
Changed to match the corresponding content in the Apply privacy policy.

### Changes proposed in this pull request

<img width="824" alt="image" src="https://user-images.githubusercontent.com/450843/104669426-e11f2380-56d1-11eb-9ec8-6b00583f9680.png">

### Guidance to review

Does the content look right?
Does the link work?

### Trello card

https://trello.com/c/fX3reVnJ/2733-broken-link-privacy-policy

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
