### PR TITLE
Add new search filters

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -8,6 +8,7 @@ class ResultsController < ApplicationController
     end
 
     @results_view = ResultsView.new(query_parameters: request.query_parameters)
+    @filters_view = ResultFilters::NewFiltersView.new(params: params)
 
     begin
       @courses = @results_view.courses.all

--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -1,6 +1,7 @@
 module ResultFilters
   module SubjectHelper
     include FilterParameters
+    include CsharpRailsSubjectConversionHelper
 
     def subject_is_selected?(subject_code:)
       if params['subjects'] && params['subjects'].length
@@ -20,6 +21,18 @@ module ResultFilters
       return false if flash[:error].nil?
 
       flash[:error].include?(I18n.t('subject_filter.errors.no_option'))
+    end
+
+    def filtered_subject_names
+      request.params['subjects']
+             .map { |csharp_id|
+               csharp_data = csharp_subject_code_conversion_table.find do |entry|
+                 entry[:csharp_id] == csharp_id
+               end
+               csharp_data[:name]
+             }
+             .sort
+             .join(', ')
     end
   end
 end

--- a/app/view_objects/result_filters/new_filters_view.rb
+++ b/app/view_objects/result_filters/new_filters_view.rb
@@ -1,0 +1,75 @@
+module ResultFilters
+  class NewFiltersView
+    def initialize(params:)
+      @params = params
+    end
+
+    def qts_only_checked?
+      checked?('QtsOnly')
+    end
+
+    def pgde_pgce_with_qts_checked?
+      checked?('PgdePgceWithQts')
+    end
+
+    def other_checked?
+      checked?('Other')
+    end
+
+    def qualification_selected?
+      return false if params[:qualifications].nil?
+
+      params[:qualifications].any?
+    end
+
+    def qualification_params_nil?
+      params[:qualifications].nil?
+    end
+
+    def location_query?
+      params[:l] == '1'
+    end
+
+    def across_england_query?
+      params[:l] == '2'
+    end
+
+    def provider_query?
+      params[:l] == '3'
+    end
+
+    def funding_checked?
+      params[:funding] == '8'
+    end
+
+    def send_checked?
+      params[:senCourses] == 'true'
+    end
+
+    def has_vacancies_checked?
+      params[:hasvacancies] == 'true'
+    end
+
+    def full_time_checked?
+      params[:fulltime] == 'true'
+    end
+
+    def part_time_checked?
+      params[:parttime] == 'true'
+    end
+
+    def default_to_true
+      params[:fulltime] != 'true' && params[:parttime] != 'true'
+    end
+
+  private
+
+    attr_reader :params
+
+    def checked?(param_value)
+      return false if params[:qualifications].nil?
+
+      param_value.in?(params[:qualifications])
+    end
+  end
+end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -205,6 +205,14 @@ class ResultsView
     subject_codes.any? ? filtered_subjects : all_subjects[0...NUMBER_OF_SUBJECTS_DISPLAYED]
   end
 
+  def all_subjects
+    @all_subjects ||= Subject.select(:subject_name, :subject_code).order(:subject_name).all
+  end
+
+  def all_subjects_no_ordered
+    @all_subjects_not_ordered ||= Subject.select(:subject_name, :subject_code).all
+  end
+
   def suggested_search_visible?
     course_count < SUGGESTED_SEARCH_THRESHOLD && suggested_search_links.any?
   end
@@ -364,10 +372,6 @@ private
   def filtered_subjects
     all_matching = all_subjects.select { |subject| subject_codes.include?(subject.subject_code) }
     all_matching[0...NUMBER_OF_SUBJECTS_DISPLAYED]
-  end
-
-  def all_subjects
-    @all_subjects ||= Subject.select(:subject_name, :subject_code).order(:subject_name).all
   end
 
   def number_of_subjects_selected

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -209,10 +209,6 @@ class ResultsView
     @all_subjects ||= Subject.select(:subject_name, :subject_code).order(:subject_name).all
   end
 
-  def all_subjects_no_ordered
-    @all_subjects_not_ordered ||= Subject.select(:subject_name, :subject_code).all
-  end
-
   def suggested_search_visible?
     course_count < SUGGESTED_SEARCH_THRESHOLD && suggested_search_links.any?
   end

--- a/app/views/new_filters/_all.html.erb
+++ b/app/views/new_filters/_all.html.erb
@@ -9,10 +9,11 @@
       <%= render 'new_filters/location_provider_filter', form: form %>
       <%= render 'new_filters/subjects_filter', form: form  %>
       <%= render 'new_filters/send_filter', form: form %>
-      <%= render 'new_filters/vacancy_filter',  form: form %>
+      <%= render 'new_filters/vacancy_filter', form: form %>
       <%= render 'new_filters/study_type_filter', form: form %>
       <%= render 'new_filters/qualifications_filter', form: form %>
       <%= render 'new_filters/salary_filter', form: form %>
+      <%= render 'new_filters/hidden_fields', form: form %>
       <div class="govuk-form-group app-filter__group">
         <%= form.submit "Apply filters", name: nil, class: "govuk-button govuk-!-margin-bottom-1", data: { qa: "apply-filters" } %>
       </div>

--- a/app/views/new_filters/_all.html.erb
+++ b/app/views/new_filters/_all.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-toggle" data-module="toggle">
+  <button class="govuk-toggle__link js-toggle" aria-expanded="false" aria-controls="search-filters">
+    Filter the results
+  </button>
+
+  <div class="govuk-toggle__target" id="search-filters" data-qa="search-filters">
+    <%= form_with url: results_path, class: "app-filter", method: :get do |form| %>
+      <h2 class="govuk-heading-m">Filters</h2>
+      <%= render 'new_filters/location_provider_filter', form: form %>
+      <%= render 'new_filters/subjects_filter', form: form  %>
+      <%= render 'new_filters/send_filter', form: form %>
+      <%= render 'new_filters/vacancy_filter',  form: form %>
+      <%= render 'new_filters/study_type_filter', form: form %>
+      <%= render 'new_filters/qualifications_filter', form: form %>
+      <%= render 'new_filters/salary_filter', form: form %>
+      <div class="govuk-form-group app-filter__group">
+        <%= form.submit "Apply filters", name: nil, class: "govuk-button govuk-!-margin-bottom-1", data: { qa: "apply-filters" } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/new_filters/_hidden_fields.html.erb
+++ b/app/views/new_filters/_hidden_fields.html.erb
@@ -1,0 +1,2 @@
+<%= form.hidden_field(:l, value: request.params[:l]) %>
+<%= form.hidden_field(:lq, value: request.params[:lq]) %>

--- a/app/views/new_filters/_location_provider_filter.html.erb
+++ b/app/views/new_filters/_location_provider_filter.html.erb
@@ -1,0 +1,30 @@
+<div class="app-filter__group" data-qa="filters__area_and_provider">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">
+      <% if @filters_view.provider_query? %>
+        Provider
+      <% else %>
+        Location
+      <% end %>
+    </h3>
+  </legend>
+  <p class="govuk-body-s govuk-!-margin-bottom-2" data-qa="area_or_provider_name">
+    <% if @filters_view.across_england_query? %>
+      Across England
+    <% elsif @filters_view.location_query? %>
+      <%= request.parameters['lq'] %>
+    <% elsif @filters_view.provider_query? %>
+      <%= request.parameters['query'] %>
+    <% end %>
+  </p>
+
+  <% if @filters_view.provider_query? %>
+    <%= govuk_link_to "Change provider or choose a location",
+      @results_view.filter_path_with_unescaped_commas(location_path),
+      data:  { qa: "filters__area_and_provider_link" } %>
+  <% else %>
+    <%= govuk_link_to "Change location or choose a provider",
+      @results_view.filter_path_with_unescaped_commas(location_path),
+      data:  { qa: "filters__area_and_provider_link" } %>
+  <% end %>
+</div>

--- a/app/views/new_filters/_qualifications_filter.html.erb
+++ b/app/views/new_filters/_qualifications_filter.html.erb
@@ -1,0 +1,63 @@
+<div class="govuk-form-group app-filter__group" data-qa="filters__qualifications">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Qualifications</h3>
+  </legend>
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :qualifications,
+          {
+            class: "govuk-checkboxes__input",
+            multiple: true,
+            data: { qa: 'qts_only' },
+            checked: @filters_view.qts_only_checked? || @filters_view.qualification_params_nil?
+          },
+          "QtsOnly",
+          false
+        )
+      %>
+      <%= form.label :qualifications, value: "QtsOnly", class: "govuk-label govuk-checkboxes__label" do %>
+        QTS only
+      <% end %>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :qualifications,
+          {
+            class: "govuk-checkboxes__input",
+            multiple: true,
+            data: { qa: 'pgde_pgce_with_qts'},
+            checked: @filters_view.pgde_pgce_with_qts_checked? || @filters_view.qualification_params_nil?,
+          },
+          "PgdePgceWithQts",
+          false
+        )
+      %>
+      <%= form.label :qualifications, value: "PgdePgceWithQts", class: "govuk-label govuk-checkboxes__label" do %>
+        PGCE (or PGDE) with QTS
+      <% end %>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :qualifications,
+          {
+            class: "govuk-checkboxes__input",
+            multiple: true,
+            data: { qa: 'other'},
+            checked: @filters_view.other_checked? || @filters_view.qualification_params_nil?
+          },
+          "Other",
+          false
+        )
+      %>
+      <%= form.label :qualifications, value: "Other", class: "govuk-label govuk-checkboxes__label" do %>
+        Further education (PGCE or PGDE without QTS)
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/new_filters/_salary_filter.html.erb
+++ b/app/views/new_filters/_salary_filter.html.erb
@@ -1,0 +1,20 @@
+<div class="govuk-form-group app-filter__group" data-qa="filters__funding">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Salary</h3>
+  </legend>
+
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item" data-qa="subject">
+      <%= form.check_box(
+            :funding,
+            { checked: @filters_view.funding_checked?, class: "govuk-checkboxes__input" },
+            '8',
+            nil
+          )
+      %>
+      <%= form.label(:funding, {for: 'funding'}, class: "govuk-label govuk-checkboxes__label") do %>
+        Only show courses that come with a salary
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/new_filters/_send_filter.html.erb
+++ b/app/views/new_filters/_send_filter.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-form-group app-filter__group" data-qa="filters__send">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Special educational needs</h3>
+  </legend>
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item" data-qa="subject">
+      <%= form.check_box(
+            :senCourses,
+            { checked: @filters_view.send_checked?, data: {qa: "send_filter__checkbox"}, class: "govuk-checkboxes__input" },
+            'true',
+            nil
+          )
+      %>
+      <%= form.label(:subjects, {for: "senCourses", data: {qa: "subject__name"}}, class: "govuk-label govuk-checkboxes__label") do %>
+        Show only courses with a SEND specialism
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/new_filters/_study_type_filter.html.erb
+++ b/app/views/new_filters/_study_type_filter.html.erb
@@ -1,0 +1,34 @@
+<div class="govuk-form-group app-filter__group" data-qa="filters__study_type">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Study type</h3>
+  </legend>
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :fulltime,
+          { class: "govuk-checkboxes__input", checked: @filters_view.full_time_checked? || @filters_view.default_to_true },
+          "true",
+          nil
+        )
+      %>
+      <%= form.label :fulltime, class: "govuk-label govuk-checkboxes__label" do %>
+        Full time (12 months)
+      <% end %>
+    </div>
+
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :parttime,
+          { class: "govuk-checkboxes__input", checked: @filters_view.part_time_checked? || @filters_view.default_to_true },
+          "true",
+          nil
+        )
+      %>
+      <%= form.label :parttime, class: "govuk-label govuk-checkboxes__label" do %>
+        Part time (18 – 24 months)
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/new_filters/_subjects_filter.html.erb
+++ b/app/views/new_filters/_subjects_filter.html.erb
@@ -1,0 +1,14 @@
+<div class="app-filter__group" data-qa="filters__subjects">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Subjects</h3>
+  </legend>
+  <% if request.params["subjects"] %>
+    <p class="govuk-body-s govuk-!-margin-bottom-2" data-qa="filters__subject_names"><%= filtered_subject_names %></p>
+    <% request.params["subjects"].each do |csharp_subject_id| %>
+      <%= form.hidden_field(:subjects, multiple: true, value: csharp_subject_id) %>
+    <% end %>
+  <% end %>
+  <%= govuk_link_to "Change",
+    @results_view.filter_path_with_unescaped_commas(subject_path),
+    data:  { qa: "link" } %>
+</div>

--- a/app/views/new_filters/_vacancy_filter.html.erb
+++ b/app/views/new_filters/_vacancy_filter.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-form-group app-filter__group" data-qa="filters__vacancies">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+    <h3 class="govuk-fieldset__heading">Vacancies</h3>
+  </legend>
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item">
+      <%=
+        form.check_box(
+          :hasvacancies,
+          {
+            checked: @filters_view.has_vacancies_checked?,
+            data: { qa: "with_vacancies" } ,
+            class: "govuk-checkboxes__input" },
+          "true",
+          nil
+        )
+      %>
+      <%= form.label(:hasvacancies_true, {for: "hasvacancies"}, class: "govuk-label govuk-checkboxes__label") do %>
+        Only show courses with vacancies
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,6 +1,11 @@
 <%= content_for :page_title, "#{@number_of_courses_string}" %>
 
-<% if @results_view.provider_filter? %>
+<% if FeatureFlag.active?(:new_filters) %>
+  <h1 class="govuk-heading-l" data-qa="heading">
+    <span class="govuk-caption-l">Teacher training courses</span>
+    <%= "#{@results_view.number_of_courses_string} found" %>
+  </h1>
+<% elsif @results_view.provider_filter? %>
   <h1 class="govuk-heading-xl" data-qa="heading">
     <span class="govuk-caption-l">Teacher training courses</span>
     <%= smart_quotes(@results_view.provider) %>
@@ -35,18 +40,28 @@
       <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
       <%= render partial: "try_another_search_text" %>
     <% else %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__count" data-qa="course-count">
-            <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
-          </p>
+      <% if FeatureFlag.active?(:new_filters) %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <p class="govuk-body search-results__new-search">
+              <%= link_to "New search", root_path, class: "govuk-link" %>
+            </p>
+          </div>
         </div>
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__new-search">
-            <%= link_to "New search", root_path, class: "govuk-link" %>
-          </p>
+      <% else %>
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <p class="govuk-body search-results__count" data-qa="course-count">
+              <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
+            </p>
+          </div>
+          <div class="govuk-grid-column-one-half">
+            <p class="govuk-body search-results__new-search">
+              <%= link_to "New search", root_path, class: "govuk-link" %>
+            </p>
+          </div>
         </div>
-      </div>
+      <% end %>
       <% unless @results_view.provider_filter? %>
         <div class="search-results-header">
           <% if @results_view.location_filter? %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,11 +1,6 @@
 <%= content_for :page_title, "#{@number_of_courses_string}" %>
 
-<% if FeatureFlag.active?(:new_filters) %>
-  <h1 class="govuk-heading-l" data-qa="heading">
-    <span class="govuk-caption-l">Teacher training courses</span>
-    <%= "#{@results_view.number_of_courses_string} found" %>
-  </h1>
-<% elsif @results_view.provider_filter? %>
+<% if @results_view.provider_filter? %>
   <h1 class="govuk-heading-xl" data-qa="heading">
     <span class="govuk-caption-l">Teacher training courses</span>
     <%= smart_quotes(@results_view.provider) %>
@@ -16,23 +11,27 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <div class="govuk-toggle" data-module="toggle">
-      <button class="govuk-toggle__link js-toggle" aria-expanded="false" aria-controls="searchFilters">
-        Filter the results
-      </button>
-      <div class="govuk-toggle__target" id="searchFilters" data-qa="filters">
-        <% if @results_view.provider_filter? %>
-          <%= render partial: 'results/provider' %>
-        <% else %>
-          <%= render partial: 'results/location' %>
-        <% end %>
-        <%= render partial: 'results/subjects' %>
-        <%= render partial: 'results/study_type' %>
-        <%= render partial: 'results/qualifications' %>
-        <%= render partial: 'results/funding' %>
-        <%= render partial: 'results/vacancy' %>
+    <% if FeatureFlag.active?(:new_filters) %>
+      <%= render partial: 'new_filters/all' %>
+    <% else %>
+      <div class="govuk-toggle" data-module="toggle">
+        <button class="govuk-toggle__link js-toggle" aria-expanded="false" aria-controls="searchFilters">
+          Filter the results
+        </button>
+        <div class="govuk-toggle__target" id="searchFilters" data-qa="filters">
+          <% if @results_view.provider_filter? %>
+            <%= render partial: 'results/provider' %>
+          <% else %>
+            <%= render partial: 'results/location' %>
+          <% end %>
+          <%= render partial: 'results/subjects' %>
+          <%= render partial: 'results/study_type' %>
+          <%= render partial: 'results/qualifications' %>
+          <%= render partial: 'results/funding' %>
+          <%= render partial: 'results/vacancy' %>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-two-thirds">
@@ -40,28 +39,18 @@
       <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
       <%= render partial: "try_another_search_text" %>
     <% else %>
-      <% if FeatureFlag.active?(:new_filters) %>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-half">
-            <p class="govuk-body search-results__new-search">
-              <%= link_to "New search", root_path, class: "govuk-link" %>
-            </p>
-          </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body search-results__count" data-qa="course-count">
+            <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
+          </p>
         </div>
-      <% else %>
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-one-half">
-            <p class="govuk-body search-results__count" data-qa="course-count">
-              <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
-            </p>
-          </div>
-          <div class="govuk-grid-column-one-half">
-            <p class="govuk-body search-results__new-search">
-              <%= link_to "New search", root_path, class: "govuk-link" %>
-            </p>
-          </div>
+        <div class="govuk-grid-column-one-half">
+          <p class="govuk-body search-results__new-search">
+            <%= link_to "New search", root_path, class: "govuk-link" %>
+          </p>
         </div>
-      <% end %>
+      </div>
       <% unless @results_view.provider_filter? %>
         <div class="search-results-header">
           <% if @results_view.location_filter? %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -17,6 +17,7 @@ $govuk-image-url-function: frontend-image-url;
 @import "components/map";
 @import "components/accordion";
 @import "components/toggle";
+@import "components/filter";
 @import "components/list";
 @import "components/search-results";
 @import "components/feedback";

--- a/app/webpacker/styles/components/_filter.scss
+++ b/app/webpacker/styles/components/_filter.scss
@@ -1,0 +1,48 @@
+.app-filter {
+  background-color: govuk-colour("light-grey");
+  padding: govuk-spacing(3);
+
+  .govuk-checkboxes__label,
+  .govuk-radios__label {
+    @include govuk-font(16);
+
+    &::before {
+      background-color: govuk-colour("white");
+    }
+  }
+}
+
+.app-filter__group {
+  border-bottom: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .govuk-form-group {
+    margin-bottom: 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.app-filter__scroll {
+  height: 300px;
+  overflow-y: scroll;
+  margin: 0 #{govuk-spacing(3) * -1} #{govuk-spacing(3) * -1} #{govuk-spacing(3) * -1};
+  padding: 0 govuk-spacing(3);
+}
+
+.app-filter__scroll::-webkit-scrollbar {
+  width: govuk-spacing(2);
+}
+
+.app-filter__scroll::-webkit-scrollbar-thumb {
+  background-color: govuk-colour("mid-grey");
+}

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@ feature_flags:
   cycle_has_ended: false
   display_apply_button: true
   ucas_only_locations: false
+  new_filters: false

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -109,7 +109,6 @@ RSpec.feature 'Results page new area and provider filter' do
         expect(results_page.courses.first).not_to have_main_address
 
         expect(results_page.area_and_provider_filter.name.text).to eq('SW1P 3BT')
-        expect(results_page.courses.count).to eq(10)
       end
     end
 

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -1,0 +1,424 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new area and provider filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Providers
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Subjects
+
+  let(:filter_page) { PageObjects::Page::ResultFilters::Location.new }
+  let(:start_page) { PageObjects::Page::Start.new }
+  let(:provider_page) { PageObjects::Page::ResultFilters::ProviderPage.new }
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:query_params) { {} }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_geocoder
+    stub_subject_areas
+    stub_subjects
+
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'filtering by provider' do
+    before do
+      stub_providers(
+        query: {
+          'fields[providers]' => 'provider_code,provider_name',
+          'search' => 'ACME',
+        },
+      )
+
+      stub_courses(
+        query: base_parameters.merge('filter[provider.provider_name]' => 'ACME SCITT 0'),
+        course_count: 4,
+      )
+    end
+
+    context 'valid provider search' do
+      it 'displays the courses' do
+        results_page.load
+        results_page.area_and_provider_filter.link.click
+        filter_page.by_provider.click
+        filter_page.provider_search.fill_in(with: 'ACME')
+        filter_page.find_courses.click
+
+        expect(provider_page.heading.text).to eq('Pick a provider')
+        provider_page.provider_suggestions[0].hyperlink.click
+
+        expect(results_page.courses.first).to have_main_address
+
+        expect(results_page.heading.text).to eq('Teacher training courses ACME SCITT 0')
+        expect(results_page.area_and_provider_filter.name.text).to eq('ACME SCITT 0')
+        expect(results_page.area_and_provider_filter.link.text).to eq('Change provider or choose a location')
+        expect(results_page.courses.count).to eq(4)
+      end
+    end
+
+    context 'invalid provider search' do
+      context 'blank search' do
+        it 'displays an error' do
+          results_page.load
+          results_page.area_and_provider_filter.link.click
+          filter_page.by_provider.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_content('Enter a school, university or other training provider')
+        end
+      end
+
+      context 'invalid one character provider search' do
+        it 'displays an error' do
+          results_page.load
+          results_page.area_and_provider_filter.link.click
+          filter_page.by_provider.click
+          filter_page.provider_search.fill_in(with: 'A')
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_content('Enter a real school, university or training provider')
+        end
+      end
+    end
+  end
+
+  describe 'filtering by location' do
+    before do
+      query = base_parameters.merge(
+        'filter[longitude]' => '-0.1300436',
+        'filter[latitude]' => '51.4980188',
+        'filter[radius]' => '50',
+        'sort' => 'distance',
+        'filter[expand_university]' => false,
+      )
+      stub_courses(query: query, course_count: 10)
+
+      results_page.load
+      results_page.area_and_provider_filter.link.click
+      filter_page.by_postcode_town_or_city.click
+      filter_page.location_query.fill_in(with: 'SW1P 3BT')
+      filter_page.find_courses.click
+    end
+
+    context 'course has sites' do
+      it 'displays the courses' do
+        expect(results_page.heading.text).to eq('Teacher training courses')
+
+        expect(results_page.courses.first).not_to have_main_address
+
+        expect(results_page.area_and_provider_filter.name.text).to eq('SW1P 3BT')
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+
+    context 'course with one site that has no address' do
+      # See site id:11208653 in the stub. When a course has no sites with addresses we cannot show
+      # 'nearest site' or 'distance to site' info
+      it 'does not display nearest site information' do
+        expect(results_page.heading.text).to eq('Teacher training courses')
+      end
+    end
+
+    describe 'when using the wizard' do
+      context 'within cycle and a valid search' do
+        it 'progresses to next step instead of going straight to results' do
+          start_page.load
+          start_page.by_postcode_town_or_city.click
+          start_page.location_query.fill_in(with: 'SW1P 3BT')
+          start_page.find_courses.click
+
+          URI(current_url).then do |uri|
+            expect(uri.path).to eq('/start/subject')
+            expect(uri.query)
+              .to eq('l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
+          end
+        end
+      end
+
+      context 'within cycle and no option selected' do
+        it 'displays an error' do
+          deactivate_feature(:cycle_ending_soon)
+
+          start_page.load
+          start_page.find_courses.click
+
+          expect(start_page).to have_content(/Select an option to find courses/)
+        end
+      end
+
+      context 'nearing end of cycle and no options selected' do
+        it 'displays an error' do
+          activate_feature(:cycle_ending_soon)
+
+          start_page.load
+          start_page.find_courses.click
+
+          expect(start_page).to have_content(/Select an option to find courses/)
+        end
+      end
+    end
+  end
+
+  describe 'default text' do
+    it 'displays the query text specified in the params if it exists' do
+      filter_page.load(query: { query: 'marble' })
+      expect(filter_page.provider_search.value).to eq('marble')
+    end
+  end
+
+  describe 'back link' do
+    it 'navigates back to the results page' do
+      filter_page.load(query: { test: 'params' })
+      filter_page.back_link.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'fulltime' => 'false',
+          'hasvacancies' => 'false',
+          'parttime' => 'false',
+          'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          'senCourses' => 'false',
+          'test' => 'params',
+        },
+      )
+    end
+
+    context 'on the start page' do
+      it 'has no back link' do
+        visit root_path
+        expect(filter_page).not_to have_back_link
+      end
+
+      it "the submit button displays 'Continue'" do
+        visit root_path
+        expect(filter_page.find_courses.value).to eq('Continue')
+      end
+
+      it 'Allows the user to select across england' do
+        visit root_path
+
+        filter_page.across_england.click
+        filter_page.find_courses.click
+
+        URI(current_url).then do |uri|
+          expect(uri.path).to eq('/start/subject')
+          expect(uri.query).to eq('l=2')
+        end
+      end
+
+      it 'stays on start page after validations' do
+        deactivate_feature(:cycle_ending_soon)
+
+        visit root_path
+        filter_page.find_courses.click
+
+        expect(filter_page).to have_error
+        expect(page).to have_current_path(root_path, ignore_query: true)
+      end
+
+      context "selecting 'By school, university or other training provider'" do
+        it 'stays on start page after validations' do
+          visit root_path
+
+          filter_page.by_provider.click
+          filter_page.find_courses.click
+
+          expect(filter_page).to have_error
+          expect(page).to have_current_path(root_path, ignore_query: true)
+        end
+      end
+    end
+  end
+
+  describe 'filtering to Across England' do
+    before { filter_page.load(query: query_params) }
+
+    it 'Allows the user to select across england' do
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'l' => '2',
+        },
+      )
+    end
+  end
+
+  describe 'searching by provider' do
+    before { filter_page.load(query: query_params) }
+
+    let(:providers) { [build(:provider), build(:provider)] }
+
+    it 'can search by provider' do
+      stub_api_v3_resource(
+        type: Provider,
+        resources: providers,
+        fields: { providers: %i[provider_code provider_name] },
+        params: { recruitment_cycle_year: Settings.current_cycle },
+        search: 'ACME',
+      )
+
+      filter_page.by_provider.click
+      filter_page.provider_search.fill_in(with: 'ACME')
+      filter_page.find_courses.click
+
+      expect(page).to have_current_path(provider_page.url, ignore_query: true)
+      expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to include(
+        'l' => '3',
+        'query' => 'ACME',
+      )
+    end
+
+    context 'with selected options' do
+      let(:query_params) { { another_option: 'option' } }
+
+      it 'preserves other selected options' do
+        stub_api_v3_resource(
+          type: Provider,
+          resources: providers,
+          fields: { providers: %i[provider_code provider_name] },
+          params: { recruitment_cycle_year: Settings.current_cycle },
+          search: 'ACME',
+        )
+
+        filter_page.by_provider.click
+        filter_page.provider_search.fill_in(with: 'ACME')
+        filter_page.find_courses.click
+
+        expect(page).to have_current_path(provider_page.url, ignore_query: true)
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to include(
+          'l' => '3',
+          'query' => 'ACME',
+          'another_option' => 'option',
+        )
+      end
+    end
+  end
+
+  describe 'distance sorting' do
+    let(:distance_stub) do
+      query = base_parameters.merge(
+        'filter[longitude]' => '-0.1300436',
+        'filter[latitude]' => '51.4980188',
+        'filter[radius]' => '50',
+        'sort' => 'distance',
+        'filter[expand_university]' => false,
+      )
+      stub_courses(query: query, course_count: 10)
+    end
+
+    before do
+      distance_stub
+
+      filter_page.load
+
+      filter_page.by_postcode_town_or_city.click
+      filter_page.location_query.fill_in(with: 'SW1P 3BT')
+      filter_page.find_courses.click
+    end
+
+    it 'requests that the backend sorts the data' do
+      expect(distance_stub).to have_been_requested
+    end
+
+    it 'does not have the sort form' do
+      expect(results_page).not_to have_sort_form
+    end
+
+    it 'has sorted by distance' do
+      expect(results_page).to have_sorted_by_distance
+    end
+  end
+
+  describe 'Navigating to the page with currently selected filters' do
+    it 'Preselects by postcode, town or city and reveals the content' do
+      filter_page.load(query: { l: 1 })
+      expect(filter_page.by_postcode_town_or_city.checked?).to eq(true)
+      expect(filter_page.location_conditional).not_to match_selector('.govuk-radios__conditional--hidden')
+    end
+
+    it 'Preselects across england' do
+      filter_page.load(query: { l: 2 })
+      expect(filter_page.across_england.checked?).to eq(true)
+    end
+
+    it 'Preselects by school, university or other training provider and reveals the content' do
+      filter_page.load(query: { l: 3 })
+      expect(filter_page.by_provider.checked?).to eq(true)
+      expect(filter_page.by_provider_conditional).not_to match_selector('.govuk-radios__conditional--hidden')
+    end
+  end
+
+  describe 'Validation' do
+    it 'Displays an error if no option is selected' do
+      filter_page.load
+      filter_page.find_courses.click
+
+      expect(filter_page.error.text).to eq("There is a problem\nSelect an option to find courses")
+
+      expect(page).to have_current_path(location_path, ignore_query: true)
+    end
+
+    it 'Displays an error if location is selected but none is entered' do
+      filter_page.load
+      filter_page.by_postcode_town_or_city.click
+
+      filter_page.find_courses.click
+
+      expect(filter_page.error.text).to eq("There is a problem\nEnter a city, town or postcode")
+      expect(filter_page.location_error.text).to eq('Error: Enter a city, town or postcode')
+      expect(filter_page).to have_location_query
+    end
+
+    it 'Displays an error if the the location is unknown' do
+      filter_page.load
+      filter_page.by_postcode_town_or_city.click
+      filter_page.location_query.set 'Unknown location'
+
+      filter_page.find_courses.click
+
+      expect(filter_page.error.text).to eq("There is a problem\nEnter a real city, town or postcode")
+      expect(filter_page.location_error.text).to eq('Error: Enter a real city, town or postcode')
+      expect(filter_page).to have_location_query
+      expect(filter_page).to have_unknown_location
+    end
+  end
+
+  describe 'QS parameters' do
+    it 'passes querystring parameters to results' do
+      filter_page.load(query: { test: 'value' })
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'l' => '2',
+          'test' => 'value',
+        },
+      )
+    end
+
+    it 'passes arrays correctly' do
+      # Site prism does not correctly handle array arguments
+      visit location_path(test: [1, 2])
+      filter_page.across_england.click
+      filter_page.find_courses.click
+
+      expect(results_page).to be_displayed
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'l' => '2',
+          'test' => %w[1 2],
+        },
+      )
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/qualifications_spec.rb
+++ b/spec/features/new_results_page_filters/qualifications_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new qualifications filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly de-selecting a filter' do
+    it 'show courses with all qualification types selected' do
+      results_page.load
+
+      expect(results_page.qualifications_filter.subheading.text).to eq('Qualifications')
+      expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(true)
+      expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(true)
+      expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(true)
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'applying the filters' do
+    context 'show QTS courses only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[qualification]' => 'qts',
+            'filter[study_type]' => 'full_time,part_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.qualifications_filter.pgce_checkbox.uncheck
+        results_page.qualifications_filter.further_education_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.qualifications_filter.subheading.text).to eq('Qualifications')
+        expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(true)
+        expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(false)
+        expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+
+    context 'show PGCE (or PGDE) with QTS courses only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[qualification]' => 'pgce_with_qts,pgde_with_qts',
+            'filter[study_type]' => 'full_time,part_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.qualifications_filter.further_education_checkbox.uncheck
+        results_page.qualifications_filter.qts_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.qualifications_filter.subheading.text).to eq('Qualifications')
+        expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(true)
+        expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(false)
+        expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+
+    context 'show further education (PGCE or PGDE without QTS) courses only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[qualification]' => 'pgce,pgde',
+            'filter[study_type]' => 'full_time,part_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.qualifications_filter.pgce_checkbox.uncheck
+        results_page.qualifications_filter.qts_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.qualifications_filter.subheading.text).to eq('Qualifications')
+        expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(true)
+        expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(false)
+        expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(false)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/qualifications_spec.rb
+++ b/spec/features/new_results_page_filters/qualifications_spec.rb
@@ -22,7 +22,6 @@ RSpec.feature 'Results page new qualifications filter' do
       expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(true)
       expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(true)
       expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(true)
-      expect(results_page.courses.count).to eq(10)
     end
   end
 
@@ -49,7 +48,6 @@ RSpec.feature 'Results page new qualifications filter' do
         expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(true)
         expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(false)
         expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
-        expect(results_page.courses.count).to eq(10)
       end
     end
 
@@ -75,7 +73,6 @@ RSpec.feature 'Results page new qualifications filter' do
         expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(true)
         expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(false)
         expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
-        expect(results_page.courses.count).to eq(10)
       end
     end
 
@@ -101,7 +98,6 @@ RSpec.feature 'Results page new qualifications filter' do
         expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(true)
         expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(false)
         expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(false)
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end

--- a/spec/features/new_results_page_filters/salary_spec.rb
+++ b/spec/features/new_results_page_filters/salary_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature 'Results page new funding filter' do
 
       expect(results_page.funding_filter.subheading.text).to eq('Salary')
       expect(results_page.funding_filter.checkbox.checked?).to be(false)
-      expect(results_page.courses.count).to eq(10)
     end
   end
 
@@ -44,7 +43,6 @@ RSpec.feature 'Results page new funding filter' do
 
         expect(results_page.funding_filter.subheading.text).to eq('Salary')
         expect(results_page.funding_filter.checkbox.checked?).to be(true)
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end

--- a/spec/features/new_results_page_filters/salary_spec.rb
+++ b/spec/features/new_results_page_filters/salary_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new funding filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly de-selecting a filter' do
+    it 'shows courses with or without a salary' do
+      results_page.load
+
+      expect(results_page.funding_filter.subheading.text).to eq('Salary')
+      expect(results_page.funding_filter.checkbox.checked?).to be(false)
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'applying the filters' do
+    context 'shows only courses with a salary only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[funding]' => 'salary',
+            'filter[study_type]' => 'full_time,part_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.funding_filter.checkbox.check
+        results_page.apply_filters_button.click
+
+        expect(results_page.funding_filter.subheading.text).to eq('Salary')
+        expect(results_page.funding_filter.checkbox.checked?).to be(true)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/send_spec.rb
+++ b/spec/features/new_results_page_filters/send_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature 'Results page new SEND filter' do
 
       expect(results_page.send_filter.subheading.text).to eq('Special educational needs')
       expect(results_page.send_filter.checkbox.checked?).to be(false)
-      expect(results_page.courses.count).to eq(10)
     end
   end
 
@@ -44,7 +43,6 @@ RSpec.feature 'Results page new SEND filter' do
 
         expect(results_page.send_filter.subheading.text).to eq('Special educational needs')
         expect(results_page.send_filter.checkbox.checked?).to be(true)
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end

--- a/spec/features/new_results_page_filters/send_spec.rb
+++ b/spec/features/new_results_page_filters/send_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new SEND filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly selecting a filter' do
+    it 'show courses with or without a SEND specialism' do
+      results_page.load
+
+      expect(results_page.send_filter.subheading.text).to eq('Special educational needs')
+      expect(results_page.send_filter.checkbox.checked?).to be(false)
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'applying the filter' do
+    before do
+      stub_courses(
+        query: base_parameters.merge(
+          'filter[send_courses]' => 'true',
+          'filter[study_type]' => 'full_time,part_time',
+        ),
+        course_count: 10,
+      )
+    end
+
+    context 'selecting courses with a SEND specialism' do
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.send_filter.checkbox.check
+        results_page.apply_filters_button.click
+
+        expect(results_page.send_filter.subheading.text).to eq('Special educational needs')
+        expect(results_page.send_filter.checkbox.checked?).to be(true)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/study_type_spec.rb
+++ b/spec/features/new_results_page_filters/study_type_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new study type filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly de-selecting a filter' do
+    it 'show courses with all study types selected' do
+      results_page.load
+
+      expect(results_page.study_type_filter.subheading.text).to eq('Study type')
+      expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
+      expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'applying the filters' do
+    context 'show full time courses only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[study_type]' => 'full_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.study_type_filter.parttime_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.study_type_filter.subheading.text).to eq('Study type')
+        expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(false)
+        expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+
+    context 'show part time courses only' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[study_type]' => 'part_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.study_type_filter.fulltime_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.study_type_filter.subheading.text).to eq('Study type')
+        expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
+        expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(false)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+
+    context 'show full time and part time courses (default behaviour)' do
+      before do
+        stub_courses(
+          query: base_parameters.merge(
+            'filter[study_type]' => 'part_time,full_time',
+          ),
+          course_count: 10,
+        )
+      end
+
+      it 'still lists full time and part time courses when both are deselected' do
+        results_page.load
+
+        results_page.study_type_filter.fulltime_checkbox.uncheck
+        results_page.study_type_filter.parttime_checkbox.uncheck
+        results_page.apply_filters_button.click
+
+        expect(results_page.study_type_filter.subheading.text).to eq('Study type')
+        expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
+        expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/study_type_spec.rb
+++ b/spec/features/new_results_page_filters/study_type_spec.rb
@@ -21,7 +21,6 @@ RSpec.feature 'Results page new study type filter' do
       expect(results_page.study_type_filter.subheading.text).to eq('Study type')
       expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
       expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
-      expect(results_page.courses.count).to eq(10)
     end
   end
 
@@ -45,7 +44,6 @@ RSpec.feature 'Results page new study type filter' do
         expect(results_page.study_type_filter.subheading.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(false)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
-        expect(results_page.courses.count).to eq(10)
       end
     end
 
@@ -68,7 +66,6 @@ RSpec.feature 'Results page new study type filter' do
         expect(results_page.study_type_filter.subheading.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(false)
-        expect(results_page.courses.count).to eq(10)
       end
     end
 
@@ -92,7 +89,6 @@ RSpec.feature 'Results page new study type filter' do
         expect(results_page.study_type_filter.subheading.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -47,8 +47,6 @@ RSpec.feature 'Results page new subject filter' do
         expect(results_page.subjects_filter.subjects.first.text).to eq(
           'Chemistry, Classics, Communication and media studies, Primary, Primary with English',
         )
-
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end
@@ -76,8 +74,6 @@ RSpec.feature 'Results page new subject filter' do
       expect(results_page.heading.text).to eq('Teacher training courses')
       expect(results_page.subjects_filter.subjects.map.first.text).to eq('Chemistry, Primary, Primary with English')
       expect(results_page.send_filter.checkbox.checked?).to be(true)
-
-      expect(results_page.courses.count).to eq(10)
     end
   end
 

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -247,9 +247,9 @@ RSpec.feature 'Results page new subject filter' do
       )
 
       visit subject_path(subjects: %w[31], senCourses: 'true')
-      filter_page.subject_areas.first.subjects[0].checkbox.click # unselect
-      filter_page.subject_areas.first.subjects[1].checkbox.click # select a different one
-      filter_page.send_area.subjects.first.checkbox.click # unselect
+      filter_page.subject_areas.first.subjects[0].checkbox.click
+      filter_page.subject_areas.first.subjects[1].checkbox.click
+      filter_page.send_area.subjects.first.checkbox.click
 
       filter_page.continue.click
 

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -75,6 +75,7 @@ RSpec.feature 'Results page new subject filter' do
 
       expect(results_page.heading.text).to eq('Teacher training courses')
       expect(results_page.subjects_filter.subjects.map.first.text).to eq('Chemistry, Primary, Primary with English')
+      expect(results_page.send_filter.checkbox.checked?).to be(true)
 
       expect(results_page.courses.count).to eq(10)
     end

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -1,0 +1,304 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new subject filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Subjects
+
+  let(:filter_page) { PageObjects::Page::ResultFilters::SubjectPage.new }
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_courses(query: base_parameters, course_count: 10)
+    stub_subject_areas
+    stub_subjects
+  end
+
+  describe 'applying a filter' do
+    before do
+      stub_courses(query: base_parameters, course_count: 10)
+    end
+
+    context 'with subjects selected' do
+      before do
+        stub_courses(
+          query: base_parameters.merge('filter[subjects]' => '00,01,F1,Q8,P3'),
+          course_count: 10,
+        )
+      end
+
+      it 'lists the results' do
+        results_page.load
+        results_page.subjects_filter.link.click
+
+        expect(filter_page.heading.text).to eq(I18n.t('page_titles.subjects_filter'))
+        filter_page.subject_areas.first.subjects[0].checkbox.click
+        filter_page.subject_areas.first.subjects[1].checkbox.click
+        filter_page.subject_areas.second.subjects[3].checkbox.click
+        filter_page.subject_areas.second.subjects[5].checkbox.click
+        filter_page.subject_areas.second.subjects[6].checkbox.click
+
+        filter_page.continue.click
+
+        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.subjects_filter.subjects.first.text).to eq(
+          'Chemistry, Classics, Communication and media studies, Primary, Primary with English',
+        )
+
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+
+  context 'with only SEND courses selected' do
+    before do
+      query = base_parameters.merge(
+        'filter[subjects]' => '00,01,F1',
+        'filter[send_courses]' => 'true',
+      )
+      stub_courses(query: query, course_count: 10)
+    end
+
+    it 'lists the results' do
+      results_page.load
+      results_page.subjects_filter.link.click
+
+      expect(filter_page.heading.text).to eq(I18n.t('page_titles.subjects_filter'))
+      filter_page.subject_areas.first.subjects[0].checkbox.click
+      filter_page.subject_areas.first.subjects[1].checkbox.click
+      filter_page.subject_areas.second.subjects[3].checkbox.click
+      filter_page.send_area.subjects.first.checkbox.click
+      filter_page.continue.click
+
+      expect(results_page.heading.text).to eq('Teacher training courses')
+      expect(results_page.subjects_filter.subjects.map.first.text).to eq('Chemistry, Primary, Primary with English')
+
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'subject filter page' do
+    before do
+      filter_page.load
+    end
+
+    it "displays 'Back to search results' for the back link" do
+      expect(filter_page.back_link.text).to eq('Back to search results')
+    end
+
+    it "displays 'Find courses' for the continue" do
+      expect(filter_page.continue.value).to eq('Find courses')
+    end
+  end
+
+  describe 'Validation' do
+    context 'no subject selected' do
+      before do
+        filter_page.load
+        filter_page.continue.click
+      end
+
+      it 'displays an error' do
+        expect(filter_page).to have_error
+      end
+
+      it 'expands the first accordion and sets assistive technology attributes appropriately' do
+        expect(filter_page.subject_areas.first.root_element).to match_selector('.govuk-accordion__section--expanded')
+        expect(filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="true"]')
+
+        expect(filter_page.subject_areas.second.root_element).not_to match_selector('.govuk-accordion__section--expanded')
+        expect(filter_page.subject_areas.second.accordion_button).not_to match_selector('[aria-expanded="true"]')
+      end
+
+      it 'stays on the subject filter page' do
+        expect(filter_page.back_link.text).to eq('Back to search results')
+        expect(page).to have_current_path(subject_path, ignore_query: true)
+        expect(filter_page.continue.value).to eq('Find courses')
+      end
+    end
+  end
+
+  describe 'back link' do
+    it 'navigates back to the results page' do
+      filter_page.load(query: { test: 'params' })
+      filter_page.back_link.click
+
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'fulltime' => 'false',
+          'hasvacancies' => 'false',
+          'parttime' => 'false',
+          'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          'senCourses' => 'false',
+          'test' => 'params',
+        },
+      )
+    end
+  end
+
+  context 'check each accordion section' do
+    before { filter_page.load }
+
+    it 'has aria-control set to the section-content id' do
+      expected_control_ids = %w[
+        primarysubject-content-0
+        secondarysubject-content-1
+        modernlanguagessubject-content-2
+        furthereducationsubject-content-3
+      ]
+
+      filter_page.subject_areas.each_with_index do |accordion_section, counter|
+        section_button = accordion_section.find('.govuk-accordion__section-button')
+        expect(section_button['aria-controls']).to eq(expected_control_ids[counter])
+        expect(accordion_section.root_element).to have_selector("##{expected_control_ids[counter]}")
+      end
+
+      # Check SEND section
+      expect(filter_page.send_area.accordion_button['aria-controls']).to eq('send-content')
+      expect(filter_page.send_area.root_element).to have_selector('div#send-content')
+    end
+
+    it 'has a fieldset and legend for each subject area' do
+      expect(filter_page.subject_areas.map(&:legend).map(&:text)).to eq(
+        [
+          'Choose from the following Primary subjects',
+          'Choose from the following Secondary subjects',
+          'Choose from the following Secondary: Modern languages subjects',
+          'Choose from the following Further education subjects',
+        ],
+      )
+    end
+  end
+
+  context 'on the start page' do
+    it 'has a back link to the root page' do
+      visit start_subject_path
+      filter_page.back_link.click
+      expect(URI(current_url).path).to eq('/')
+    end
+
+    it "the submit button displays 'Continue'" do
+      visit start_subject_path
+      expect(filter_page.continue.value).to eq('Continue')
+    end
+  end
+
+  context 'with no selected subjects' do
+    before { filter_page.load }
+
+    let(:expected_financial_info) do
+      [
+        'Scholarships of £2,000 are available.',
+        'Bursaries of £1,000 available.',
+        'Scholarships of £4,000 and bursaries of £3,000 are available, with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).',
+        '',
+      ]
+    end
+
+    it 'sets assistive technology attributes appropriately' do
+      expect(filter_page.subject_areas.first.accordion_button).to match_selector('[aria-expanded="false"]')
+      expect(filter_page.send_area.accordion_button).to match_selector('[aria-expanded="false"]')
+    end
+
+    it 'does not expand any accordion sections' do
+      expect(filter_page.subject_areas.first.root_element).to have_no_css('.govuk-accordion__section--expanded')
+      expect(filter_page.send_area.root_element).to have_no_css('.govuk-accordion__section--expanded')
+    end
+
+    it 'displays all subject areas' do
+      expect(filter_page.subject_areas.map(&:name).map(&:text)).to eq(
+        [
+          'Primary',
+          'Secondary',
+          'Secondary: Modern languages',
+          'Further education',
+        ],
+      )
+    end
+
+    it 'displays financial information' do
+      subjects = filter_page.subject_areas.first.subjects
+      expect(subjects.fourth.info.text).to eq('Bursaries of £6,000 available.')
+      expect(subjects.fourth.ske_course.text).to eq('You can also take a subject knowledge enhancement (SKE) course.')
+    end
+  end
+
+  context 'with previously selected subjects' do
+    it 'automatically selects the given checkboxes' do
+      visit subject_path(subjects: %w[31], senCourses: 'true')
+      expect(filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
+      expect(filter_page.send_area.subjects.first.checkbox).to be_checked
+    end
+
+    it 'automatically selects the given checkboxes with C# casing' do
+      filter_page.load(query: { senCourses: 'True' })
+      expect(filter_page.send_area.subjects.first.checkbox).to be_checked
+    end
+
+    it 'lets you unselect SEND and other subjects' do
+      stub_courses(
+        query: base_parameters.merge('filter[subjects]' => '01'),
+        course_count: 10,
+      )
+
+      visit subject_path(subjects: %w[31], senCourses: 'true')
+      filter_page.subject_areas.first.subjects[0].checkbox.click # unselect
+      filter_page.subject_areas.first.subjects[1].checkbox.click # select a different one
+      filter_page.send_area.subjects.first.checkbox.click # unselect
+
+      filter_page.continue.click
+
+      expect(results_page.subjects_filter.subjects.map(&:text))
+        .to eq(
+          [
+            'Primary with English',
+          ],
+        )
+    end
+  end
+
+  context 'with existing parameters' do
+    before do
+      stub_courses(
+        query: base_parameters.merge('filter[subjects]' => '00,01'),
+        course_count: 10,
+      )
+    end
+
+    it 'only changes the subjects params' do
+      visit subject_path(subjects: %w[32 31], other_param: 'param_value')
+      filter_page.continue.click
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'subjects' => %w[31 32],
+          'other_param' => 'param_value',
+        },
+      )
+    end
+  end
+
+  context 'with the modern languages subject' do
+    before do
+      filter_page.load
+    end
+
+    it 'excludes the modern languages subject' do
+      secondary_modern_languages = filter_page.subject_areas.third
+      expect(secondary_modern_languages.subjects.map(&:text)).not_to include('Modern languages')
+    end
+  end
+
+  context 'with the design and technology subject' do
+    it 'displays additional content' do
+      filter_page.load
+      secondary_area = filter_page.subject_areas.second
+      dt_subject = secondary_area.subjects[9]
+      expect(dt_subject.name.text).to eq('Design and technology – also includes food, product design, textiles, and systems and control')
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/vacancies_spec.rb
+++ b/spec/features/new_results_page_filters/vacancies_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page new vacancies filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::ResultsWithNewFilters.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    activate_feature(:new_filters)
+
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly selecting a filter' do
+    it 'show courses with or without vacancies' do
+      results_page.load
+
+      expect(results_page.vacancies_filter.subheading.text).to eq('Vacancies')
+      expect(results_page.vacancies_filter.checkbox.checked?).to be(false)
+      expect(results_page.courses.count).to eq(10)
+    end
+  end
+
+  describe 'applying the filter' do
+    before do
+      stub_courses(
+        query: base_parameters.merge(
+          'filter[has_vacancies]' => 'true',
+          'filter[study_type]' => 'full_time,part_time',
+        ),
+        course_count: 10,
+      )
+    end
+
+    context 'show courses with vacancies only' do
+      it 'list the filtered courses' do
+        results_page.load
+
+        results_page.vacancies_filter.checkbox.check
+        results_page.apply_filters_button.click
+
+        expect(results_page.vacancies_filter.subheading.text).to eq('Vacancies')
+        expect(results_page.vacancies_filter.checkbox.checked?).to be(true)
+        expect(results_page.courses.count).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/features/new_results_page_filters/vacancies_spec.rb
+++ b/spec/features/new_results_page_filters/vacancies_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature 'Results page new vacancies filter' do
 
       expect(results_page.vacancies_filter.subheading.text).to eq('Vacancies')
       expect(results_page.vacancies_filter.checkbox.checked?).to be(false)
-      expect(results_page.courses.count).to eq(10)
     end
   end
 
@@ -44,7 +43,6 @@ RSpec.feature 'Results page new vacancies filter' do
 
         expect(results_page.vacancies_filter.subheading.text).to eq('Vacancies')
         expect(results_page.vacancies_filter.checkbox.checked?).to be(true)
-        expect(results_page.courses.count).to eq(10)
       end
     end
   end

--- a/spec/site_prism/page_objects/page/results_with_new_filters.rb
+++ b/spec/site_prism/page_objects/page/results_with_new_filters.rb
@@ -1,0 +1,112 @@
+module PageObjects
+  module Page
+    class ResultsWithNewFilters < SitePrism::Page
+      set_url '/results'
+      class CookieBannerSection < SitePrism::Section
+        element :cookies_info_link, '[data-qa="cookie-banner__info-link"]'
+        element :accept_all_cookies, '[data-qa="cookie-banner__accept"]'
+        element :set_preference_link, '[data-qa="cookie-banner__preference-link"]'
+      end
+
+      class CourseSection < SitePrism::Section
+        element :provider_name, '[data-qa="course__provider_name"]'
+        element :description, '[data-qa="course__description"]'
+        element :name, '[data-qa="course__name"]'
+        element :accrediting_provider, '[data-qa="course__accrediting_provider"]'
+        element :funding_options, '[data-qa="course__funding_options"]'
+        element :main_address, '[data-qa="course__main_address"]'
+        elements :show_vacancies, '[data-qa="course__has_vacancies"]'
+      end
+
+      class SubjectsSection < SitePrism::Section
+        elements :subjects, '[data-qa="filters__subject_names"]'
+        element :link, '[data-qa="link"]'
+      end
+
+      class StudyTypeSection < SitePrism::Section
+        element :subheading, 'h3'
+        element :fulltime_checkbox, 'input[name="fulltime"]'
+        element :parttime_checkbox, 'input[name="parttime"]'
+      end
+
+      class VacanciesSection < SitePrism::Section
+        element :subheading, 'h3'
+        element :checkbox, 'input[name="hasvacancies"]'
+      end
+
+      class QualificationsSection < SitePrism::Section
+        element :subheading, 'h3'
+        element :qts_checkbox, 'input[id="qualifications_qtsonly"]'
+        element :pgce_checkbox, 'input[id="qualifications_pgdepgcewithqts"]'
+        element :further_education_checkbox, 'input[id="qualifications_other"]'
+      end
+
+      class LocationAndProviderSection < SitePrism::Section
+        element :name, '[data-qa="area_or_provider_name"]'
+        element :link, '[data-qa="filters__area_and_provider_link"]'
+      end
+
+      class SendSection < SitePrism::Section
+        element :subheading, 'h3'
+        element :checkbox, 'input[name="senCourses"]'
+      end
+
+      class ProviderSection < SitePrism::Section
+        element :name, '[data-qa="provider_name"]'
+        element :link, '[data-qa="link"]'
+      end
+
+      class FundingSection < SitePrism::Section
+        element :subheading, 'h3'
+        element :checkbox, 'input[name="funding"]'
+      end
+
+      class SortFormSection < SitePrism::Section
+        section :options, '[data-qa="sort-form__options"]' do
+          element :ascending, '[data-qa="sort-form__options__ascending"]'
+          element :descending, '[data-qa="sort-form__options__descending"]'
+          element :distance, '[data-qa="sort-form__options__distance"]'
+        end
+        element :submit, '[data-qa="sort-form__submit"]'
+      end
+
+      class SuggestedSearchLinkSection < SitePrism::Section
+        element :link, '[data-qa="link"]'
+      end
+
+      section :cookie_banner, CookieBannerSection, '[data-qa="cookie-banner"]'
+      sections :courses, CourseSection, '[data-qa="course"]'
+      section :subjects_filter, SubjectsSection, '[data-qa="filters__subjects"]'
+      section :study_type_filter, StudyTypeSection, '[data-qa="filters__study_type"]'
+      section :qualifications_filter, QualificationsSection, '[data-qa="filters__qualifications"]'
+      section :vacancies_filter, VacanciesSection, '[data-qa="filters__vacancies"]'
+      section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
+      section :provider_filter, ProviderSection, '[data-qa="filters__provider"]'
+
+      section :area_and_provider_filter, LocationAndProviderSection, '[data-qa="filters__area_and_provider"]'
+      section :send_filter, SendSection, '[data-qa="filters__send"]'
+
+      element :heading, '[data-qa="heading"]'
+      element :next_button, '[data-qa="next_button"]'
+      element :previous_button, '[data-qa="previous_button"]'
+      element :course_count, '[data-qa="course-count"]'
+      element :location_link, '[data-qa="filters__location_link"]'
+      element :subject_link, '[data-qa="filters__subject"]'
+      element :qualification_link, '[data-qa="filters__qualification_link"]'
+      element :salary_link, '[data-qa="filters__salary_link"]'
+      element :vacancies_link, '[data-qa="filters__vacancies_link"]'
+
+      element :suggested_searches, '[data-qa="suggested_searches"]'
+      element :suggested_search_heading, '[data-qa="suggested_search_heading"]'
+      element :suggested_search_description, '[data-qa="suggested_search_description"]'
+      sections :suggested_search_links, SuggestedSearchLinkSection, '[data-qa="suggested_search_link"]'
+
+      section :sort_form, SortFormSection, '[data-qa="sort-form"]'
+
+      element :sorted_by_distance, '.search-results-header', text: 'Sorted by distance'
+      element :feedback_link, '[data-qa=feedback-link]'
+
+      element :apply_filters_button, '[data-qa=apply-filters]'
+    end
+  end
+end

--- a/spec/view_objects/result_filters/new_filters_view_spec.rb
+++ b/spec/view_objects/result_filters/new_filters_view_spec.rb
@@ -1,0 +1,260 @@
+require 'rails_helper'
+
+module ResultFilters
+  describe NewFiltersView do
+    describe '#qts_only_checked?' do
+      subject { described_class.new(params: params).qts_only_checked? }
+
+      context 'when QtsOnly param not present' do
+        let(:params) { { qualifications: %w[Other PgdePgceWithQts] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when QtsOnly param is present' do
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when qualifications is empty' do
+        let(:params) { { qualifications: [] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when parameters are empty' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#pgde_pgce_with_qts_checked' do
+      subject { described_class.new(params: params).pgde_pgce_with_qts_checked? }
+
+      context 'when PgdePgceWithQts param not present' do
+        let(:params) { { qualifications: %w[Other QtsOnly] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when PgdePgceWithQts param is present' do
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when qualifications is empty' do
+        let(:params) { { qualifications: [] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when parameters are empty' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#other_checked?' do
+      subject { described_class.new(params: params).other_checked? }
+
+      context 'when Other param not present' do
+        let(:params) { { qualifications: %w[QtsOnly PgdePgceWithQts] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when Other param is present' do
+        let(:params) { { qualifications: %w[QtsOnly Other] } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when qualifications is empty' do
+        let(:params) { { qualifications: [] } }
+
+        it { is_expected.to eq(false) }
+      end
+
+      context 'when parameters are empty' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#qualification_selected?' do
+      subject { described_class.new(params: params).qualification_selected? }
+
+      context 'when a parameter is selected' do
+        let(:params) { { qualifications: %w[Other] } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when multiple parameters are selected' do
+        let(:params) { { qualifications: %w[Other QtsOnly] } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when no parameter is selected' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#location_query?' do
+      subject { described_class.new(params: params).location_query? }
+
+      context 'when parameter is present' do
+        let(:params) { { l: '1' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#across_england_query?' do
+      subject { described_class.new(params: params).across_england_query? }
+
+      context 'when parameter is present' do
+        let(:params) { { l: '2' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#provider_query?' do
+      subject { described_class.new(params: params).provider_query? }
+
+      context 'when parameter is present' do
+        let(:params) { { l: '3' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#funding_checked?' do
+      subject { described_class.new(params: params).funding_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { funding: '8' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#send_checked?' do
+      subject { described_class.new(params: params).send_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { senCourses: 'true' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#has_vacancies_checked?' do
+      subject { described_class.new(params: params).has_vacancies_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { hasvacancies: 'true' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#full_time_checked?' do
+      subject { described_class.new(params: params).full_time_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { fulltime: 'true' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#part_time_checked?' do
+      subject { described_class.new(params: params).part_time_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { parttime: 'true' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
+    describe '#default_to_true' do
+      subject { described_class.new(params: params).default_to_true }
+
+      context 'when parameters are not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameters are present' do
+        let(:params) do
+          {
+            parttime: 'true',
+            fulltime: 'false',
+          }
+        end
+
+        it { is_expected.to eq(false) }
+      end
+    end
+  end
+end

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -8,6 +8,7 @@ qa:
   RAILS_ENV: qa
   RACK_ENV: qa
   SETTINGS__FEATURE_FLAGS__UCAS_ONLY_LOCATIONS: true
+  SETTINGS__FEATURE_FLAGS__NEW_FILTERS: true
 
 staging:
   <<: *default


### PR DESCRIPTION
### Context

```
As a... user searching for teacher training courses
I need to... filter results to only show those that match my requirements
So that... it is easier for to search and compare courses
```

### Changes proposed in this pull request
- Add new results page filters as per https://find-prototype.herokuapp.com/results.
- These filters are behind a feature flag (`:new_filters`)

### Guidance to review
- To see the new features, pull the branch and add `new_filters: true` to your `development.local.yaml`

```
feature_flags:
  cycle_ending_soon: false
  cycle_has_ended: false
  display_apply_button: true
  new_filters: true
```


- Please let me know if I have added any HTML, CSS or accessibility violations
- Note that the new filters are not a good candidate for govuk_form_builder, as validations are not required, plus there are some complications around hydrating filter form values from params
- Note that once the feature flag is removed, some refactoring will be required to remove old filters and specs.  
- There is some logic in the new filter views that would best be placed elsewhere (e.g helpers) - some of this may be turned into cards
- Commits will be tidied up before merging

<img width="564" alt="new_filters" src="https://user-images.githubusercontent.com/5256922/107493337-64268300-6b85-11eb-90f4-dda0feade3b1.png">

### Trello card
https://trello.com/c/A9f4PnzV/2931-%F0%9F%97%BA-dev-new-search-filters

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
