### PR TITLE
Update school placement partials to use standardised content

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -37,4 +37,10 @@ class Course < Base
   def further_education?
     level == 'further_education' && subjects.any? { |s| s.subject_name == 'Further education' || s.subject_code = '41' }
   end
+
+  def travel_to_work_areas
+    travel_to_work_areas = site_statuses.map(&:site).map { |site| site.london_borough || site.travel_to_work_area }.uniq
+
+    travel_to_work_areas.to_sentence(last_word_connector: ' and ')
+  end
 end

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,6 +1,13 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
+      <%= render AdviceComponent.new(title: "Where you will train") do %>
+        <% if course.provider_type == "university" %>
+          <%= render partial: 'courses/placement/hei', locals: { course: course }  %>
+        <% else %>
+          <%= render partial: 'courses/placement/scitt', locals: { course: course }  %>
+        <% end %>
+      <% end %>
     <%= markdown(course.how_school_placements_work) %>
   </div>
 </div>

--- a/app/views/courses/placement/_hei.html.erb
+++ b/app/views/courses/placement/_hei.html.erb
@@ -1,0 +1,3 @@
+<p class="govuk-body">You’ll be placed in schools for most of your course. This university is based in <%= course.travel_to_work_areas %>, and your school placements will be within commuting distance.</p>
+<p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+<p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>

--- a/app/views/courses/placement/_scitt.html.erb
+++ b/app/views/courses/placement/_scitt.html.erb
@@ -1,0 +1,2 @@
+<p class="govuk-body">This course has placement schools in <%= course.travel_to_work_areas %>. Most of your time will be spent in the classroom with experienced teachers.</p>
+<p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -20,6 +20,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/list";
 @import "components/search-results";
 @import "components/feedback";
+@import "components/advice";
 @import "patterns/course-parts";
 @import "patterns/success-summary";
 @import "patterns/definition-list";

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     # This hardcodes the provider code to A0. This should probably be fixed at
     # some point. Right now it doesn't break anything.
     sequence(:provider_code) { 'A0' }
+    provider_type { nil }
     name { 'English' }
     description { 'PGCE with QTS full time' }
     findable? { true }

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -14,6 +14,8 @@ FactoryBot.define do
     postcode { nil }
     latitude { nil }
     longitude { nil }
+    travel_to_work_area { nil }
+    london_borough { nil }
     recruitment_cycle_year { Settings.current_cycle }
 
     after :build do |course, evaluator|

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -6,6 +6,7 @@ describe 'Course show', type: :feature do
       :provider,
       provider_name: 'ACME SCITT A0',
       provider_code: 'T92',
+      provider_type: 'scitt',
       website: 'https://scitt.org',
       address1: '1 Long Rd',
       postcode: 'E1 ABC',
@@ -19,6 +20,7 @@ describe 'Course show', type: :feature do
       course_code: 'X130',
       provider: provider,
       provider_code: provider.provider_code,
+      provider_type: provider.provider_type,
       recruitment_cycle: current_recruitment_cycle,
       accrediting_provider: accrediting_provider,
       course_length: 'OneYear',
@@ -81,6 +83,7 @@ describe 'Course show', type: :feature do
       params: {
         recruitment_cycle_year: Settings.current_cycle,
         provider_code: course.provider_code,
+        provider_type: course.provider_type,
         course_code: course.course_code,
       },
       resources: course,
@@ -144,6 +147,10 @@ describe 'Course show', type: :feature do
 
       expect(course_page.school_placements).to have_content(
         course.how_school_placements_work,
+      )
+
+      expect(course_page.school_placements).to have_content(
+        'This course has placement schools in Leeds',
       )
 
       expect(course_page.uk_fees).to have_content(
@@ -264,6 +271,7 @@ describe 'Course show', type: :feature do
             fee_international: nil,
             provider: provider,
             provider_code: provider.provider_code,
+            provider_type: provider.provider_type,
             recruitment_cycle: current_recruitment_cycle,
             accrediting_provider: accrediting_provider)
     end
@@ -297,6 +305,6 @@ describe 'Course show', type: :feature do
   end
 
   def jsonapi_site_status(name, study_mode, status)
-    build(:site_status, study_mode, site: build(:site, location_name: name), status: status)
+    build(:site_status, study_mode, site: build(:site, location_name: name, travel_to_work_area: 'Leeds'), status: status)
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe Course do
+  describe '#travel_to_work_areas' do
+    context 'when there is a single site' do
+      let(:course) do
+        build(
+          :course,
+          site_statuses: [
+            build(:site_status, site: build(:site, london_borough: 'Westminster')),
+          ],
+        )
+      end
+
+      it 'returns that site' do
+        expect(course.travel_to_work_areas).to eq 'Westminster'
+      end
+    end
+
+    context 'when there are two travel sites' do
+      let(:course) do
+        build(
+          :course,
+          site_statuses: [
+            build(:site_status, site: build(:site, london_borough: 'Westminster')),
+            build(:site_status, site: build(:site, london_borough: 'Camden')),
+          ],
+        )
+      end
+
+      it 'returns both sites with the correct format' do
+        expect(course.travel_to_work_areas).to eq 'Westminster and Camden'
+      end
+    end
+
+    context 'when there are more than two travel sites' do
+      let(:course) do
+        build(
+          :course,
+          site_statuses: [
+            build(:site_status, site: build(:site, london_borough: 'Westminster')),
+            build(:site_status, site: build(:site, london_borough: 'Camden')),
+            build(:site_status, site: build(:site, london_borough: 'Southwark')),
+            build(:site_status, site: build(:site, london_borough: 'Islington')),
+          ],
+        )
+      end
+
+      it 'returns all sites with the correct format' do
+        expect(course.travel_to_work_areas).to eq 'Westminster, Camden, Southwark and Islington'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

In order to improve guidance for candidates trying to understand
how school placements work, standardised content has been added.

### Changes proposed in this pull request

As there is a slight difference in the content shown for University
courses and SCITT/School Direct courses, two partials have been added.
|SCITT/School Direct|University|
|-----|-----|
|![SCITT](https://user-images.githubusercontent.com/47917431/107674871-5c530580-6c8f-11eb-8cb4-93b71ef7f242.png)|![University](https://user-images.githubusercontent.com/47917431/107674878-5f4df600-6c8f-11eb-8f75-d4a464252563.png)|

### Guidance to review

### Trello card

https://trello.com/c/GC2b4xrH/2936-%F0%9F%97%BA-dev-add-standardised-content-for-where-you-will-train-to-course-detail-pages

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
