### PR TITLE
Fix hint text styling on subject options

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -55,7 +55,7 @@
                           <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
                             <% financial_info.concat(".") %>
                           <% end %>
-                          <span class="govuk-body" data-qa="subject__info"><%= financial_info %></span>
+                          <span class="govuk-hint govuk-!-margin-bottom-0" data-qa="subject__info"><%= financial_info %></span>
 
                           <% if subject.subject_knowledge_enhancement_course_available %>
                             <span class="govuk-!-display-block" data-qa="subject__ske_course">


### PR DESCRIPTION
### Context

Bursary and scholarship info should appear as hint text.

### Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="620" alt="Screenshot 2021-02-15 at 11 41 00" src="https://user-images.githubusercontent.com/813383/107942204-d41c7b00-6f82-11eb-86d7-693f44a16a7e.png"> | <img width="620" alt="Screenshot 2021-02-15 at 11 40 45" src="https://user-images.githubusercontent.com/813383/107942201-d383e480-6f82-11eb-904c-04c2ab8f65b7.png"> |

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
