### PR TITLE
Manage secrets in KeyVault

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,13 +72,6 @@ jobs:
         with:
           terraform_version: 0.13.5
 
-      - name: Download app configuration file
-        working-directory: terraform
-        run: |
-          echo $APP_SECRETS | base64 -d >> app_secrets.yml
-        env:
-          APP_SECRETS: ${{ secrets[format('APP_SECRETS_{0}', env.DEPLOY_ENV)] }}
-
       - name: Terraform init, plan & apply
         id: terraform_deploy
         run: |
@@ -87,15 +80,9 @@ jobs:
           terraform apply -auto-approve -input=false "tfplan"
         working-directory: terraform
         env:
-          ARM_ACCESS_KEY: ${{ secrets[format('TERRAFORM_STATE_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_paas_user: ${{ secrets[format('CF_USER_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_paas_password: ${{ secrets[format('CF_PASSWORD_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_paas_logstash_url: ${{ secrets.LOGSTASH_URL }}
+          ARM_ACCESS_KEY:               ${{ secrets[format('TERRAFORM_STATE_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
+          TF_VAR_azure_credentials:     ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
           TF_VAR_paas_app_docker_image: ${{ env.DOCKER_IMAGE }}
-          TF_VAR_dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
-          TF_VAR_dockerhub_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
-          TF_VAR_statuscake_password: ${{ secrets.STATUSCAKE_PASSWORD }}
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1.1

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,14 @@
+data azurerm_key_vault key_vault {
+  name                = var.key_vault_name
+  resource_group_name = var.key_vault_resource_group
+}
+
+data azurerm_key_vault_secret app_secrets {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = var.key_vault_app_secret_name
+}
+
+data azurerm_key_vault_secret infra_secrets {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = var.key_vault_infra_secret_name
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.29.0"
+      version = "2.45.1"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
@@ -14,30 +14,40 @@ terraform {
       version = "1.0.0"
     }
   }
-  backend "azurerm" {
+  backend azurerm {
   }
+}
+
+provider azurerm {
+  features {}
+
+  skip_provider_registration = true
+  subscription_id            = local.azure_credentials.subscriptionId
+  client_id                  = local.azure_credentials.clientId
+  client_secret              = local.azure_credentials.clientSecret
+  tenant_id                  = local.azure_credentials.tenantId
 }
 
 module paas {
   source = "./modules/paas"
 
   cf_api_url                = local.cf_api_url
-  cf_user                   = var.paas_user
-  cf_user_password          = var.paas_password
+  cf_user                   = local.infra_secrets.CF_USER
+  cf_user_password          = local.infra_secrets.CF_PASSWORD
   cf_sso_passcode           = var.paas_sso_code
   cf_space                  = var.paas_cf_space
   app_environment           = var.paas_app_environment
   app_docker_image          = var.paas_app_docker_image
   web_app_instances         = var.paas_web_app_instances
   web_app_memory            = var.paas_web_app_memory
-  logstash_url              = var.paas_logstash_url
+  logstash_url              = local.infra_secrets.LOGSTASH_URL
   app_environment_variables = local.paas_app_environment_variables
   docker_credentials        = local.docker_credentials
 }
 
 provider statuscake {
-  username = var.statuscake_username
-  apikey   = var.statuscake_password
+  username = local.infra_secrets.STATUSCAKE_USERNAME
+  apikey   = local.infra_secrets.STATUSCAKE_PASSWORD
 }
 
 module statuscake {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,3 @@
-variable paas_user {}
-
-variable paas_password {}
-
 variable paas_sso_code {}
 
 variable paas_cf_space {}
@@ -14,15 +10,17 @@ variable paas_web_app_instances { default = 1 }
 
 variable paas_web_app_memory { default = 512 }
 
-variable paas_logstash_url {}
-
 variable paas_app_config_file { default = "./workspace_variables/app_config.yml" }
 
-variable paas_app_secrets_file { default = "./app_secrets.yml" }
+variable key_vault_name {}
 
-variable dockerhub_username {}
+variable key_vault_resource_group {}
 
-variable dockerhub_password {}
+variable key_vault_app_secret_name {}
+
+variable key_vault_infra_secret_name {}
+
+variable azure_credentials {}
 
 #StatusCake
 variable statuscake_alerts {
@@ -30,17 +28,15 @@ variable statuscake_alerts {
   default = {}
 }
 
-variable statuscake_username { default = "not-empty" }
-
-variable statuscake_password { default = "not-empty" }
-
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
   app_config                     = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment]
-  app_secrets                    = yamldecode(file(var.paas_app_secrets_file))
+  app_secrets                    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
+  infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.app_config, local.app_secrets)
   docker_credentials = {
-    username = var.dockerhub_username
-    password = var.dockerhub_password
+    username = local.infra_secrets.DOCKERHUB_USERNAME
+    password = local.infra_secrets.DOCKERHUB_PASSWORD
   }
+  azure_credentials = jsondecode(var.azure_credentials)
 }

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -5,6 +5,11 @@ paas_cf_space          = "bat-prod"
 paas_web_app_instances = 2
 paas_web_app_memory    = 1024
 
+# KeyVault
+key_vault_name              = "s121p01-shared-kv-01"
+key_vault_resource_group    = "s121p01-shared-rg"
+key_vault_app_secret_name   = "FIND-APP-SECRETS-PRODUCTION"
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -5,6 +5,12 @@ paas_cf_space          = "bat-qa"
 paas_web_app_instances = 1
 paas_web_app_memory    = 512
 
+# KeyVault
+key_vault_name              = "s121d01-shared-kv-01"
+key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_app_secret_name   = "FIND-APP-SECRETS-QA"
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
+
 #StatusCake
 statuscake_alerts = {
   find-qa = {

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -5,6 +5,12 @@ paas_cf_space          = "bat-prod"
 paas_web_app_instances = 2
 paas_web_app_memory    = 512
 
+# KeyVault
+key_vault_name              = "s121p01-shared-kv-01"
+key_vault_resource_group    = "s121p01-shared-rg"
+key_vault_app_secret_name   = "FIND-APP-SECRETS-SANDBOX"
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
+
 #StatusCake
 statuscake_alerts = {
   find-sandbox = {

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -5,6 +5,12 @@ paas_cf_space          = "bat-staging"
 paas_web_app_instances = 2
 paas_web_app_memory    = 512
 
+# KeyVault
+key_vault_name              = "s121t01-shared-kv-01"
+key_vault_resource_group    = "s121t01-shared-rg"
+key_vault_app_secret_name   = "FIND-APP-SECRETS-STAGING"
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
+
 #StatusCake
 statuscake_alerts = {
   find-staging = {


### PR DESCRIPTION
Move secrets from GitHub to Azure KeyVault

BAT-INFRA-SECRETS-{ENV} & FIND-APP-SECRETS-{ENV}
stored in Azure KeyVault

### Context

Managing secrets in GitHub Secrets makes it difficult to view/edit secrets.
Storing Application Secrets and Infrastructure as separate yaml files in KeyVault 
and accessing them directly using terraform during deployment.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
