### PR TITLE
Use govuk-components `Details` component

### DIFF
--- a/app/views/courses/qualification/_pgce.html.erb
+++ b/app/views/courses/qualification/_pgce.html.erb
@@ -1,16 +1,11 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate certificate in education (PGCE) is an academic qualification in education.
-    </p>
-    <p class="govuk-body">
-      It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      This course does not lead to qualified teacher status (QTS).
-    </p>
-  </div>
-</details>
+<%= render GovukComponent::Details.new(summary: 'PGCE') do %>
+  <p class="govuk-body">
+    A postgraduate certificate in education (PGCE) is an academic qualification in education.
+  </p>
+  <p class="govuk-body">
+    It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+  </p>
+  <p class="govuk-body">
+    This course does not lead to qualified teacher status (QTS).
+  </p>
+<% end %>

--- a/app/views/courses/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgce_with_qts.html.erb
@@ -1,16 +1,11 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGCE with QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      Many PGCE courses include credits that count toward a Master&rsquo;s degree.
-    </p>
-  </div>
-</details>
+<%= render GovukComponent::Details.new(summary: 'PGCE with QTS') do %>
+  <p class="govuk-body">
+    A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
+  </p>
+  <p class="govuk-body">
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+  </p>
+  <p class="govuk-body">
+    Many PGCE courses include credits that count toward a Master&rsquo;s degree.
+  </p>
+<% end %>

--- a/app/views/courses/qualification/_pgde.html.erb
+++ b/app/views/courses/qualification/_pgde.html.erb
@@ -1,16 +1,11 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
-    </p>
-    <p class="govuk-body">
-      It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      This course does not lead to qualified teacher status (QTS).
-    </p>
-  </div>
-</details>
+<%= render GovukComponent::Details.new(summary: 'PGDE') do %>
+  <p class="govuk-body">
+    A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
+  </p>
+  <p class="govuk-body">
+    It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+  </p>
+  <p class="govuk-body">
+    This course does not lead to qualified teacher status (QTS).
+  </p>
+<% end %>

--- a/app/views/courses/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgde_with_qts.html.erb
@@ -1,16 +1,11 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">PGDE with QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-    <p class="govuk-body">
-      Many PGDE courses include credits towards a Master&rsquo;s degree.
-    </p>
-  </div>
-</details>
+<%= render GovukComponent::Details.new(summary: 'PGDE with QTS') do %>
+  <p class="govuk-body">
+    A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
+  </p>
+  <p class="govuk-body">
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+  </p>
+  <p class="govuk-body">
+    Many PGDE courses include credits towards a Master&rsquo;s degree.
+  </p>
+<% end %>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -1,16 +1,11 @@
-<details class="govuk-details" data-module="govuk-details">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">QTS</span>
-  </summary>
-  <div class="govuk-details__text">
-    <p class="govuk-body">
-      Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
-    </p>
-    <p class="govuk-body">
-      It may also allow you to teach in <%= link_to "the EU and EEA", "https://www.gov.uk/eu-eea", class: "govuk-link" %>, though this could change after 2020.
-    </p>
-    <p class="govuk-body">
-      If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
-    </p>
-  </div>
-</details>
+<%= render GovukComponent::Details.new(summary: 'QTS') do %>
+  <p class="govuk-body">
+    Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
+  </p>
+  <p class="govuk-body">
+    It may also allow you to teach in <%= link_to "the EU and EEA", "https://www.gov.uk/eu-eea", class: "govuk-link" %>, though this could change after 2020.
+  </p>
+  <p class="govuk-body">
+    If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+  </p>
+<% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -19,26 +19,21 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <div>
-      <details class="govuk-details" role="group">
-        <summary class="govuk-details__summary" role="button">
-          <span class="govuk-details__summary-text">Try another provider</span>
-        </summary>
-        <div class="govuk-details__text">
-          <%= form_with url: provider_path, method: :get, data: { "ga-event-form" => "Provider" } do |form| %>
-            <fieldset class="govuk-fieldset">
-              <div class="govuk-form-group">
-                <%= form.label :query, class: "govuk-label" do %>
-                  <strong>School, university or other training provider</strong>
-                  <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
-                <% end %>
-                <%= form.text_field :query, class: "govuk-input" %>
-              </div>
+      <%= render GovukComponent::Details.new(summary: 'Try another provider') do %>
+        <%= form_with url: provider_path, method: :get, data: { "ga-event-form" => "Provider" } do |form| %>
+          <fieldset class="govuk-fieldset">
+            <div class="govuk-form-group">
+              <%= form.label :query, class: "govuk-label" do %>
+                <strong>School, university or other training provider</strong>
+                <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
+              <% end %>
+              <%= form.text_field :query, class: "govuk-input" %>
+            </div>
 
-              <%= form.submit "Search again", name: nil, class: "govuk-button" %>
-            </fieldset>
-          <% end %>
-        </div>
-      </details>
+            <%= form.submit "Search again", name: nil, class: "govuk-button" %>
+          </fieldset>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -7,18 +7,13 @@
         <span class="govuk-list--description__hint govuk-!-margin-top-0">University</span>
       <% else %>
         <span class="govuk-list--description__hint govuk-!-margin-top-0">Placement schools</span>
-        <details class="govuk-details" data-module="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">
-              <%= @results_view.placement_schools_summary(course) %>
-            </span>
-          </summary>
-          <div class="govuk-details__text">
-            <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
-            <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-            <%= link_to "More about placements on this course", course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: "govuk-link" %>
-          </div>
-        </details>
+        <%= render GovukComponent::Details.new(
+          summary: @results_view.placement_schools_summary(course),
+        ) do %>
+          <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
+          <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+          <%= link_to "More about placements on this course", course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: "govuk-link" %>
+        <% end %>
         You’ll be placed in schools for most of your course
         <span class="govuk-list--description__hint govuk-!-padding-top-2">University</span>
       <% end %>


### PR DESCRIPTION
### Context

This is a follow-up to https://github.com/DFE-Digital/find-teacher-training/pull/610 in which we introduced the `govuk-components` gem and began using those components in views. This PR uses the the Details component.

### Changes proposed in this pull request

- [x] Replace details pattern in Results, Course details and Pick a Provider pages with a `Details` component.

### Guidance to review

There should be no visible changes as a result of this PR.

### Trello card

https://trello.com/c/53RWVPVj/2826-dev-use-govuk-view-components-in-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
