### PR TITLE
Update ordering of information on course detail pages

### DIFF
--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,9 +1,11 @@
-<h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-<p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
+<div class="govuk-!-margin-bottom-8">
+  <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
+  <p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
 
-<h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-<p class="govuk-body"><%= link_to "Register with #{t('service_name.get_into_teaching')}", t('get_into_teaching.url_get_an_advisor'), class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events.</p>
-<p class="govuk-body">You can also call them free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their <%= link_to "online chat service", t('get_into_teaching.url_online_chat'), class: 'govuk-link' %> <%= t('get_into_teaching.opening_times') %>.</p>
+  <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
+  <p class="govuk-body"><%= govuk_link_to "Register with #{t('service_name.get_into_teaching')}", t('get_into_teaching.url_get_an_advisor') %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events.</p>
+  <p class="govuk-body">You can also call them free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their <%= govuk_link_to "online chat service", t('get_into_teaching.url_online_chat') %> <%= t('get_into_teaching.opening_times') %>.</p>
 
-<h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
-<p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>
+  <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
+  <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>
+</div>

--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -2,9 +2,7 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= Settings.google.maps_api_key %>&callback=initLocationsMap" async defer></script>
 <% end %>
 
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
-
+<div class="govuk-!-margin-bottom-8" id="section-apply">
   <% if @course.has_vacancies? %>
     <% if FeatureFlag.active?(:display_apply_button) %>
       <p class="govuk-body">

--- a/app/views/courses/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/_entry_requirements_qualifications.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-entry">Requirements</h2>
+  <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
   <% if course.required_qualifications.present? %>
     <h3 class="govuk-heading-m">Qualifications</h3>
     <div data-qa="course__required_qualifications">

--- a/app/views/courses/_fees.html.erb
+++ b/app/views/courses/_fees.html.erb
@@ -1,6 +1,4 @@
-<div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-fees">Fees</h2>
-
+<div>
   <% if course.fee_uk_eu.present? %>
     <div class="body-text">
       <% if course.fee_uk_eu.present? && course.fee_international.present? %>

--- a/app/views/courses/_fees_and_financial_support.html.erb
+++ b/app/views/courses/_fees_and_financial_support.html.erb
@@ -1,5 +1,9 @@
 <div class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
+  <h2 class="govuk-heading-l" id="section-financial-support">Fees and financial support</h2>
+
+  <% if course.has_fees? %>
+    <%= render partial: 'courses/fees' %>
+  <% end %>
 
   <% if course.salaried? %>
     <%= render partial: 'courses/financial_support/salaried' %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -57,25 +57,23 @@
         <% if course.how_school_placements_work.present? %>
           <li><%= link_to course.placements_heading, '#section-schools', class: 'govuk-link' %></li>
         <% end %>
-        <% if course.interview_process.present? %>
-          <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
-        <% end %>
-        <% if course.has_fees? %>
-          <li><%= link_to 'Fees', '#section-fees', class: 'govuk-link' %></li>
-        <% else %>
-          <li><%= link_to 'Salary', '#section-salary', class: 'govuk-link' %></li>
-        <% end %>
-        <li><%= link_to 'Financial support', '#section-financial-support', class: 'govuk-link' %></li>
-        <li><%= link_to 'Requirements', '#section-entry', class: 'govuk-link' %></li>
+        <li><%= link_to 'Entry requirements', '#section-entry', class: 'govuk-link' %></li>
         <% if course.provider.train_with_us.present? ||  course.about_accrediting_body.present? %>
           <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
+        <% end %>
+        <% if course.salaried? %>
+          <li><%= link_to 'Salary', '#section-salary', class: 'govuk-link' %></li>
+        <% end %>
+        <li><%= link_to 'Fees and financial support', '#section-financial-support', class: 'govuk-link' %></li>
+        <% if course.interview_process.present? %>
+          <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
         <% end %>
         <% if course.provider.train_with_disability.present? %>
           <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
         <% end %>
         <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
-        <li><%= link_to 'Apply', '#section-apply', class: 'govuk-link' %></li>
         <li><%= link_to 'Support and advice', '#section-advice', class: 'govuk-link' %></li>
+        <li><%= link_to 'Apply', '#section-apply', class: 'govuk-link' %></li>
       </ul>
 
       <% if course.about_course.present? %>
@@ -86,22 +84,20 @@
         <%= render partial: 'courses/about_schools' %>
       <% end %>
 
-      <% if course.interview_process.present? %>
-        <%= render partial: 'courses/interview_process' %>
-      <% end %>
-
-      <% if course.has_fees? %>
-        <%= render partial: 'courses/fees' %>
-      <% else %>
-        <%= render partial: 'courses/salary' %>
-      <% end %>
-
-      <%= render partial: 'courses/financial_support' %>
-
       <%= render partial: 'courses/entry_requirements_qualifications' %>
+
+      <% if course.salaried? %>
+        <%= render partial: 'courses/salary' %>
+      <% end  %>
+
+      <%= render partial: 'courses/fees_and_financial_support' %>
 
       <% if course.provider.train_with_us.present? ||  course.about_accrediting_body.present? %>
         <%= render partial: 'courses/about_the_provider' %>
+      <% end %>
+
+      <% if course.interview_process.present? %>
+        <%= render partial: 'courses/interview_process' %>
       <% end %>
 
       <% if course.provider.train_with_disability.present? %>
@@ -110,11 +106,11 @@
 
       <%= render partial: 'courses/contact_details' %>
 
+      <%= render partial: 'courses/advice' %>
+
       <% if !FeatureFlag.active?(:ucas_only_locations) %>
         <%= render partial: 'courses/apply' %>
       <% end %>
-
-      <%= render partial: 'courses/advice' %>
 
       <% if FeatureFlag.active?(:ucas_only_locations) %>
         <%= render partial: 'courses/apply_button' %>


### PR DESCRIPTION
### Context
```
As a... user looking for teacher training courses
I need to... find out information about a course
So that... I know if I want to apply to it or not
```

### Changes proposed in this pull request
- Change ordering of sections

### Guidance to review

### Trello card
https://trello.com/c/26UU3jvU/2934-%F0%9F%97%BA-dev-update-ordering-of-information-on-course-detail-pages

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
