### PR TITLE
Fix Apply section bookmark link

### DIFF
--- a/app/views/courses/_apply_button.html.erb
+++ b/app/views/courses/_apply_button.html.erb
@@ -1,15 +1,17 @@
-<% if FeatureFlag.active?(:display_apply_button) %>
-  <p class="govuk-body">
-  <%= render GovukComponent::StartNowButton.new(
-    text: 'Apply for this course',
-    href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-    html_attributes: { 'data-qa': 'course__apply_link' },
-  ) %>
-  </p>
-<% else %>
-  <div data-qa="course__end_of_cycle_notice">
+<div class="govuk-!-margin-bottom-8" id="section-apply">
+  <% if FeatureFlag.active?(:display_apply_button) %>
     <p class="govuk-body">
-    You can apply to this course from 13 October.
+      <%= render GovukComponent::StartNowButton.new(
+        text:            'Apply for this course',
+        href:            apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+        html_attributes: { 'data-qa': 'course__apply_link' },
+      ) %>
     </p>
-  </div>
-<% end %>
+  <% else %>
+    <div data-qa="course__end_of_cycle_notice">
+      <p class="govuk-body">
+        You can apply to this course from 13 October.
+      </p>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
### Context
Clicking on the 'Apply' link in the contents section was not taking the user to the Apply section (when the `ucas_only_locations` feature flag was turned on)

### Changes proposed in this pull request
- Fixed

### Trello card
https://trello.com/c/oplOt4W5/3005-apply-on-course-details-page-does-not-link-to-new-apply-section

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
