### PR TITLE
Update search results heading to show number of results

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,13 +1,9 @@
 <%= content_for :page_title, "#{@number_of_courses_string}" %>
 
-<% if @results_view.provider_filter? %>
-  <h1 class="govuk-heading-xl" data-qa="heading">
-    <span class="govuk-caption-l">Teacher training courses</span>
-    <%= smart_quotes(@results_view.provider) %>
-  </h1>
-<% else %>
-  <h1 class="govuk-heading-xl" data-qa="heading">Teacher training courses</h1>
-<% end %>
+<h1 class="govuk-heading-xl" data-qa="heading">
+  <span class="govuk-caption-l">Teacher training courses</span>
+  <span data-qa="course-count"><%= "#{@results_view.number_of_courses_string} found" %></span>
+</h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
@@ -39,18 +35,6 @@
       <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
       <%= render partial: "try_another_search_text" %>
     <% else %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__count" data-qa="course-count">
-            <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
-          </p>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__new-search">
-            <%= link_to "New search", root_path, class: "govuk-link" %>
-          </p>
-        </div>
-      </div>
       <% unless @results_view.provider_filter? %>
         <div class="search-results-header">
           <% if @results_view.location_filter? %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -37,31 +37,43 @@
     <% else %>
       <% unless @results_view.provider_filter? %>
         <div class="search-results-header">
-          <% if @results_view.location_filter? %>
-            <p class="govuk-body govuk-!-margin-bottom-0">Sorted by distance</p>
-          <% else %>
-            <%= form_with(url: results_path, method: "get", skip_enforcing_utf8: true, class: "govuk-form", data: {qa: "sort-form"}) do |form| %>
-              <%= render 'shared/hidden_fields',
-                form: form,
-                exclude_keys: ["sortby"]
-              %>
-              <div class="govuk-form-group">
-                <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-label--inline sortedby-label") %>
-                <%= form.select(
-                  :sortby,
-                  options_for_select(@results_view.sort_options, selected: params["sortby"].to_i || 0),
-                  {},
-                  {
-                    class: "govuk-select trigger-result-update sortby-selector",
-                    onchange: "this.form.submit()",
-                    role: "listbox",
-                    "data-qa": "sort-form__options"
-                  }
-                ) %>
-              </div>
-              <%= form.submit("Update", name: nil, class: "govuk-button", data: { qa: "sort-form__submit" })%>
+          <div class="govuk-grid-row">
+
+            <div class="govuk-grid-column-two-thirds">
+              <% if @results_view.location_filter? %>
+                <p class="govuk-body govuk-!-margin-bottom-0">Sorted by distance</p>
+              <% else %>
+                <%= form_with(url: results_path, method: "get", skip_enforcing_utf8: true, class: "govuk-form", data: {qa: "sort-form"}) do |form| %>
+                  <%= render 'shared/hidden_fields',
+                    form: form,
+                    exclude_keys: ["sortby"]
+                  %>
+                <div class="govuk-form-group">
+                  <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-label--inline sortedby-label") %>
+                  <%= form.select(
+                    :sortby,
+                    options_for_select(@results_view.sort_options, selected: params["sortby"].to_i || 0),
+                    {},
+                    {
+                      class: "govuk-select trigger-result-update sortby-selector",
+                      onchange: "this.form.submit()",
+                      role: "listbox",
+                      "data-qa": "sort-form__options"
+                    }
+                  ) %>
+                </div>
+                <%= form.submit("Update", name: nil, class: "govuk-button", data: { qa: "sort-form__submit" })%>
+              <% end %>
             <% end %>
-          <% end %>
+            </div>
+
+            <div class="govuk-grid-column-one-third">
+              <p class="govuk-body search-results__new-search">
+              <%= link_to "New search", root_path, class: "govuk-link" %>
+              </p>
+            </div>
+
+          </div>
         </div>
       <% end %>
     <% end %>
@@ -99,7 +111,7 @@
                 <%= render partial: 'results/university', locals: { course: course } %>
               <% else %>
                 <%= render partial: 'results/non_university', locals: { course: course } %>
-                <% end %>
+              <% end %>
             <% end %>
             <dt class="govuk-list--description__label">Financial support</dt>
             <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>

--- a/app/webpacker/styles/components/_search-results.scss
+++ b/app/webpacker/styles/components/_search-results.scss
@@ -19,6 +19,7 @@
 
   &__new-search {
     float: right;
+    margin-bottom: 0;
   }
 }
 
@@ -48,12 +49,6 @@
 
     .js-enabled & {
       display: block;
-    }
-  }
-
-  .govuk-form {
-    @include mq($from: desktop) {
-      text-align: right;
     }
   }
 

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature 'Results page new area and provider filter' do
 
         expect(results_page.courses.first).to have_main_address
 
-        expect(results_page.heading.text).to eq('Teacher training courses ACME SCITT 0')
+        expect(results_page.heading.text).to eq('Teacher training courses 4 courses found')
         expect(results_page.area_and_provider_filter.name.text).to eq('ACME SCITT 0')
         expect(results_page.area_and_provider_filter.link.text).to eq('Change provider or choose a location')
         expect(results_page.courses.count).to eq(4)
@@ -104,7 +104,7 @@ RSpec.feature 'Results page new area and provider filter' do
 
     context 'course has sites' do
       it 'displays the courses' do
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
 
         expect(results_page.courses.first).not_to have_main_address
 
@@ -116,7 +116,7 @@ RSpec.feature 'Results page new area and provider filter' do
       # See site id:11208653 in the stub. When a course has no sites with addresses we cannot show
       # 'nearest site' or 'distance to site' info
       it 'does not display nearest site information' do
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       end
     end
 

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -43,7 +43,7 @@ RSpec.feature 'Results page new subject filter' do
 
         filter_page.continue.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.subjects_filter.subjects.first.text).to eq(
           'Chemistry, Classics, Communication and media studies, Primary, Primary with English',
         )
@@ -71,7 +71,7 @@ RSpec.feature 'Results page new subject filter' do
       filter_page.send_area.subjects.first.checkbox.click
       filter_page.continue.click
 
-      expect(results_page.heading.text).to eq('Teacher training courses')
+      expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       expect(results_page.subjects_filter.subjects.map.first.text).to eq('Chemistry, Primary, Primary with English')
       expect(results_page.send_filter.checkbox.checked?).to be(true)
     end

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -97,7 +97,7 @@ describe 'Funding filter', type: :feature do
         stub_courses(query: base_parameters, course_count: 10)
       end
 
-      it 'list the courses' do
+      it 'lists the courses' do
         results_page.load
         results_page.funding_filter.link.click
 
@@ -106,7 +106,7 @@ describe 'Funding filter', type: :feature do
         filter_page.all_courses.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.funding_filter.with_or_without_salary.text).to eq('Courses with and without salary')
 
         expect(results_page.courses.count).to eq(10)
@@ -127,7 +127,7 @@ describe 'Funding filter', type: :feature do
         filter_page.salary_courses.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.funding_filter.with_salary.text).to eq('Only courses with a salary')
 
         expect(results_page.courses.count).to eq(10)

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -49,7 +49,7 @@ describe 'Location filter', type: :feature do
 
         expect(results_page.courses.first).to have_main_address
 
-        expect(results_page.heading.text).to eq('Teacher training courses ACME SCITT 0')
+        expect(results_page.heading.text).to eq('Teacher training courses 4 courses found')
         expect(results_page.provider_filter.name.text).to eq('ACME SCITT 0')
         expect(results_page.provider_filter.link.text).to eq('Change provider or choose a location')
         expect(results_page.courses.count).to eq(4)
@@ -102,7 +102,7 @@ describe 'Location filter', type: :feature do
 
     context 'course has sites' do
       it 'displays the courses' do
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
 
         expect(results_page.courses.first).not_to have_main_address
 
@@ -116,7 +116,7 @@ describe 'Location filter', type: :feature do
       # See site id:11208653 in the stub. When a course has no sites with addresses we cannot show
       # 'nearest site' or 'distance to site' info
       it 'does not display nearest site information' do
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       end
     end
 

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -92,7 +92,7 @@ describe 'Qualifications filter', type: :feature do
         filter_page.qts_only.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.qualifications_filter).to have_pgde_pgce_with_qts
         expect(results_page.qualifications_filter).to have_other_qualifications
 
@@ -117,7 +117,7 @@ describe 'Qualifications filter', type: :feature do
         filter_page.pgde_pgce_with_qts.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.qualifications_filter).to have_qts_only
         expect(results_page.qualifications_filter).to have_other_qualifications
 
@@ -142,7 +142,7 @@ describe 'Qualifications filter', type: :feature do
         filter_page.other.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.qualifications_filter).to have_pgde_pgce_with_qts
         expect(results_page.qualifications_filter).to have_qts_only
 
@@ -179,7 +179,7 @@ describe 'Qualifications filter', type: :feature do
       expect(filter_page.heading.text).to eq('Choose the qualifications to search for')
       filter_page.find_courses.click
 
-      expect(results_page.heading.text).to eq('Teacher training courses')
+      expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       expect(results_page.qualifications_filter).to have_qualifications
 
       expect(results_page.courses.count).to eq(10)

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -110,7 +110,7 @@ describe 'Study type filter', type: :feature do
         filter_page.full_time.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.study_type_filter).to have_parttime
 
         expect(results_page.courses.count).to eq(10)
@@ -130,7 +130,7 @@ describe 'Study type filter', type: :feature do
         filter_page.part_time.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.study_type_filter).to have_fulltime
 
         expect(results_page.courses.count).to eq(10)
@@ -164,7 +164,7 @@ describe 'Study type filter', type: :feature do
 
         filter_page.find_courses.click
 
-        expect(filter_page.heading.text).to eq('Teacher training courses')
+        expect(filter_page.heading.text).to eq('Teacher training courses 10 courses found')
 
         expect(results_page.study_type_filter).to have_fulltime
 

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -38,7 +38,7 @@ describe 'Subject filter', type: :feature do
 
         filter_page.continue.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.subjects_filter.subjects.map(&:text))
           .to eq(
             %w[
@@ -73,7 +73,7 @@ describe 'Subject filter', type: :feature do
 
         filter_page.continue.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.subjects_filter.subjects.map(&:text))
           .to eq(
             [
@@ -110,7 +110,7 @@ describe 'Subject filter', type: :feature do
       filter_page.send_area.subjects.first.checkbox.click
       filter_page.continue.click
 
-      expect(results_page.heading.text).to eq('Teacher training courses')
+      expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       expect(results_page.subjects_filter).to have_send_courses
       expect(results_page.subjects_filter.subjects.map(&:text))
         .to eq(

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -91,7 +91,7 @@ describe 'Vacancy filter', type: :feature do
         filter_page.with_and_without_vacancies.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.vacancies_filter.vacancies.text).to eq('Courses with and without vacancies')
         expect(results_page.courses.count).to eq(10)
       end
@@ -114,7 +114,7 @@ describe 'Vacancy filter', type: :feature do
         filter_page.with_vacancies.click
         filter_page.find_courses.click
 
-        expect(results_page.heading.text).to eq('Teacher training courses')
+        expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.vacancies_filter.vacancies.text).to eq('Only courses with vacancies')
 
         expect(results_page.courses.count).to eq(10)


### PR DESCRIPTION




### Context
To make the search result pages more consistent across types of search
(location, across England, provider, no results), and to make it easier
for non-sighted users to know what's changed on the page, we should show
the number of results in the page heading.
### Changes proposed in this pull request

- Update markup on results page
- Update all feature specs that look for the heading on the page
#### Before:
![Screenshot_20210215_151308](https://user-images.githubusercontent.com/519250/107963637-56fffe80-6fa0-11eb-836a-d9a6f3c95961.png)

#### After:
![Screenshot_20210215_151237](https://user-images.githubusercontent.com/519250/107963567-3f287a80-6fa0-11eb-9c11-96102f937003.png)


### Guidance to review

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
