### PR TITLE
Remove logstash gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,6 @@ gem 'draper'
 # http client
 gem 'httparty'
 
-# Offshore logging
-gem 'logstash-logger'
-
 # Semantic Logger makes logs pretty
 gem 'rails_semantic_logger'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -203,9 +203,6 @@ GEM
     listen (3.4.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logstash-event (1.2.02)
-    logstash-logger (0.26.1)
-      logstash-event (~> 1.2)
     loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -435,7 +432,6 @@ DEPENDENCIES
   kaminari
   launchy
   listen (>= 3.0.5, < 3.5)
-  logstash-logger
   pkg-config (~> 1.4.4)
   pry-byebug
   puma (~> 5.1)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,13 +57,4 @@ Rails.application.configure do
   # Logging
   config.log_tags = [:request_id] # Prepend all log lines with the following tags.
   config.log_level = Settings.log_level
-
-  if Settings.logstash.host && Settings.logstash.port
-    config.logger = LogStashLogger.new(Settings.logstash.to_h)
-  else
-    config.rails_semantic_logger.format = :json
-    config.semantic_logger.add_appender(io: STDOUT, level: config.log_level, formatter: config.rails_semantic_logger.format)
-    config.logger = ActiveSupport::Logger.new(STDOUT)
-    config.logger.info("Application logging to STDOUT")
-  end
 end

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,8 +1,0 @@
-if Settings.logstash.host && Settings.logstash.port
-  LogStashLogger.configure do |config|
-    config.customize_event do |event|
-      event['application'] = Settings.application_name
-      event['environment'] = Rails.env
-    end
-  end
-end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,14 +1,4 @@
-if Settings.logstash.host && Settings.logstash.port
-  logstash_formatter = proc do |event|
-    # For some reason logstash / elasticsearch drops events where the payload
-    # is a hash. These are more conveniently accessed at the top level of the
-    # event, anyway, so we move it there.
-    if event['payload'].present?
-      event.append(event['payload'])
-      event['payload'] = nil
-    end
-  end
-
-  log_stash = LogStashLogger.new(Settings.logstash.to_h.merge(customize_event: logstash_formatter))
-  SemanticLogger.add_appender(logger: log_stash, level: :info, formatter: :json)
-end
+Rails.application.config.semantic_logger.application = Settings.application_name
+Rails.application.config.rails_semantic_logger.format = :json
+SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
+Rails.application.config.logger.info('Application logging to STDOUT')

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,11 +13,6 @@ google:
   places_api_path: "/maps/api/place/autocomplete/json"
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
-logstash:
-  type: tcp
-  host: # Our hostname here
-  port: # Our port here
-  ssl_enable: true
 log_level: info
 cycle_has_ended:
 cycle_ending_soon:


### PR DESCRIPTION
### Context

Logstash gem is not used in production,
Logit endpoint is configured as a user_provided_service in PaaS to send logs to logit.
Logstash gem and config are not required.


### Trello card
https://trello.com/c/bvHSkeO4/2859-check-for-api-keys-in-logs-sent-to-logit

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
