### PR TITLE
Refactor stubbed requests that use fixtures

### DIFF
--- a/spec/controllers/result_filters/subject_controller_spec.rb
+++ b/spec/controllers/result_filters/subject_controller_spec.rb
@@ -1,18 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe ResultFilters::SubjectController do
+  include StubbedRequests::SubjectAreas
+
   describe '#new' do
     context 'when subjects is a comma delimited string' do
       it 'returns a 200' do
-        stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects")
-           .with(
-             headers: {
-               'Accept' => 'application/vnd.api+json',
-               'Accept-Encoding' => 'gzip,deflate',
-               'Content-Type' => 'application/vnd.api+json',
-               'User-Agent' => /^Faraday/,
-             },
-           ).to_return(status: 200, body: '', headers: {})
+        stub_subject_areas
 
         get :new, params: { subjects: '38,29' }
         expect(response).to be_successful

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'cookie banner', type: :feature do
+  include StubbedRequests::Courses
+
   let(:results_page) { PageObjects::Page::Results.new }
   let(:params) {}
   let(:subject_areas) do
@@ -22,12 +24,7 @@ describe 'cookie banner', type: :feature do
   let(:base_parameters) { results_page_parameters }
 
   def stub_results_request
-    stub_request(:get, courses_url)
-      .with(query: base_parameters)
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(query: base_parameters, course_count: 10)
   end
 
   before do

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'cookie banner', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:results_page) { PageObjects::Page::Results.new }
   let(:params) {}
@@ -29,8 +30,7 @@ describe 'cookie banner', type: :feature do
 
   before do
     stub_results_request
-    stub_subjects_request
-
+    stub_subjects
     visit results_path(params)
   end
 

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Search results', type: :feature do
+  include StubbedRequests::Courses
+
   let(:results_page) { PageObjects::Page::Results.new }
 
   let(:base_parameters) { results_page_parameters }
@@ -22,12 +24,7 @@ describe 'Search results', type: :feature do
   let(:page_index) { nil }
 
   let(:stub_courses_request) do
-    stub_request(:get, courses_url)
-      .with(query: base_parameters)
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(query: base_parameters, course_count: 10)
   end
 
   before do

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Search results', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:results_page) { PageObjects::Page::Results.new }
 
@@ -28,7 +29,7 @@ describe 'Search results', type: :feature do
   end
 
   before do
-    stub_subjects_request
+    stub_subjects
     stub_courses_request
 
     visit results_path(page: page_index)

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Funding filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
@@ -22,12 +24,7 @@ describe 'Funding filter', type: :feature do
 
     describe 'back link' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters, course_count: 10)
       end
 
       it 'navigates back to the results page' do
@@ -78,12 +75,7 @@ describe 'Funding filter', type: :feature do
 
   describe 'viewing results without explicitly selecting a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     it 'lists course with or without salary' do
@@ -96,22 +88,12 @@ describe 'Funding filter', type: :feature do
 
   describe 'applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     context 'selecting all courses' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters, course_count: 10)
       end
 
       it 'list the courses' do
@@ -132,12 +114,7 @@ describe 'Funding filter', type: :feature do
 
     context 'selecting salary only courses' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[funding]' => 'salary'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters.merge('filter[funding]' => 'salary'), course_count: 10)
       end
 
       it 'lists the courses' do
@@ -159,19 +136,8 @@ describe 'Funding filter', type: :feature do
 
   describe 'submitting without applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
-
-      stub_request(:get, courses_url)
-        .with(query: base_parameters.merge('filter[qualifications]' => 'QtsOnly,PgdePgceWithQts,Other'))
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
+      stub_courses(query: base_parameters.merge('filter[qualifications]' => 'QtsOnly,PgdePgceWithQts,Other'), course_count: 10)
     end
 
     it 'lists only courses with and without salary' do

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Funding filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -11,7 +12,7 @@ describe 'Funding filter', type: :feature do
   let(:base_parameters) { results_page_parameters }
 
   before do
-    stub_subjects_request
+    stub_subjects
   end
 
   describe 'Funding filter page' do

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Location filter back link', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::Providers
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
@@ -11,7 +12,7 @@ describe 'Location filter back link', type: :feature do
 
   before do
     stub_results_page_request
-    stub_subjects_request
+    stub_subjects
   end
 
   context 'before the location filter form has been submitted' do

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Location filter back link', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -125,42 +127,23 @@ describe 'Location filter back link', type: :feature do
   end
 
   def stub_results_page_request
-    stub_request(:get, courses_url)
-      .with(any_parameters)
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(query: hash_including({}), course_count: 10)
   end
 
   def stub_courses_request_with_acme
-    stub_request(:get, courses_url)
-      .with(
-        query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
-      )
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/four_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(
+      query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
+      course_count: 4,
+    )
   end
 
   def stub_courses_request_with_location
-    stub_request(:get, courses_url)
-      .with(
-        query: base_parameters.merge(
-          'filter[longitude]' => '-0.1300436',
-          'filter[latitude]' => '51.4980188',
-          'filter[radius]' => '20',
-          'sort' => 'distance',
-        ),
-      )
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
-  end
-
-  def any_parameters
-    { query: hash_including({}) }
+    query = base_parameters.merge(
+      'filter[longitude]' => '-0.1300436',
+      'filter[latitude]' => '51.4980188',
+      'filter[radius]' => '20',
+      'sort' => 'distance',
+    )
+    stub_courses(query: query, course_count: 10)
   end
 end

--- a/spec/features/result_filters/location_back_link_spec.rb
+++ b/spec/features/result_filters/location_back_link_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Location filter back link', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Providers
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
@@ -112,17 +113,11 @@ describe 'Location filter back link', type: :feature do
   end
 
   def stub_provider_request
-    stub_request(
-      :get,
-      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
-    ).with(
+    stub_providers(
       query: {
         'fields[providers]' => 'provider_code,provider_name',
         'search' => 'ACME',
       },
-    ).to_return(
-      body: File.new('spec/fixtures/api_responses/providers.json'),
-      headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
     )
   end
 

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'Location filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Providers
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:start_page) { PageObjects::Page::Start.new }
@@ -23,17 +24,11 @@ describe 'Location filter', type: :feature do
 
   describe 'filtering by provider' do
     before do
-      stub_request(
-        :get,
-        "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
-      ).with(
+      stub_providers(
         query: {
           'fields[providers]' => 'provider_code,provider_name',
           'search' => 'ACME',
         },
-      ).to_return(
-        body: File.new('spec/fixtures/api_responses/providers.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
       )
 
       stub_courses(

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Location filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:start_page) { PageObjects::Page::Start.new }
   let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
@@ -16,12 +18,7 @@ describe 'Location filter', type: :feature do
     stub_subject_area_request
     stub_subjects_request
 
-    stub_request(:get, courses_url)
-      .with(query: base_parameters)
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(query: base_parameters, course_count: 10)
   end
 
   describe 'filtering by provider' do
@@ -39,14 +36,10 @@ describe 'Location filter', type: :feature do
         headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
       )
 
-      stub_request(:get, courses_url)
-        .with(
-          query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
-        )
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/four_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(
+        query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
+        course_count: 4,
+      )
     end
 
     context 'valid provider search' do
@@ -97,20 +90,14 @@ describe 'Location filter', type: :feature do
 
   describe 'filtering by location' do
     before do
-      stub_request(:get, courses_url)
-        .with(
-          query: base_parameters.merge(
-            'filter[longitude]' => '-0.1300436',
-            'filter[latitude]' => '51.4980188',
-            'filter[radius]' => '50',
-            'sort' => 'distance',
-            'filter[expand_university]' => false,
-          ),
-        )
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      query = base_parameters.merge(
+        'filter[longitude]' => '-0.1300436',
+        'filter[latitude]' => '51.4980188',
+        'filter[radius]' => '50',
+        'sort' => 'distance',
+        'filter[expand_university]' => false,
+      )
+      stub_courses(query: query, course_count: 10)
 
       results_page.load
       results_page.location_filter.link.click
@@ -316,20 +303,14 @@ describe 'Location filter', type: :feature do
 
   describe 'distance sorting' do
     let(:distance_stub) do
-      stub_request(:get, courses_url)
-        .with(
-          query: base_parameters.merge(
-            'filter[longitude]' => '-0.1300436',
-            'filter[latitude]' => '51.4980188',
-            'filter[radius]' => '50',
-            'sort' => 'distance',
-            'filter[expand_university]' => false,
-          ),
-        )
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      query = base_parameters.merge(
+        'filter[longitude]' => '-0.1300436',
+        'filter[latitude]' => '51.4980188',
+        'filter[radius]' => '50',
+        'sort' => 'distance',
+        'filter[expand_university]' => false,
+      )
+      stub_courses(query: query, course_count: 10)
     end
 
     before do

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Location filter', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::Providers
+  include StubbedRequests::SubjectAreas
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:start_page) { PageObjects::Page::Start.new }
@@ -10,14 +11,11 @@ describe 'Location filter', type: :feature do
   let(:results_page) { PageObjects::Page::Results.new }
   let(:query_params) { {} }
   let(:base_parameters) { results_page_parameters }
-  let(:stub_subject_area_request) do
-    stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects")
-  end
 
   before do
     stub_geocoder
-    stub_subject_area_request
     stub_subjects_request
+    stub_subject_areas
 
     stub_courses(query: base_parameters, course_count: 10)
   end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -4,6 +4,7 @@ describe 'Location filter', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::Providers
   include StubbedRequests::SubjectAreas
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:start_page) { PageObjects::Page::Start.new }
@@ -14,8 +15,8 @@ describe 'Location filter', type: :feature do
 
   before do
     stub_geocoder
-    stub_subjects_request
     stub_subject_areas
+    stub_subjects
 
     stub_courses(query: base_parameters, course_count: 10)
   end

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Provider filter', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::Providers
+  include StubbedRequests::Subjects
 
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:location_filter_page) { PageObjects::Page::ResultFilters::Location.new }
@@ -12,7 +13,7 @@ describe 'Provider filter', type: :feature do
   let(:query_params) { { query: search_term } }
 
   before do
-    stub_subjects_request
+    stub_subjects
 
     stub_courses(
       query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Provider filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:location_filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -16,15 +18,10 @@ describe 'Provider filter', type: :feature do
   before do
     stub_subjects_request
 
-    stub_request(:get, courses_url)
-      .with(
-        query: base_parameters.merge(
-          'filter[provider.provider_name]' => 'ACME SCITT 0',
-        ),
-      ).to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
+    stub_courses(
+      query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
+      course_count: 10,
+    )
   end
 
   context 'with an empty search' do

--- a/spec/features/result_filters/provider_spec.rb
+++ b/spec/features/result_filters/provider_spec.rb
@@ -2,16 +2,12 @@ require 'rails_helper'
 
 describe 'Provider filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Providers
 
   let(:provider_filter_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
   let(:location_filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:providers_url) do
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers?fields%5Bproviders%5D=provider_code,provider_name&search=#{search_term}"
-  end
-
   let(:base_parameters) { results_page_parameters }
-
   let(:search_term) { 'ACME' }
   let(:query_params) { { query: search_term } }
 
@@ -43,11 +39,12 @@ describe 'Provider filter', type: :feature do
   context 'with a query' do
     context 'with many providers' do
       before do
-        stub_request(:get, providers_url)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/providers.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_providers(
+          query: {
+            'fields[providers]' => 'provider_code,provider_name',
+            'search' => search_term,
+          },
+        )
 
         provider_filter_page.load(query: query_params)
       end
@@ -84,12 +81,12 @@ describe 'Provider filter', type: :feature do
 
     context 'with only one provider' do
       before do
-        stub_request(:get, providers_url)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/one_provider.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
-
+        stub_one_provider(
+          query: {
+            'fields[providers]' => 'provider_code,provider_name',
+            'search' => search_term,
+          },
+        )
         provider_filter_page.load(query: query_params)
       end
 
@@ -103,11 +100,12 @@ describe 'Provider filter', type: :feature do
 
     context 'with no providers' do
       before do
-        stub_request(:get, providers_url)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/empty_providers.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_empty_providers(
+          query: {
+            'fields[providers]' => 'provider_code,provider_name',
+            'search' => search_term,
+          },
+        )
 
         provider_filter_page.load(query: query_params)
       end
@@ -125,11 +123,12 @@ describe 'Provider filter', type: :feature do
     let(:search_term) { 'ACME SCITT' }
 
     before do
-      stub_request(:get, providers_url)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/providers.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_providers(
+        query: {
+          'fields[providers]' => 'provider_code,provider_name',
+          'search' => search_term,
+        },
+      )
 
       provider_filter_page.load(query: query_params)
     end

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe 'Qualifications filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
 
   before do
-    stub_subjects_request
+    stub_subjects
   end
 
   describe 'Qualification filter page' do

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Qualifications filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Qualification.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
@@ -19,12 +21,7 @@ describe 'Qualifications filter', type: :feature do
 
     describe 'back link' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters, course_count: 10)
       end
 
       it 'navigates back to the results page' do
@@ -61,12 +58,7 @@ describe 'Qualifications filter', type: :feature do
 
   describe 'viewing results without explicitly selecting a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     it 'lists only courses with all qualifications' do
@@ -79,22 +71,15 @@ describe 'Qualifications filter', type: :feature do
 
   describe 'applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     context "deselecting courses with 'qts only' qualification" do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[qualification]' => 'pgce_with_qts,pgde_with_qts,pgce,pgde'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[qualification]' => 'pgce_with_qts,pgde_with_qts,pgce,pgde'),
+          course_count: 10,
+        )
       end
 
       it 'list the courses' do
@@ -116,12 +101,10 @@ describe 'Qualifications filter', type: :feature do
 
     context "deselecting courses that with 'pgde with qts' qualification" do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[qualification]' => 'qts,pgce,pgde'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[qualification]' => 'qts,pgce,pgde'),
+          course_count: 10,
+        )
       end
 
       it 'list the courses' do
@@ -143,12 +126,10 @@ describe 'Qualifications filter', type: :feature do
 
     context "deselecting courses with 'further education' qualification" do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[qualification]' => 'qts,pgce_with_qts,pgde_with_qts'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[qualification]' => 'qts,pgce_with_qts,pgde_with_qts'),
+          course_count: 10,
+        )
       end
 
       it 'list the courses' do
@@ -187,19 +168,7 @@ describe 'Qualifications filter', type: :feature do
 
   describe 'submitting without applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
-
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     it 'list the courses' do

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Study type filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
@@ -39,12 +41,7 @@ describe 'Study type filter', type: :feature do
 
     describe 'back link' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters, course_count: 10)
       end
 
       it 'navigates back to the results page' do
@@ -81,12 +78,7 @@ describe 'Study type filter', type: :feature do
 
   describe 'viewing results without explicitly selecting a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     it 'lists only courses with both study types' do
@@ -101,22 +93,12 @@ describe 'Study type filter', type: :feature do
 
   describe 'applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     context 'deselecting full time' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[study_type]' => 'part_time'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters.merge('filter[study_type]' => 'part_time'), course_count: 10)
       end
 
       it 'list the courses' do
@@ -136,12 +118,7 @@ describe 'Study type filter', type: :feature do
 
     context 'deselecting part time' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[study_type]' => 'full_time'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters.merge('filter[study_type]' => 'full_time'), course_count: 10)
       end
 
       it 'list the courses' do
@@ -175,12 +152,7 @@ describe 'Study type filter', type: :feature do
 
     context 'submitting without deselection' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[study_type]' => 'full_time,part_time'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters.merge('filter[study_type]' => 'full_time,part_time'), course_count: 10)
       end
 
       it 'list the courses' do

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe 'Study type filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::StudyType.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
 
   before do
-    stub_subjects_request
+    stub_subjects
   end
 
   describe 'Study type filter page' do

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -2,23 +2,15 @@ require 'rails_helper'
 
 describe 'Subject filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::SubjectAreas
 
   let(:filter_page) { PageObjects::Page::ResultFilters::SubjectPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
-  let(:stub_subject_areas_request) do
-    stub_request(
-      :get,
-      "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects",
-    ).to_return(
-      body: File.new('spec/fixtures/api_responses/subject_areas.json'),
-      headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-    )
-  end
 
   before do
     stub_courses(query: base_parameters, course_count: 10)
-    stub_subject_areas_request
+    stub_subject_areas
     stub_subjects_request
   end
 

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'Subject filter', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::SubjectAreas
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::SubjectPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -11,7 +12,7 @@ describe 'Subject filter', type: :feature do
   before do
     stub_courses(query: base_parameters, course_count: 10)
     stub_subject_areas
-    stub_subjects_request
+    stub_subjects
   end
 
   describe 'applying a filter' do

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Subject filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::SubjectPage.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
@@ -15,38 +17,22 @@ describe 'Subject filter', type: :feature do
   end
 
   before do
-    stub_request(:get, courses_url)
-      .with(query: base_parameters)
-      .to_return(
-        body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
-
+    stub_courses(query: base_parameters, course_count: 10)
     stub_subject_areas_request
-
     stub_subjects_request
   end
 
   describe 'applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     context 'with less than 4 subjects selected' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge(
-            'filter[subjects]' => '00,F1',
-          ))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[subjects]' => '00,F1'),
+          course_count: 10,
+        )
       end
 
       it 'lists the results' do
@@ -75,14 +61,10 @@ describe 'Subject filter', type: :feature do
 
     context 'with subjects selected' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge(
-            'filter[subjects]' => '00,01,F1,Q8,P3',
-          ))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[subjects]' => '00,01,F1,Q8,P3'),
+          course_count: 10,
+        )
       end
 
       it 'lists the results' do
@@ -117,15 +99,11 @@ describe 'Subject filter', type: :feature do
 
   context 'with only SEND courses selected' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters.merge(
-          'filter[subjects]' => '00,01,F1',
-          'filter[send_courses]' => 'true',
-        ))
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      query = base_parameters.merge(
+        'filter[subjects]' => '00,01,F1',
+        'filter[send_courses]' => 'true',
+      )
+      stub_courses(query: query, course_count: 10)
     end
 
     it 'lists the results' do
@@ -315,14 +293,10 @@ describe 'Subject filter', type: :feature do
     end
 
     it 'lets you unselect SEND and other subjects' do
-      stub_request(:get, courses_url)
-          .with(query: base_parameters.merge(
-            'filter[subjects]' => '01',
-          ))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+      stub_courses(
+        query: base_parameters.merge('filter[subjects]' => '01'),
+        course_count: 10,
+      )
 
       visit subject_path(subjects: %w[31], senCourses: 'true')
       filter_page.subject_areas.first.subjects[0].checkbox.click # unselect
@@ -344,14 +318,10 @@ describe 'Subject filter', type: :feature do
 
   context 'with existing parameters' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters.merge(
-          'filter[subjects]' => '00,01',
-        ))
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(
+        query: base_parameters.merge('filter[subjects]' => '00,01'),
+        course_count: 10,
+      )
     end
 
     it 'only changes the subjects params' do

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe 'Vacancy filter', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
 
   before do
-    stub_subjects_request
+    stub_subjects
   end
 
   describe 'Vacancy filter page' do

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Vacancy filter', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Vacancy.new }
   let(:results_page) { PageObjects::Page::Results.new }
   let(:base_parameters) { results_page_parameters }
@@ -19,12 +21,7 @@ describe 'Vacancy filter', type: :feature do
 
     describe 'back link' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: base_parameters, course_count: 10)
       end
 
       it 'navigates back to the results page' do
@@ -60,12 +57,7 @@ describe 'Vacancy filter', type: :feature do
 
   describe 'viewing results without explicitly selecting a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     it 'lists only courses with vacancies' do
@@ -78,22 +70,15 @@ describe 'Vacancy filter', type: :feature do
 
   describe 'applying a filter' do
     before do
-      stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: base_parameters, course_count: 10)
     end
 
     context 'selecting courses with or without vacancies' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[has_vacancies]' => 'false'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[has_vacancies]' => 'false'),
+          course_count: 10,
+        )
       end
 
       it 'list the courses' do
@@ -113,12 +98,10 @@ describe 'Vacancy filter', type: :feature do
 
     context 'selecting courses with vacancies' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: base_parameters.merge('filter[has_vacancies]' => 'true'))
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(
+          query: base_parameters.merge('filter[has_vacancies]' => 'true'),
+          course_count: 10,
+        )
       end
 
       it 'lists the courses' do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -1,25 +1,12 @@
 require 'rails_helper'
 
 describe 'results', type: :feature do
+  include StubbedRequests::Courses
+
   let(:results_page) { PageObjects::Page::Results.new }
   let(:sort) { 'provider.provider_name,name' }
   let(:params) {}
   let(:base_parameters) { results_page_parameters('sort' => sort) }
-
-  let(:results_page_request) do
-    {
-      course_stub: stub_request(:get, courses_url)
-        .with(query: base_parameters)
-        .to_return(
-          body: courses,
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        ),
-    }
-  end
-
-  let(:courses) do
-    File.new('spec/fixtures/api_responses/ten_courses.json')
-  end
 
   before do
     stub_request(
@@ -30,7 +17,7 @@ describe 'results', type: :feature do
       headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
     )
 
-    results_page_request
+    stub_courses(query: base_parameters, course_count: 10)
 
     allow(Settings).to receive(:google).and_return(maps_api_key: 'alohomora')
     allow(Settings).to receive(:google).and_return(maps_api_url: 'https://maps.googleapis.com/maps/api/staticmap')
@@ -117,21 +104,17 @@ describe 'results', type: :feature do
 
   context 'provider sorting' do
     let(:ascending_stub) do
-      stub_request(:get, courses_url)
-        .with(query: results_page_parameters('sort' => 'provider.provider_name,name'))
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(
+        query: results_page_parameters('sort' => 'provider.provider_name,name'),
+        course_count: 10,
+      )
     end
 
     let(:descending_stub) do
-      stub_request(:get, courses_url)
-        .with(query: results_page_parameters('sort' => '-provider.provider_name,-name'))
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(
+        query: results_page_parameters('sort' => '-provider.provider_name,-name'),
+        course_count: 10,
+      )
     end
 
     before do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'results', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:results_page) { PageObjects::Page::Results.new }
   let(:sort) { 'provider.provider_name,name' }
@@ -9,14 +10,7 @@ describe 'results', type: :feature do
   let(:base_parameters) { results_page_parameters('sort' => sort) }
 
   before do
-    stub_request(
-      :get,
-      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-    ).to_return(
-      body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-      headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-    )
-
+    stub_subjects
     stub_courses(query: base_parameters, course_count: 10)
 
     allow(Settings).to receive(:google).and_return(maps_api_key: 'alohomora')

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -2,22 +2,13 @@ require 'rails_helper'
 
 describe 'Suggested salary searches', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
   def default_query_for_location_search(radius:)
     { l: 1, loc: 'Cat Town', lq: 'Cat Town', lat: 51.4980188, lng: -0.1300436, rad: radius }
-  end
-
-  def stub_subjects
-    stub_request(
-      :get,
-      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-    ).to_return(
-      body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-      headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-    )
   end
 
   def suggested_search_count_parameters

--- a/spec/features/suggested_salary_searches_spec.rb
+++ b/spec/features/suggested_salary_searches_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe 'Suggested salary searches', type: :feature do
+  include StubbedRequests::Courses
+
   let(:filter_page) { PageObjects::Page::ResultFilters::Funding.new }
   let(:results_page) { PageObjects::Page::Results.new }
 
@@ -18,53 +20,29 @@ describe 'Suggested salary searches', type: :feature do
     )
   end
 
-  def course_fixture_for(results:)
-    file_name = case results
-                when 0
-                  'empty_courses.json'
-                when 2
-                  'two_courses.json'
-                when 4
-                  'four_courses.json'
-                when 10
-                  'ten_courses.json'
-                end
-
-    File.new("spec/fixtures/api_responses/#{file_name}")
-  end
-
   def suggested_search_count_parameters
     results_page_parameters.reject do |k, _v|
       ['page[page]', 'page[per_page]', 'sort'].include?(k)
     end
   end
 
-  def stub_courses(number_of_results:, query:)
-    stub_request(:get, courses_url)
-      .with(query: query)
-      .to_return(
-        body: course_fixture_for(results: number_of_results),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
-  end
-
   def stub_suggested_across_england_with_salary_filter(number_of_results:)
     stub_courses(
-      number_of_results: number_of_results,
+      course_count: number_of_results,
       query: suggested_search_count_parameters.merge('filter[funding]' => 'salary'),
     )
   end
 
   def stub_suggested_across_england_without_salary_filter(number_of_results:)
     stub_courses(
-      number_of_results: number_of_results,
+      course_count: number_of_results,
       query: suggested_search_count_parameters,
     )
   end
 
   def stub_results_with_salary_filter(radius:, number_of_results:)
     stub_courses(
-      number_of_results: number_of_results,
+      course_count: number_of_results,
       query: results_page_parameters.merge(
         'filter[funding]' => 'salary',
         'filter[latitude]' => 51.4980188,
@@ -77,7 +55,7 @@ describe 'Suggested salary searches', type: :feature do
 
   def stub_suggested_with_salary_filter(radius:, number_of_results:)
     stub_courses(
-      number_of_results: number_of_results,
+      course_count: number_of_results,
       query: suggested_search_count_parameters.merge(
         'filter[funding]' => 'salary',
         'filter[latitude]' => 51.4980188,
@@ -90,7 +68,7 @@ describe 'Suggested salary searches', type: :feature do
 
   def stub_suggested_without_salary_filter(radius:, number_of_results:)
     stub_courses(
-      number_of_results: number_of_results,
+      course_count: number_of_results,
       query: suggested_search_count_parameters.merge(
         'filter[latitude]' => 51.4980188,
         'filter[longitude]' => -0.1300436,

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'suggested searches', type: :feature do
   include StubbedRequests::Courses
   include StubbedRequests::Providers
+  include StubbedRequests::Subjects
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -17,8 +18,7 @@ describe 'suggested searches', type: :feature do
 
   before do
     stub_geocoder
-
-    stub_subjects_request
+    stub_subjects
   end
 
   def results_page_request(radius:, results_to_return:)

--- a/spec/features/suggested_searches_spec.rb
+++ b/spec/features/suggested_searches_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe 'suggested searches', type: :feature do
   include StubbedRequests::Courses
+  include StubbedRequests::Providers
 
   let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
   let(:results_page) { PageObjects::Page::Results.new }
@@ -123,17 +124,11 @@ describe 'suggested searches', type: :feature do
 
   context 'a search filtered by provider with 2 results' do
     before do
-      stub_request(
-        :get,
-        "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers",
-      ).with(
+      stub_providers(
         query: {
           'fields[providers]' => 'provider_code,provider_name',
           'search' => 'ACME',
         },
-      ).to_return(
-        body: File.new('spec/fixtures/api_responses/providers.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
       )
 
       stub_courses(

--- a/spec/fixtures/api_responses/subject_areas.json
+++ b/spec/fixtures/api_responses/subject_areas.json
@@ -1,1 +1,753 @@
-{"data":[{"id":"PrimarySubject","type":"subject_areas","attributes":{"name":"Primary","typename":"PrimarySubject"},"relationships":{"subjects":{"data":[{"type":"subjects","id":"1"},{"type":"subjects","id":"2"},{"type":"subjects","id":"3"},{"type":"subjects","id":"4"},{"type":"subjects","id":"5"},{"type":"subjects","id":"6"},{"type":"subjects","id":"7"}]}}},{"id":"SecondarySubject","type":"subject_areas","attributes":{"name":"Secondary","typename":"SecondarySubject"},"relationships":{"subjects":{"data":[{"type":"subjects","id":"8"},{"type":"subjects","id":"9"},{"type":"subjects","id":"10"},{"type":"subjects","id":"11"},{"type":"subjects","id":"12"},{"type":"subjects","id":"13"},{"type":"subjects","id":"14"},{"type":"subjects","id":"15"},{"type":"subjects","id":"16"},{"type":"subjects","id":"17"},{"type":"subjects","id":"18"},{"type":"subjects","id":"19"},{"type":"subjects","id":"20"},{"type":"subjects","id":"21"},{"type":"subjects","id":"22"},{"type":"subjects","id":"23"},{"type":"subjects","id":"24"},{"type":"subjects","id":"25"},{"type":"subjects","id":"26"},{"type":"subjects","id":"27"},{"type":"subjects","id":"28"},{"type":"subjects","id":"29"},{"type":"subjects","id":"30"},{"type":"subjects","id":"31"},{"type":"subjects","id":"32"},{"type":"subjects","id":"33"}]}}},{"id":"ModernLanguagesSubject","type":"subject_areas","attributes":{"name":"Secondary: Modern languages","typename":"ModernLanguagesSubject"},"relationships":{"subjects":{"data":[{"type":"subjects","id":"34"},{"type":"subjects","id":"35"},{"type":"subjects","id":"36"},{"type":"subjects","id":"37"},{"type":"subjects","id":"38"},{"type":"subjects","id":"39"},{"type":"subjects","id":"40"},{"type":"subjects","id":"41"},{"type":"subjects","id":"42"}]}}},{"id":"FurtherEducationSubject","type":"subject_areas","attributes":{"name":"Further education","typename":"FurtherEducationSubject"},"relationships":{"subjects":{"data":[{"type":"subjects","id":"43"}]}}}],"included":[{"id":"1","type":"subjects","attributes":{"subject_name":"Primary","subject_code":"00","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"2","type":"subjects","attributes":{"subject_name":"Primary with English","subject_code":"01","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"3","type":"subjects","attributes":{"subject_name":"Primary with geography and history","subject_code":"02","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"4","type":"subjects","attributes":{"subject_name":"Primary with mathematics","subject_code":"03","bursary_amount":"6000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"5","type":"subjects","attributes":{"subject_name":"Primary with modern languages","subject_code":"04","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"6","type":"subjects","attributes":{"subject_name":"Primary with physical education","subject_code":"06","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"7","type":"subjects","attributes":{"subject_name":"Primary with science","subject_code":"07","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"8","type":"subjects","attributes":{"subject_name":"Art and design","subject_code":"W1","bursary_amount":"9000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":false}},{"id":"9","type":"subjects","attributes":{"subject_name":"Science","subject_code":"F0","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"10","type":"subjects","attributes":{"subject_name":"Biology","subject_code":"C1","bursary_amount":"26000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"11","type":"subjects","attributes":{"subject_name":"Business studies","subject_code":"08","bursary_amount":"9000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":false}},{"id":"12","type":"subjects","attributes":{"subject_name":"Chemistry","subject_code":"F1","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"13","type":"subjects","attributes":{"subject_name":"Citizenship","subject_code":"09","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"14","type":"subjects","attributes":{"subject_name":"Classics","subject_code":"Q8","bursary_amount":"26000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":false}},{"id":"15","type":"subjects","attributes":{"subject_name":"Communication and media studies","subject_code":"P3","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"16","type":"subjects","attributes":{"subject_name":"Computing","subject_code":"11","bursary_amount":"26000","early_career_payments":null,"scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"17","type":"subjects","attributes":{"subject_name":"Dance","subject_code":"12","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"18","type":"subjects","attributes":{"subject_name":"Design and technology","subject_code":"DT","bursary_amount":"15000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"19","type":"subjects","attributes":{"subject_name":"Drama","subject_code":"13","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"20","type":"subjects","attributes":{"subject_name":"Economics","subject_code":"L1","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"21","type":"subjects","attributes":{"subject_name":"English","subject_code":"Q3","bursary_amount":"12000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"22","type":"subjects","attributes":{"subject_name":"Geography","subject_code":"F8","bursary_amount":"15000","early_career_payments":null,"scholarship":"17000","subject_knowledge_enhancement_course_available":true}},{"id":"23","type":"subjects","attributes":{"subject_name":"Health and social care","subject_code":"L5","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"24","type":"subjects","attributes":{"subject_name":"History","subject_code":"V1","bursary_amount":"9000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":false}},{"id":"25","type":"subjects","attributes":{"subject_name":"Mathematics","subject_code":"G1","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"26","type":"subjects","attributes":{"subject_name":"Music","subject_code":"W3","bursary_amount":"9000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":false}},{"id":"27","type":"subjects","attributes":{"subject_name":"Philosophy","subject_code":"P1","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"28","type":"subjects","attributes":{"subject_name":"Physical education","subject_code":"C6","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"29","type":"subjects","attributes":{"subject_name":"Physics","subject_code":"F3","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"30","type":"subjects","attributes":{"subject_name":"Psychology","subject_code":"C8","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"31","type":"subjects","attributes":{"subject_name":"Religious education","subject_code":"V6","bursary_amount":"9000","early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"32","type":"subjects","attributes":{"subject_name":"Social sciences","subject_code":"14","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"33","type":"subjects","attributes":{"subject_name":"Modern Languages","subject_code":null,"bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"34","type":"subjects","attributes":{"subject_name":"French","subject_code":"15","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"35","type":"subjects","attributes":{"subject_name":"English as a second or other language","subject_code":"16","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}},{"id":"36","type":"subjects","attributes":{"subject_name":"German","subject_code":"17","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"37","type":"subjects","attributes":{"subject_name":"Italian","subject_code":"18","bursary_amount":"26000","early_career_payments":"2000","scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"38","type":"subjects","attributes":{"subject_name":"Japanese","subject_code":"19","bursary_amount":"26000","early_career_payments":"2000","scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"39","type":"subjects","attributes":{"subject_name":"Mandarin","subject_code":"20","bursary_amount":"26000","early_career_payments":"2000","scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"40","type":"subjects","attributes":{"subject_name":"Russian","subject_code":"21","bursary_amount":"26000","early_career_payments":"2000","scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"41","type":"subjects","attributes":{"subject_name":"Spanish","subject_code":"22","bursary_amount":"26000","early_career_payments":"2000","scholarship":"28000","subject_knowledge_enhancement_course_available":true}},{"id":"42","type":"subjects","attributes":{"subject_name":"Modern languages (other)","subject_code":"24","bursary_amount":"26000","early_career_payments":"2000","scholarship":null,"subject_knowledge_enhancement_course_available":true}},{"id":"43","type":"subjects","attributes":{"subject_name":"Further education","subject_code":"41","bursary_amount":null,"early_career_payments":null,"scholarship":null,"subject_knowledge_enhancement_course_available":null}}],"jsonapi":{"version":"1.0"}}
+{
+  "data": [
+    {
+      "id": "PrimarySubject",
+      "type": "subject_areas",
+      "attributes": {
+        "name": "Primary",
+        "typename": "PrimarySubject"
+      },
+      "relationships": {
+        "subjects": {
+          "data": [
+            {
+              "type": "subjects",
+              "id": "1"
+            },
+            {
+              "type": "subjects",
+              "id": "2"
+            },
+            {
+              "type": "subjects",
+              "id": "3"
+            },
+            {
+              "type": "subjects",
+              "id": "4"
+            },
+            {
+              "type": "subjects",
+              "id": "5"
+            },
+            {
+              "type": "subjects",
+              "id": "6"
+            },
+            {
+              "type": "subjects",
+              "id": "7"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "SecondarySubject",
+      "type": "subject_areas",
+      "attributes": {
+        "name": "Secondary",
+        "typename": "SecondarySubject"
+      },
+      "relationships": {
+        "subjects": {
+          "data": [
+            {
+              "type": "subjects",
+              "id": "8"
+            },
+            {
+              "type": "subjects",
+              "id": "9"
+            },
+            {
+              "type": "subjects",
+              "id": "10"
+            },
+            {
+              "type": "subjects",
+              "id": "11"
+            },
+            {
+              "type": "subjects",
+              "id": "12"
+            },
+            {
+              "type": "subjects",
+              "id": "13"
+            },
+            {
+              "type": "subjects",
+              "id": "14"
+            },
+            {
+              "type": "subjects",
+              "id": "15"
+            },
+            {
+              "type": "subjects",
+              "id": "16"
+            },
+            {
+              "type": "subjects",
+              "id": "17"
+            },
+            {
+              "type": "subjects",
+              "id": "18"
+            },
+            {
+              "type": "subjects",
+              "id": "19"
+            },
+            {
+              "type": "subjects",
+              "id": "20"
+            },
+            {
+              "type": "subjects",
+              "id": "21"
+            },
+            {
+              "type": "subjects",
+              "id": "22"
+            },
+            {
+              "type": "subjects",
+              "id": "23"
+            },
+            {
+              "type": "subjects",
+              "id": "24"
+            },
+            {
+              "type": "subjects",
+              "id": "25"
+            },
+            {
+              "type": "subjects",
+              "id": "26"
+            },
+            {
+              "type": "subjects",
+              "id": "27"
+            },
+            {
+              "type": "subjects",
+              "id": "28"
+            },
+            {
+              "type": "subjects",
+              "id": "29"
+            },
+            {
+              "type": "subjects",
+              "id": "30"
+            },
+            {
+              "type": "subjects",
+              "id": "31"
+            },
+            {
+              "type": "subjects",
+              "id": "32"
+            },
+            {
+              "type": "subjects",
+              "id": "33"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "ModernLanguagesSubject",
+      "type": "subject_areas",
+      "attributes": {
+        "name": "Secondary: Modern languages",
+        "typename": "ModernLanguagesSubject"
+      },
+      "relationships": {
+        "subjects": {
+          "data": [
+            {
+              "type": "subjects",
+              "id": "34"
+            },
+            {
+              "type": "subjects",
+              "id": "35"
+            },
+            {
+              "type": "subjects",
+              "id": "36"
+            },
+            {
+              "type": "subjects",
+              "id": "37"
+            },
+            {
+              "type": "subjects",
+              "id": "38"
+            },
+            {
+              "type": "subjects",
+              "id": "39"
+            },
+            {
+              "type": "subjects",
+              "id": "40"
+            },
+            {
+              "type": "subjects",
+              "id": "41"
+            },
+            {
+              "type": "subjects",
+              "id": "42"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "FurtherEducationSubject",
+      "type": "subject_areas",
+      "attributes": {
+        "name": "Further education",
+        "typename": "FurtherEducationSubject"
+      },
+      "relationships": {
+        "subjects": {
+          "data": [
+            {
+              "type": "subjects",
+              "id": "43"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "included": [
+    {
+      "id": "1",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary",
+        "subject_code": "00",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "2",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with English",
+        "subject_code": "01",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "3",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with geography and history",
+        "subject_code": "02",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "4",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with mathematics",
+        "subject_code": "03",
+        "bursary_amount": "6000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "5",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with modern languages",
+        "subject_code": "04",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "6",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with physical education",
+        "subject_code": "06",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "7",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Primary with science",
+        "subject_code": "07",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "8",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Art and design",
+        "subject_code": "W1",
+        "bursary_amount": "9000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": false
+      }
+    },
+    {
+      "id": "9",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Science",
+        "subject_code": "F0",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "10",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Biology",
+        "subject_code": "C1",
+        "bursary_amount": "26000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "11",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Business studies",
+        "subject_code": "08",
+        "bursary_amount": "9000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": false
+      }
+    },
+    {
+      "id": "12",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Chemistry",
+        "subject_code": "F1",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "13",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Citizenship",
+        "subject_code": "09",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "14",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Classics",
+        "subject_code": "Q8",
+        "bursary_amount": "26000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": false
+      }
+    },
+    {
+      "id": "15",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Communication and media studies",
+        "subject_code": "P3",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "16",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Computing",
+        "subject_code": "11",
+        "bursary_amount": "26000",
+        "early_career_payments": null,
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "17",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Dance",
+        "subject_code": "12",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "18",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Design and technology",
+        "subject_code": "DT",
+        "bursary_amount": "15000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "19",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Drama",
+        "subject_code": "13",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "20",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Economics",
+        "subject_code": "L1",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "21",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "English",
+        "subject_code": "Q3",
+        "bursary_amount": "12000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "22",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Geography",
+        "subject_code": "F8",
+        "bursary_amount": "15000",
+        "early_career_payments": null,
+        "scholarship": "17000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "23",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Health and social care",
+        "subject_code": "L5",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "24",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "History",
+        "subject_code": "V1",
+        "bursary_amount": "9000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": false
+      }
+    },
+    {
+      "id": "25",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Mathematics",
+        "subject_code": "G1",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "26",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Music",
+        "subject_code": "W3",
+        "bursary_amount": "9000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": false
+      }
+    },
+    {
+      "id": "27",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Philosophy",
+        "subject_code": "P1",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "28",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Physical education",
+        "subject_code": "C6",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "29",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Physics",
+        "subject_code": "F3",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "30",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Psychology",
+        "subject_code": "C8",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "31",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Religious education",
+        "subject_code": "V6",
+        "bursary_amount": "9000",
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "32",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Social sciences",
+        "subject_code": "14",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "33",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Modern Languages",
+        "subject_code": null,
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "34",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "French",
+        "subject_code": "15",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "35",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "English as a second or other language",
+        "subject_code": "16",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    },
+    {
+      "id": "36",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "German",
+        "subject_code": "17",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "37",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Italian",
+        "subject_code": "18",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "38",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Japanese",
+        "subject_code": "19",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "39",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Mandarin",
+        "subject_code": "20",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "40",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Russian",
+        "subject_code": "21",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "41",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Spanish",
+        "subject_code": "22",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": "28000",
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "42",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Modern languages (other)",
+        "subject_code": "24",
+        "bursary_amount": "26000",
+        "early_career_payments": "2000",
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": true
+      }
+    },
+    {
+      "id": "43",
+      "type": "subjects",
+      "attributes": {
+        "subject_name": "Further education",
+        "subject_code": "41",
+        "bursary_amount": null,
+        "early_career_payments": null,
+        "scholarship": null,
+        "subject_knowledge_enhancement_course_available": null
+      }
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  }
+}

--- a/spec/requests/location_suggestions_spec.rb
+++ b/spec/requests/location_suggestions_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe '/location-suggestions', type: :request do
+  include StubbedRequests::LocationSuggestions
+
   context 'when provider suggestion is blank' do
     it 'returns bad request (400)' do
       get '/location-suggestions'
@@ -13,11 +15,7 @@ describe '/location-suggestions', type: :request do
   context 'when location suggestion query is valid' do
     it 'returns success (200)' do
       query = 'london'
-      location_suggestions = stub_request(
-        :get,
-        "#{Settings.google.places_api_host}/maps/api/place/autocomplete/json?components=country:uk&input=#{query}&key=replace_me&language=en&types=geocode",
-      ).to_return(body: File.new('spec/fixtures/api_responses/location-suggestions.json'))
-
+      location_suggestions = stub_location_suggestions(query: query)
       get "/location-suggestions?query=#{query}"
 
       expect(location_suggestions).to have_been_requested

--- a/spec/requests/provider_suggestions_spec.rb
+++ b/spec/requests/provider_suggestions_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe '/provider-suggestions', type: :request do
+  include StubbedRequests::ProviderSuggestions
+
   context 'when provider suggestion is blank' do
     it 'returns bad request (400)' do
       get '/provider-suggestions'
@@ -25,11 +27,7 @@ describe '/provider-suggestions', type: :request do
 
     [query, query_with_unicode_character].each do |provider_query|
       it "returns success (200) for query: '#{provider_query}'" do
-        provider_suggestions = stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=#{provider_query}")
-                                 .to_return(
-                                   headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-                                   body: File.new('spec/fixtures/api_responses/provider-suggestions.json'),
-                                 )
+        provider_suggestions = stub_provider_suggestions(query: provider_query)
 
         get "/provider-suggestions?query=#{provider_query}"
 

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe '/results', type: :request do
+  include StubbedRequests::Courses
+
   context 'a valid request' do
     before do
       stub_request(
@@ -11,12 +13,7 @@ describe '/results', type: :request do
         headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
       )
 
-      stub_request(:get, courses_url)
-        .with(query: results_page_parameters)
-        .to_return(
-          body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-        )
+      stub_courses(query: results_page_parameters, course_count: 10)
     end
 
     it 'returns success (200)' do

--- a/spec/requests/results_spec.rb
+++ b/spec/requests/results_spec.rb
@@ -2,17 +2,11 @@ require 'rails_helper'
 
 describe '/results', type: :request do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   context 'a valid request' do
     before do
-      stub_request(
-        :get,
-        "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-      ).to_return(
-        body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
-
+      stub_subjects
       stub_courses(query: results_page_parameters, course_count: 10)
     end
 
@@ -24,14 +18,7 @@ describe '/results', type: :request do
 
   context 'API returns client error (400)' do
     before do
-      stub_request(
-        :get,
-        "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-      ).to_return(
-        body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-      )
-
+      stub_subjects
       stub_request(:get, courses_url)
         .with(query: results_page_parameters)
         .to_return(status: 400)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ RSpec.configure do |config|
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend
   #   # you configure your source control system to ignore this file.
-  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = 'tmp/rspec-failures'
   #
   #   # Limits the available syntax to the non-monkey patched syntax that is
   #   # recommended. For more details, see:

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -67,10 +67,6 @@ module Helpers
     expect(page).to be_displayed
     expect(Rack::Utils.parse_nested_query(current_query_string)).to eq(expected_query_params)
   end
-
-  def courses_url
-    "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
-  end
 end
 
 RSpec.configure do |config|

--- a/spec/support/stub_subjects_request.rb
+++ b/spec/support/stub_subjects_request.rb
@@ -1,9 +1,0 @@
-def stub_subjects_request
-  stub_request(
-    :get,
-    "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-  ).to_return(
-    body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-    headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-  )
-end

--- a/spec/support/stubbed_requests/courses.rb
+++ b/spec/support/stubbed_requests/courses.rb
@@ -1,0 +1,32 @@
+module StubbedRequests
+  module Courses
+    def stub_courses(query:, course_count:)
+      fixture_file = course_fixture(course_count)
+      stub_request(:get, courses_url)
+        .with(query: query)
+        .to_return(
+          body: File.new("spec/fixtures/api_responses/#{fixture_file}"),
+          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+        )
+    end
+
+    def course_fixture(course_count)
+      case course_count
+      when 0
+        'empty_courses.json'
+      when 1
+        'one_course.json'
+      when 2
+        'two_courses.json'
+      when 4
+        'four_courses.json'
+      when 10
+        'ten_courses.json'
+      end
+    end
+
+    def courses_url
+      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+    end
+  end
+end

--- a/spec/support/stubbed_requests/location_suggestions.rb
+++ b/spec/support/stubbed_requests/location_suggestions.rb
@@ -1,0 +1,10 @@
+module StubbedRequests
+  module LocationSuggestions
+    def stub_location_suggestions(query:)
+      stub_request(
+        :get,
+        "#{Settings.google.places_api_host}/maps/api/place/autocomplete/json?components=country:uk&input=#{query}&key=replace_me&language=en&types=geocode",
+      ).to_return(body: File.new('spec/fixtures/api_responses/location-suggestions.json'))
+    end
+  end
+end

--- a/spec/support/stubbed_requests/provider_suggestions.rb
+++ b/spec/support/stubbed_requests/provider_suggestions.rb
@@ -1,0 +1,11 @@
+module StubbedRequests
+  module ProviderSuggestions
+    def stub_provider_suggestions(query:)
+      stub_request(:get, "#{Settings.teacher_training_api.base_url}/api/v3/provider-suggestions?query=#{query}")
+        .to_return(
+          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+          body: File.new('spec/fixtures/api_responses/provider-suggestions.json'),
+        )
+    end
+  end
+end

--- a/spec/support/stubbed_requests/providers.rb
+++ b/spec/support/stubbed_requests/providers.rb
@@ -1,0 +1,34 @@
+module StubbedRequests
+  module Providers
+    def stub_empty_providers(query: nil)
+      stub_request(:get, providers_url)
+        .with(query: query)
+        .to_return(
+          body: File.new('spec/fixtures/api_responses/empty_providers.json'),
+          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+        )
+    end
+
+    def stub_one_provider(query: nil)
+      stub_request(:get, providers_url)
+        .with(query: query)
+        .to_return(
+          body: File.new('spec/fixtures/api_responses/one_provider.json'),
+          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+        )
+    end
+
+    def stub_providers(query: nil)
+      stub_request(:get, providers_url)
+        .with(query: query)
+        .to_return(
+          body: File.new('spec/fixtures/api_responses/providers.json'),
+          headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+        )
+    end
+
+    def providers_url
+      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers"
+    end
+  end
+end

--- a/spec/support/stubbed_requests/subject_areas.rb
+++ b/spec/support/stubbed_requests/subject_areas.rb
@@ -1,0 +1,13 @@
+module StubbedRequests
+  module SubjectAreas
+    def stub_subject_areas
+      stub_request(
+        :get,
+        "#{Settings.teacher_training_api.base_url}/api/v3/subject_areas?include=subjects",
+      ).to_return(
+        body: File.new('spec/fixtures/api_responses/subject_areas.json'),
+        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+      )
+    end
+  end
+end

--- a/spec/support/stubbed_requests/subjects.rb
+++ b/spec/support/stubbed_requests/subjects.rb
@@ -1,0 +1,13 @@
+module StubbedRequests
+  module Subjects
+    def stub_subjects
+      stub_request(
+        :get,
+        "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
+      ).to_return(
+        body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
+        headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
+      )
+    end
+  end
+end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 describe ResultsView do
+  include StubbedRequests::Courses
+
   let(:query_parameters) { ActionController::Parameters.new(parameter_hash) }
 
   let(:default_output_parameters) do
@@ -383,12 +385,7 @@ describe ResultsView do
 
     context 'there are more than three results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 10)
       end
 
       it { is_expected.to be(10) }
@@ -396,12 +393,7 @@ describe ResultsView do
 
     context 'there are no results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/empty_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 0)
       end
 
       it { is_expected.to be(0) }
@@ -467,12 +459,7 @@ describe ResultsView do
 
     context 'there are more than three results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 10)
       end
 
       it { is_expected.to be(false) }
@@ -480,19 +467,8 @@ describe ResultsView do
 
     context 'there are less than three results and there are suggested courses found' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/two_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
-
-        stub_request(:get, courses_url)
-          .with(query: suggested_search_count_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 2)
+        stub_courses(query: suggested_search_count_parameters, course_count: 10)
       end
 
       it { is_expected.to be(true) }
@@ -500,18 +476,8 @@ describe ResultsView do
 
     context 'there are less than three results and there are no suggested courses found' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/two_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
-        stub_request(:get, courses_url)
-          .with(query: suggested_search_count_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/empty_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 2)
+        stub_courses(query: suggested_search_count_parameters, course_count: 0)
       end
 
       it { is_expected.to be(false) }
@@ -747,12 +713,7 @@ describe ResultsView do
 
     context 'there are more than three results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/ten_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 10)
       end
 
       it { is_expected.to eq(false) }
@@ -760,12 +721,7 @@ describe ResultsView do
 
     context 'there are no results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/empty_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 0)
       end
 
       it { is_expected.to eq(true) }
@@ -777,12 +733,7 @@ describe ResultsView do
 
     context 'there are two results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/two_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 2)
       end
 
       it { is_expected.to eq('2 courses') }
@@ -790,12 +741,7 @@ describe ResultsView do
 
     context 'there is one result' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/one_course.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 1)
       end
 
       it { is_expected.to eq('1 course') }
@@ -803,12 +749,7 @@ describe ResultsView do
 
     context 'there are no results' do
       before do
-        stub_request(:get, courses_url)
-          .with(query: results_page_parameters)
-          .to_return(
-            body: File.new('spec/fixtures/api_responses/empty_courses.json'),
-            headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-          )
+        stub_courses(query: results_page_parameters, course_count: 0)
       end
 
       it { is_expected.to eq('No courses') }

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 describe ResultsView do
   include StubbedRequests::Courses
+  include StubbedRequests::Subjects
 
   let(:query_parameters) { ActionController::Parameters.new(parameter_hash) }
 
@@ -16,13 +17,7 @@ describe ResultsView do
   end
 
   before do
-    stub_request(
-      :get,
-      "#{Settings.teacher_training_api.base_url}/api/v3/subjects?fields%5Bsubjects%5D=subject_name,subject_code&sort=subject_name",
-    ).to_return(
-      body: File.new('spec/fixtures/api_responses/subjects_sorted_name_code.json'),
-      headers: { "Content-Type": 'application/vnd.api+json; charset=utf-8' },
-    )
+    stub_subjects
   end
 
   describe '#query_parameters_with_defaults' do

--- a/spec/views/results/non_university_spec.rb
+++ b/spec/views/results/non_university_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'results/non_university.html.erb', type: :view do
   let(:html) do
-    render partial: 'results/non_university.html.erb', locals: { course: course }
+    render partial: 'results/non_university', locals: { course: course }
   end
 
   let(:site1) do

--- a/spec/views/results/try_another_search_text_spec.rb
+++ b/spec/views/results/try_another_search_text_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'results/try_another_search_text.html.erb', type: :view do
-  let(:html) { render partial: 'results/try_another_search_text.html.erb' }
+  let(:html) { render partial: 'results/try_another_search_text' }
   let(:salary_suffix) { 'or searching for courses that do not offer a salary' }
 
   before do

--- a/spec/views/results/university_spec.rb
+++ b/spec/views/results/university_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'results/university.html.erb', type: :view do
   let(:html) do
-    render partial: 'results/university.html.erb', locals: { course: course }
+    render partial: 'results/university', locals: { course: course }
   end
 
   let(:site1) do

--- a/spec/views/shared/hidden_previous_fields_spec.rb
+++ b/spec/views/shared/hidden_previous_fields_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'shared/hidden_previous_fields.html.erb', type: :view do
 
   before do
     allow(form_builder).to receive(:hidden_field)
-    render partial: 'shared/hidden_previous_fields.html.erb', locals: { form: form_builder, params: params }
+    render partial: 'shared/hidden_previous_fields', locals: { form: form_builder, params: params }
   end
 
   context 'prev_ parameters are present in the params' do


### PR DESCRIPTION
### Context

We stub various requests across the test suite, returning the contents of one of several JSON fixture files. This tends to be quite verbose, so this PR adds some helpers to take care of this stubbing.

### Changes proposed in this pull request
- A couple of test suite improvements - support for `--only-failures` and fixing some deprecation warnings.
- Replace every inline case of a request being stubbed to return a JSON fixture with a helper that does the same.

### Guidance to review
- Per-commit highly recommended, each set of replacements has been batched by the kind of endpoint being stubbed.
- Is it clear enough? Has anything been missed?
 
### Trello card
https://trello.com/c/cAWS3e8v
### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
