### PR TITLE
Use `govuk-components` gem to replace standard markup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ gem 'skylight'
 
 # Allows the creation of components which encapsulate and test logic in views
 gem 'view_component'
+gem 'govuk-components'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
     geokit (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    govuk-components (1.0.2)
+      rails (>= 6.0)
+      view_component (>= 2.22.1, < 2.25.0)
     hashdiff (1.0.1)
     httparty (0.18.1)
       mime-types (~> 3.0)
@@ -423,6 +426,7 @@ DEPENDENCIES
   foreman
   geocoder
   geokit
+  govuk-components
   httparty
   json_api_client
   jsonapi-deserializable

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -8,10 +8,10 @@
   <% if @course.has_vacancies? %>
     <% if Settings.display_apply_button %>
       <p class="govuk-body">
-        <%= link_to "Apply for this course", apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-                    class: "govuk-button govuk-button--start",
-                    data: { qa: 'course__apply_link' },
-                    rel: "nofollow" %>
+        <%= render GovukComponent::StartNowButton.new(
+          text: 'Apply for this course',
+          href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+        ) %>
       </p>
     <% else %>
       <div data-qa="course__end_of_cycle_notice">

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -11,6 +11,7 @@
         <%= render GovukComponent::StartNowButton.new(
           text: 'Apply for this course',
           href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+          html_attributes: { 'data-qa': 'course__apply_link' },
         ) %>
       </p>
     <% else %>
@@ -56,13 +57,9 @@
       </tbody>
     </table>
   <% else %>
-    <div class="govuk-warning-text">
-      <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-      <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.
-      </strong>
-    </div>
+    <%= render GovukComponent::Warning.new(
+      text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.',
+    ) %>
   <% end %>
 </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,26 +26,11 @@
 
     <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
     <%= render partial: 'layouts/cookie-banner' unless current_page?(cookie_preferences_path)%>
-    <header class="govuk-header" role="banner" data-module="govuk-header">
-      <div class="govuk-header__container govuk-width-container">
-        <div class="govuk-header__logo">
-          <%= link_to "https://www.gov.uk", class: "govuk-header__link govuk-header__link--homepage" do %>
-            <span class="govuk-header__logotype">
-              <svg role="presentation" focusable="false" class="govuk-header__logotype-crown" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 132 97" height="32" width="36">
-                <path fill="currentColor" fill-rule="evenodd" d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"></path>
-                <image src="<%= asset_pack_path('media/images/govuk-logotype-crown.png') %>" class="govuk-header__logotype-crown-fallback-image"></image>
-              </svg>
-              <span class="govuk-header__logotype-text">
-                GOV.UK
-              </span>
-            </span>
-          <% end %>
-        </div>
-        <div class="govuk-header__content">
-          <%= link_to "Find postgraduate teacher training", root_path, class: "govuk-header__link govuk-header__link--service-name" %>
-        </div>
-      </div>
-    </header>
+    <%= render GovukComponent::Header.new(
+      logo: 'GOV.UK',
+      service_name: 'Find postgraduate teacher training',
+      service_name_href: root_path,
+    ) %>
 
     <div class="govuk-width-container">
       <div class="govuk-phase-banner">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,14 +33,9 @@
     ) %>
 
     <div class="govuk-width-container">
-      <div class="govuk-phase-banner">
-        <p class="govuk-phase-banner__content">
-          <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
-          <span class="govuk-phase-banner__text">
-            This is a new service – <%= link_to "give feedback or report a problem", "mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training", class: 'govuk-link govuk-link--no-visited-state' %>
-          </span>
-        </p>
-      </div>
+      <%= render GovukComponent::PhaseBanner.new(phase: 'Beta') do %>
+        This is a new service – <%= govuk_link_to "give feedback or report a problem", "mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training", class: 'govuk-link govuk-link--no-visited-state' %>
+      <% end %>
       <%= yield(:before_content) %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <% if flash[:success] %>

--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -4,13 +4,9 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Find postgraduate teacher training</h1>
-      <div class="govuk-warning-text">
-        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-        <strong class="govuk-warning-text__text">
-          <span class="govuk-warning-text__assistive">Warning</span>
-          It’s no longer possible to apply for courses for the 2020 to 2021 academic year
-        </strong>
-      </div>
+      <%= render GovukComponent::Warning.new(
+        text: 'It’s no longer possible to apply for courses for the 2020 to 2021 academic year',
+      ) %>
       <h2 class="govuk-heading-m">Find courses starting in the 2021 to 2022 academic year</h2>
       <p class="govuk-body">
         Come back from 6 October 2020 to find courses.


### PR DESCRIPTION
### Context
The `govuk-components` gem provides component wrappers for some of the standard markup shared across services. This PR explores using these components in Find.

### Changes proposed in this pull request

So far:
- [x] Add `govuk-components` gem
- [x] Replace the header with the `Header` component
- [x] Replace the call to action link to Apply with a `StartNowButton` component (see visual change below)
- [x] Replace the phase banner with a component
- [x] Replace a couple of warning panels with a component

Not covered here is replacing the Accordion used for subject selection with Accordion component. We have a requirement to render the current selected subject(s) in an expanded section. It doesn't look as though this is possible with the `govuk-components` gem right now, though I think we can raise a PR to add that feature.

All the changes should be invisible except for this one:

Before:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/450843/104741465-29295f00-5741-11eb-9c9a-9db4cc31edb2.png">

After:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/450843/104741260-dfd90f80-5740-11eb-8c6b-23722bfe060b.png">

### Guidance to review

- Per commit recommended

### Trello card
https://trello.com/c/53RWVPVj/2826-dev-use-govuk-view-components-in-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
