### PR TITLE
Manage StatusCake in Terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,8 @@ jobs:
           TF_VAR_paas_app_docker_image: ${{ env.DOCKER_IMAGE }}
           TF_VAR_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
           TF_VAR_dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
+          TF_VAR_statuscake_password: ${{ secrets.STATUSCAKE_PASSWORD }}
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1.1

--- a/terraform/modules/statuscake/main.tf
+++ b/terraform/modules/statuscake/main.tf
@@ -1,0 +1,12 @@
+resource statuscake_test alert {
+  for_each = var.alerts
+
+  website_name   = each.value.website_name
+  website_url    = each.value.website_url
+  test_type      = each.value.test_type
+  check_rate     = each.value.check_rate
+  contact_group  = each.value.contact_group
+  trigger_rate   = each.value.trigger_rate
+  node_locations = each.value.node_locations
+  confirmations  = 2
+}

--- a/terraform/modules/statuscake/providers.tf
+++ b/terraform/modules/statuscake/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    statuscake = {
+      source  = "terraform-providers/statuscake"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/terraform/modules/statuscake/variables.tf
+++ b/terraform/modules/statuscake/variables.tf
@@ -1,0 +1,1 @@
+variable alerts { type = map }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -10,8 +10,8 @@ terraform {
       version = "0.12.6"
     }
     statuscake = {
-      source  = "thde/statuscake"
-      version = "1.1.2"
+      source  = "terraform-providers/statuscake"
+      version = "1.0.0"
     }
   }
   backend "azurerm" {
@@ -32,4 +32,15 @@ module paas {
   logstash_url              = var.paas_logstash_url
   app_environment_variables = local.paas_app_environment_variables
   docker_credentials        = local.docker_credentials
+}
+
+provider statuscake {
+  username = var.statuscake_username
+  apikey   = var.statuscake_password
+}
+
+module statuscake {
+  source = "./modules/statuscake"
+
+  alerts = var.statuscake_alerts
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,16 @@ variable dockerhub_username {}
 
 variable dockerhub_password {}
 
+#StatusCake
+variable statuscake_alerts {
+  type    = map
+  default = {}
+}
+
+variable statuscake_username { default = "not-empty" }
+
+variable statuscake_password { default = "not-empty" }
+
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
   app_config                     = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment]

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -3,3 +3,17 @@ paas_sso_code          = ""
 paas_app_environment   = "prod"
 paas_web_app_instances = 2
 paas_web_app_memory    = 1024
+
+
+#StatusCake
+statuscake_alerts = {
+  find-prod = {
+    website_name   = "find-teacher-training-prod"
+    website_url    = "https://www.find-postgraduate-teacher-training.service.gov.uk/ping"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [151103]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -3,3 +3,16 @@ paas_sso_code          = ""
 paas_app_environment   = "qa"
 paas_web_app_instances = 1
 paas_web_app_memory    = 512
+
+#StatusCake
+statuscake_alerts = {
+  find-qa = {
+    website_name   = "find-teacher-training-qa"
+    website_url    = "https://qa.find-postgraduate-teacher-training.service.gov.uk/ping"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -3,3 +3,16 @@ paas_sso_code          = ""
 paas_app_environment   = "staging"
 paas_web_app_instances = 2
 paas_web_app_memory    = 512
+
+#StatusCake
+statuscake_alerts = {
+  find-staging = {
+    website_name   = "find-teacher-training-staging"
+    website_url    = "https://staging.find-postgraduate-teacher-training.service.gov.uk/ping"
+    test_type      = "HTTP"
+    check_rate     = 60
+    contact_group  = [188603]
+    trigger_rate   = 0
+    node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
+  }
+}


### PR DESCRIPTION
### Context
Managing Find StatusCake configuration using terraform.

Find statuscake was managed from Azure pipelines which has now been disabled.


`node_locations` from https://app.statuscake.com/API/Locations/json
Also see https://www.statuscake.com/kb/knowledge-base/my-test-isnt-using-the-locations-i-set/

### Changes proposed in this pull request
StatusCake configuration inside terraform

### Guidance to review

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
