### PR TITLE
Add localised strings for GIT contact numbers and URLs

### DIFF
--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -2,7 +2,8 @@
 <p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to "the contact details above", "#contact_section", class: "govuk-link" %>.</p>
 
 <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-<p class="govuk-body">Register with <%= link_to 'Get Into Teaching', 'https://beta-getintoteaching.education.gov.uk/helping-you-become-a-teacher', class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= link_to "online chat service", "https://beta-getintoteaching.education.gov.uk/#talk-to-us", class: 'govuk-link' %>, from 8am to 8pm, Monday to Friday.</p>
+<p class="govuk-body"><%= link_to "Register with #{t('service_name.get_into_teaching')}", t('get_into_teaching.url_get_an_advisor'), class: "govuk-link" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events.</p>
+<p class="govuk-body">You can also call them free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their <%= link_to "online chat service", t('get_into_teaching.url_online_chat'), class: 'govuk-link' %> <%= t('get_into_teaching.opening_times') %>.</p>
 
 <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
 <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,16 +69,16 @@
             <div class="govuk-grid-column-one-half">
               <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Telephone</h2>
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li>0800 389 2500</li>
-                <li>Monday to Friday, 8.30am to 5pm (except public&nbsp;holidays)</li>
+                <li><%= t('get_into_teaching.tel') %></li>
+                <li><%= t('get_into_teaching.opening_times') %></li>
                 <li>Free of charge</li>
               </ul>
             </div>
             <div class="govuk-grid-column-one-half">
               <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Online chat</h2>
               <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-                <li><%= link_to "Talk to an adviser online", "https://getintoteaching.education.gov.uk/lp/live-chat", class: "govuk-footer__link" %></li>
-                <li>Monday to Friday, 8.30am to 5pm (except public&nbsp;holidays)</li>
+                <li><%= link_to "Talk to an adviser online", t('get_into_teaching.url_online_chat'), class: "govuk-footer__link" %></li>
+                <li><%= t('get_into_teaching.opening_times') %></li>
               </ul>
             </div>
           </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -69,3 +69,12 @@ en:
   page_titles:
     error_prefix: "Error: "
     subjects_filter: "Select the subjects you want to teach"
+  service_name:
+    get_into_teaching: Get Into Teaching
+  get_into_teaching:
+    # TODO: Update to 0800 389 2500 when GIT leaves beta
+    tel: 0800 389 2501
+    opening_times: "Monday to Friday, 8.30am to 5pm (except public\u00A0holidays)"
+    # TODO: Update domain names when GIT leaves beta
+    url_get_an_advisor: https://beta-adviser-getintoteaching.education.gov.uk
+    url_online_chat: https://beta-getintoteaching.education.gov.uk/#talk-to-us


### PR DESCRIPTION
### Context

Currently the contact information for GIT that we show in the footer differs from the information we show on course pages.

### Changes proposed in this pull request

Like we’re doing on Apply (https://github.com/DFE-Digital/apply-for-teacher-training/pull/3995), store common GIT values as localised strings. 

### Guidance to review

* ~~To render the `nbsp;` in the `opening_times` string, am using `html_safe` method on `t`; is that okay?~~
* Unlike on Apply, have not moved all GIT URLs into the localisation file – should we?
* Noticed that we’re not using `govuk_link_to`; can address in a later PR

### Trello card

https://trello.com/c/wpgn9P98/

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
