### PR TITLE
Readable rspec output in build workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ brakeman: ## Run Brakeman static analysis
 
 .PHONY: rspec
 rspec: ## Run Ruby tests
-		docker run --name find-rspec-runner ${IMAGE} \
-		                  rails spec SPEC_OPTS='--format RspecJunitFormatter --out rspec-results.xml'
+		docker run -t -e RAILS_ENV=test --name find-rspec-runner ${IMAGE} \
+		                  rspec --format RspecJunitFormatter --out rspec-results.xml --format documentation
 		test_result=$$?
 		docker cp find-rspec-runner:/app/coverage .
 		docker cp find-rspec-runner:/app/rspec-results.xml .

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,4 +35,7 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+
+  # Only log warnings and above in test environment.
+  config.log_level = :warn
 end


### PR DESCRIPTION
### Context

Rspec errors are difficult to find in build results

### Changes proposed in this pull request

Setting RAILS_ENV=test and turning off verbose logging in test.rb
use `rspec --format documentation` for better console output


### Trello card
https://trello.com/c/dYRnEQg6/2893-find-github-actions-build-is-not-exporting-rspec-results

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
