### PR TITLE
Remove location map from course details page

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -8,16 +8,16 @@
   <% if @course.has_vacancies? %>
     <% if FeatureFlag.active?(:display_apply_button) %>
       <p class="govuk-body">
-        <%= render GovukComponent::StartNowButton.new(
-          text: 'Apply for this course',
-          href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-          html_attributes: { 'data-qa': 'course__apply_link' },
-        ) %>
+      <%= render GovukComponent::StartNowButton.new(
+        text: 'Apply for this course',
+        href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+        html_attributes: { 'data-qa': 'course__apply_link' },
+      ) %>
       </p>
     <% else %>
       <div data-qa="course__end_of_cycle_notice">
         <p class="govuk-body">
-          You can apply to this course from 13 October.
+        You can apply to this course from 13 October.
         </p>
       </div>
     <% end %>

--- a/app/views/courses/_apply_button.html.erb
+++ b/app/views/courses/_apply_button.html.erb
@@ -1,0 +1,15 @@
+<% if FeatureFlag.active?(:display_apply_button) %>
+  <p class="govuk-body">
+  <%= render GovukComponent::StartNowButton.new(
+    text: 'Apply for this course',
+    href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+    html_attributes: { 'data-qa': 'course__apply_link' },
+  ) %>
+  </p>
+<% else %>
+  <div data-qa="course__end_of_cycle_notice">
+    <p class="govuk-body">
+    You can apply to this course from 13 October.
+    </p>
+  </div>
+<% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -110,9 +110,15 @@
 
       <%= render partial: 'courses/contact_details' %>
 
-      <%= render partial: 'courses/apply' %>
+      <% if !FeatureFlag.active?(:ucas_only_locations) %>
+        <%= render partial: 'courses/apply' %>
+      <% end %>
 
       <%= render partial: 'courses/advice' %>
+
+      <% if FeatureFlag.active?(:ucas_only_locations) %>
+        <%= render partial: 'courses/apply_button' %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/webpacker/scripts/locations-map.js
+++ b/app/webpacker/scripts/locations-map.js
@@ -2,6 +2,7 @@ import createPopupClass from "./map-popup";
 
 const initLocationsMap = () => {
   const $map = document.getElementById("locations-map");
+  if (!$map) return;
   const trainingLocations = window.trainingLocations
     .filter(({lat, lng}) => lat !== "" && lng !== "")
     .map(location => {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,3 +21,4 @@ feature_flags:
   cycle_ending_soon: false
   cycle_has_ended: false
   display_apply_button: true
+  ucas_only_locations: false

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -244,6 +244,7 @@ describe 'Course show', type: :feature do
     context 'End of cycle' do
       before do
         deactivate_feature(:display_apply_button)
+        deactivate_feature(:ucas_only_locations)
         visit course_path(course.provider_code, course.course_code)
       end
 


### PR DESCRIPTION

### Context
We're reworking the locations UX. Part of this design change involves
removing the locations section from the course details page.

### Changes proposed in this pull request
- Wrap the `_apply` partial with a new feature flag check.
- Conditionally render the apply button at the bottom of the page if the feature flag is active.
- Conditionally return early from the JS function that initialises the map.
---
#### Feature flag off:

![Screenshot_20210208_154419](https://user-images.githubusercontent.com/519250/107243409-e0ee1b80-6a24-11eb-9f87-ee87aa5ba6e5.png)
---
#### Feature flag on:
![Screenshot_20210208_154738](https://user-images.githubusercontent.com/519250/107243507-f95e3600-6a24-11eb-8842-504b813a034b.png)




### Guidance to review
- Review diff.
### Trello card
https://trello.com/c/h3R0gdap
### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
