### PR TITLE
Update Ruby Pants configuration (dashes)

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -22,7 +22,7 @@ module ApplicationHelper
   def smart_quotes(string)
     return '' if string.blank?
 
-    RubyPants.new(string, 2, ruby_pants_options).to_html
+    RubyPants.new(string, [2, :dashes], ruby_pants_options).to_html
   end
 
 private

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -34,7 +34,7 @@ describe 'Application helpers', type: :helper do
     end
 
     it 'converts quotes to smart quotes' do
-      output = helper.markdown("\"Wow -- what's this...\", O'connor asked.")
+      output = helper.markdown("\"Wow – what's this...\", O'connor asked.")
       expect(output).to eq('<p class="govuk-body">“Wow – what’s this…”, O’connor asked.</p>')
     end
 
@@ -47,8 +47,13 @@ describe 'Application helpers', type: :helper do
 
   describe '#smart_quotes' do
     it 'converts quotes to smart quotes' do
-      output = helper.smart_quotes("\"Wow -- what's this...\", O'connor asked.")
+      output = helper.smart_quotes("\"Wow – what's this...\", O'connor asked.")
       expect(output).to include('“Wow – what’s this…”, O’connor asked.')
+    end
+
+    it 'does not convert three consecutive dashes to an em dash' do
+      output = helper.smart_quotes('https://www.londonmet.ac.uk/courses/postgraduate/pgce-secondary-science-with-biology---pgce')
+      expect(output).to include('https://www.londonmet.ac.uk/courses/postgraduate/pgce-secondary-science-with-biology---pgce')
     end
 
     context 'when nil' do


### PR DESCRIPTION
### Context
London Metropolitan University has included a url containing three consecutive dashes ( --- ) inside its 'about course' description. When the url is displayed on Find, RubyPants is converting the three consecutive dashes to an em dash, breaking the link.

[Monster Slack thread](https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1610725336016200)

### Changes proposed in this pull request
The RubyPants config has been updated to ignore three consecutive dashes and therefore not convert to an em dash

### Trello card
https://trello.com/c/mbieHoJC/127-find-url-error

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
