### PR TITLE
Update financial support partial to use standardised content

### DIFF
--- a/app/views/courses/_fees_and_financial_support.html.erb
+++ b/app/views/courses/_fees_and_financial_support.html.erb
@@ -1,20 +1,22 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Fees and financial support</h2>
 
-  <% if course.has_fees? %>
-    <%= render partial: 'courses/fees' %>
+  <%= render AdviceComponent.new(title: "Financial support") do %>
+      <% if course.salaried? %>
+      <%= render partial: 'courses/financial_support/salaried' %>
+    <% elsif course.excluded_from_bursary? %>
+      <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+    <% elsif course.bursary_only? %>
+      <%= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
+    <% elsif course.has_scholarship_and_bursary? %>
+      <%= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
+    <% else %>
+      <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+    <% end %>
   <% end %>
 
-  <% if course.salaried? %>
-    <%= render partial: 'courses/financial_support/salaried' %>
-  <% elsif course.excluded_from_bursary? %>
-    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
-  <% elsif course.bursary_only? %>
-    <%= render partial: 'courses/financial_support/bursary', locals: { course: course } %>
-  <% elsif course.has_scholarship_and_bursary? %>
-    <%= render partial: 'courses/financial_support/scholarship_and_bursary', locals: { course: course } %>
-  <% else %>
-    <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>
+  <% if course.has_fees? %>
+    <%= render partial: 'courses/fees' %>
   <% end %>
 
   <% if course.financial_support.present? %>


### PR DESCRIPTION
### Context

This is an additional section on the course details page that is being updated to use standardised content, as part of the work to improve guidance for candidates.

### Changes proposed in this pull request

The standardised content box has now been added for the 'Financial support' section:

![Screenshot](https://user-images.githubusercontent.com/47917431/106936733-d970fe80-6714-11eb-9c17-45d201a835cc.png)


Prototype: https://find-prototype.herokuapp.com/course/1N1/2XT2

### Guidance to review

This is using the new component & styling added in [#638](https://github.com/DFE-Digital/find-teacher-training/pull/638).

### Trello card

https://trello.com/c/ZX2WSDA1/2938-%F0%9F%97%BA-dev-update-standardised-content-for-financial-support-on-course-detail-pages

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
