### PR TITLE
Show links to relevant teacher training websites

### DIFF
--- a/app/form_objects/result_filters/location_filter_form.rb
+++ b/app/form_objects/result_filters/location_filter_form.rb
@@ -48,6 +48,7 @@ module ResultFilters
           lng: results.longitude,
           loc: results.address,
           lq: location_query,
+          c: country(results),
         }
       end
     end
@@ -62,6 +63,13 @@ module ResultFilters
 
     def search_radius
       @params[:rad]
+    end
+
+    def country(results)
+      flattened_results = results.address_components.map(&:values).flatten
+      countries = [DEVOLVED_NATIONS, 'England'].flatten
+
+      countries.each { |country| return country if flattened_results.include?(country) }
     end
   end
 end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -266,6 +266,14 @@ class ResultsView
     end
   end
 
+  def country
+    query_parameters['c']
+  end
+
+  def devolved_nation?
+    DEVOLVED_NATIONS.include?(country)
+  end
+
 private
 
   def nearest_location(course)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -210,7 +210,7 @@ class ResultsView
   end
 
   def suggested_search_visible?
-    course_count < SUGGESTED_SEARCH_THRESHOLD && suggested_search_links.any?
+    course_count < SUGGESTED_SEARCH_THRESHOLD && suggested_search_links.any? && !devolved_nation?
   end
 
   def suggested_search_links

--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -1,0 +1,21 @@
+<% if devolved_nation %>
+  <h2 class="govuk-heading-l">This service is for courses in England</h2>
+<% end %>
+
+<% case country
+   when "Scotland" %>
+  <p class="govuk-body">
+    <%= link_to "Learn more about teacher training in Scotland", "https://teachinscotland.scot/", class: "govuk-link" %>
+  </p>
+<% when "Wales"%>
+  <p class="govuk-body">
+    <%= link_to "Learn more about teacher training in Wales", "https://www.discoverteaching.wales/routes-into-teaching/", class: "govuk-link" %>
+  </p>
+<% when "Northern Ireland"%>
+  <p class="govuk-body">
+    <%= link_to "Learn more about teacher training in Northern Ireland", "https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland", class: "govuk-link" %>
+  </p>
+<% else %>
+  <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
+  <%= render partial: "try_another_search_text" %>
+<% end %>

--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -17,5 +17,5 @@
   </p>
 <% else %>
   <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
-  <%= render partial: "try_another_search_text" %>
+  <%= render partial: 'try_another_search_text' %>
 <% end %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -33,8 +33,7 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @results_view.no_results_found? %>
       <div class="app-search-results">
-        <h2 class="govuk-heading-m">There are no courses matching your&nbsp;search</h2>
-        <%= render partial: 'try_another_search_text' %>
+        <%= render partial: 'no_results', locals: { country: @results_view.country, devolved_nation: @results_view.devolved_nation? } %>
       </div>
     <% else %>
       <% unless @results_view.provider_filter? %>

--- a/config/initializers/devolved_nations.rb
+++ b/config/initializers/devolved_nations.rb
@@ -1,0 +1,5 @@
+DEVOLVED_NATIONS = [
+  'Northern Ireland',
+  'Scotland',
+  'Wales',
+].freeze

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature 'Results page new area and provider filter' do
           URI(current_url).then do |uri|
             expect(uri.path).to eq('/start/subject')
             expect(uri.query)
-              .to eq('l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
+              .to eq('c=England&l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
           end
         end
       end

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -131,7 +131,7 @@ describe 'Location filter', type: :feature do
           URI(current_url).then do |uri|
             expect(uri.path).to eq('/start/subject')
             expect(uri.query)
-            .to eq('l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
+            .to eq('c=England&l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
           end
         end
       end

--- a/spec/support/geocoder_helper.rb
+++ b/spec/support/geocoder_helper.rb
@@ -9,6 +9,7 @@ def stub_geocoder
         'state' => 'England',
         'country' => 'United Kingdom',
         'country_code' => 'UK',
+        'address_components' => [{ long_name: 'England' }],
       },
     ],
   )
@@ -23,6 +24,7 @@ def stub_geocoder
         'state_code' => 'England',
         'country' => 'United Kingdom',
         'country_code' => 'UK',
+        'address_components' => [{ long_name: 'England' }],
       },
     ],
   )

--- a/spec/views/results/no_results_spec.rb
+++ b/spec/views/results/no_results_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe 'results/no_results.html.erb', type: :view do
+  context 'Scotland' do
+    let(:html) do
+      render partial: 'results/no_results', locals: { country: 'Scotland', devolved_nation: true }
+    end
+
+    it 'renders Scottish teacher training website' do
+      expect(html).to match('This service is for courses in England')
+      expect(html).to have_link('Learn more about teacher training in Scotland', href: 'https://teachinscotland.scot/')
+    end
+  end
+
+  context 'Wales' do
+    let(:html) do
+      render partial: 'results/no_results', locals: { country: 'Wales', devolved_nation: true }
+    end
+
+    it 'renders Welsh teacher training website' do
+      expect(html).to match('This service is for courses in England')
+      expect(html).to have_link('Learn more about teacher training in Wales',
+                                href: 'https://www.discoverteaching.wales/routes-into-teaching/')
+    end
+  end
+
+  context 'Northern Ireland' do
+    let(:html) do
+      render partial: 'results/no_results', locals: { country: 'Northern Ireland', devolved_nation: true }
+    end
+
+    it 'renders Northern Irish teacher training website' do
+      expect(html).to match('This service is for courses in England')
+      expect(html).to have_link('Learn more about teacher training in Northern Ireland',
+                                href: 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland')
+    end
+  end
+
+  context 'England' do
+    let(:html) { render partial: 'results/no_results', locals: { country: 'England', devolved_nation: false } }
+
+    it 'renders try another search text' do
+      assign(:results_view, ResultsView.new(query_parameters: { 'c' => 'England', 'lat' => '51.4975', 'lng' => '0.1357' }))
+      expect(html).to match('There are no courses matching your&nbsp;search')
+    end
+  end
+end


### PR DESCRIPTION
### Context

We should show different text to users in the devolved nations.

### Changes proposed in this pull request

- find the country from the geocode results
- pass it through as a param
- conditionally render different text for each of the devolved nations
- hide search suggestions for devolved nations

### Guidance to review

- Is it OK to pass the country through as a param?
- I intended to leave all other behaviour unaffected, ie suggested search for England or if you search for Rome etc.

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
