### PR TITLE
Refactor apply button rendering based on ucas_only_locations feature

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -4,21 +4,7 @@
 
 <div class="govuk-!-margin-bottom-8" id="section-apply">
   <% if @course.has_vacancies? %>
-    <% if FeatureFlag.active?(:display_apply_button) %>
-      <p class="govuk-body">
-      <%= render GovukComponent::StartNowButton.new(
-        text: 'Apply for this course',
-        href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-        html_attributes: { 'data-qa': 'course__apply_link' },
-      ) %>
-      </p>
-    <% else %>
-      <div data-qa="course__end_of_cycle_notice">
-        <p class="govuk-body">
-        You can apply to this course from 13 October.
-        </p>
-      </div>
-    <% end %>
+    <%= render 'apply_button' %>
 
     <% if FeatureFlag.active?(:display_apply_button) %>
       <h3 class="govuk-heading-m">Choose a training location</h3>
@@ -55,9 +41,7 @@
       </tbody>
     </table>
   <% else %>
-    <%= render GovukComponent::Warning.new(
-      text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.',
-    ) %>
+    <%= render 'no_vacancies_warning' %>
   <% end %>
 </div>
 

--- a/app/views/courses/_no_vacancies_warning.html.erb
+++ b/app/views/courses/_no_vacancies_warning.html.erb
@@ -1,0 +1,3 @@
+<%= render GovukComponent::Warning.new(
+  text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.',
+) %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -108,12 +108,12 @@
 
       <%= render partial: 'courses/advice' %>
 
-      <% if !FeatureFlag.active?(:ucas_only_locations) %>
-        <%= render partial: 'courses/apply' %>
-      <% end %>
-
       <% if FeatureFlag.active?(:ucas_only_locations) %>
-        <%= render partial: 'courses/apply_button' %>
+        <div class="govuk-!-margin-bottom-8" id="section-apply">
+          <%= @course.has_vacancies? ? render('apply_button') : render('no_vacancies_warning') %>
+        </div>
+      <% else %>
+          <%= render 'apply' %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION


### Context


https://github.com/DFE-Digital/find-teacher-training/pull/655
### Changes proposed in this pull request
Refactors:
- Use _apply_button in the _apply partial as well as the root
  show.html.erb template
- Make the if branching in show.html.erb clearer

Bug fixes:
- Add a container div with the correct id to fix the 'Apply' link at the
  top of the page when ucas_only_locations is switched on
- When the feature is on, show a warning instead of an apply button if
  the course has no vacancies
### Guidance to review
- View diff
### Trello card
https://trello.com/c/oplOt4W5/3005-apply-on-course-details-page-does-not-link-to-new-apply-section
### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
