### PR TITLE
Fix image to alpine:3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_RUBY_IMAGE=ruby:2.7.2-alpine
+ARG BASE_RUBY_IMAGE=ruby:2.7.2-alpine3.12
 
 FROM ${BASE_RUBY_IMAGE} AS base-image
 


### PR DESCRIPTION
### Context
alpine has released version 3.13 with an updated verrsion of node.

### Changes proposed in this pull request

Use `ruby-2.7.2:alpine-3.12`

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
