### PR TITLE
Update styles and markup for search results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -239,6 +239,10 @@ class ResultsView
     course_count.zero?
   end
 
+  def has_results?
+    course_count.positive?
+  end
+
   def number_of_courses_string
     case course_count
     when 0

--- a/app/views/new_filters/_location_provider_filter.html.erb
+++ b/app/views/new_filters/_location_provider_filter.html.erb
@@ -21,10 +21,12 @@
   <% if @filters_view.provider_query? %>
     <%= govuk_link_to "Change provider or choose a location",
       @results_view.filter_path_with_unescaped_commas(location_path),
+      class: 'govuk-link--no-visited-state',
       data:  { qa: "filters__area_and_provider_link" } %>
   <% else %>
     <%= govuk_link_to "Change location or choose a provider",
       @results_view.filter_path_with_unescaped_commas(location_path),
+      class: 'govuk-link--no-visited-state',
       data:  { qa: "filters__area_and_provider_link" } %>
   <% end %>
 </div>

--- a/app/views/new_filters/_subjects_filter.html.erb
+++ b/app/views/new_filters/_subjects_filter.html.erb
@@ -10,5 +10,6 @@
   <% end %>
   <%= govuk_link_to "Change",
     @results_view.filter_path_with_unescaped_commas(subject_path),
+    class: 'govuk-link--no-visited-state',
     data:  { qa: "link" } %>
 </div>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@number_of_courses_string}" %>
+<%= content_for :page_title, @number_of_courses_string %>
 
 <h1 class="govuk-heading-xl" data-qa="heading">
   <span class="govuk-caption-l">Teacher training courses</span>
@@ -32,107 +32,100 @@
 
   <div class="govuk-grid-column-two-thirds">
     <% if @results_view.no_results_found? %>
-      <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
-      <%= render partial: "try_another_search_text" %>
+      <div class="app-search-results">
+        <h2 class="govuk-heading-m">There are no courses matching your&nbsp;search</h2>
+        <%= render partial: 'try_another_search_text' %>
+      </div>
     <% else %>
       <% unless @results_view.provider_filter? %>
-        <div class="search-results-header">
-          <div class="govuk-grid-row">
-
-            <div class="govuk-grid-column-two-thirds">
-              <% if @results_view.location_filter? %>
-                <p class="govuk-body govuk-!-margin-bottom-0">Sorted by distance</p>
-              <% else %>
-                <%= form_with(url: results_path, method: "get", skip_enforcing_utf8: true, class: "govuk-form", data: {qa: "sort-form"}) do |form| %>
-                  <%= render 'shared/hidden_fields',
-                    form: form,
-                    exclude_keys: ["sortby"]
-                  %>
-                <div class="govuk-form-group">
-                  <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-label--inline sortedby-label") %>
-                  <%= form.select(
-                    :sortby,
-                    options_for_select(@results_view.sort_options, selected: params["sortby"].to_i || 0),
-                    {},
-                    {
-                      class: "govuk-select trigger-result-update sortby-selector",
-                      onchange: "this.form.submit()",
-                      role: "listbox",
-                      "data-qa": "sort-form__options"
-                    }
-                  ) %>
-                </div>
-                <%= form.submit("Update", name: nil, class: "govuk-button", data: { qa: "sort-form__submit" })%>
-              <% end %>
+        <div class="app-search-results-header">
+          <% if @results_view.location_filter? %>
+            <p class="govuk-body">Sorted by distance</p>
+          <% else %>
+            <%= form_with(url: results_path, method: 'get', skip_enforcing_utf8: true, class: 'app-search-results-header__sort', data: { qa: 'sort-form' }) do |form| %>
+              <%= render 'shared/hidden_fields',
+                form: form,
+                exclude_keys: ['sortby']
+              %>
+              <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
+              <%= form.select(
+                :sortby,
+                options_for_select(@results_view.sort_options, selected: params['sortby'].to_i || 0),
+                {},
+                {
+                  class: 'govuk-select',
+                  onchange: 'this.form.submit()',
+                  role: 'listbox',
+                  'data-qa': 'sort-form__options',
+                }
+              ) %>
+              <%= form.submit('Update', name: nil, class: 'govuk-button', data: { qa: 'sort-form__submit' }) %>
             <% end %>
-            </div>
+          <% end %>
 
-            <div class="govuk-grid-column-one-third">
-              <p class="govuk-body search-results__new-search">
-              <%= link_to "New search", root_path, class: "govuk-link" %>
-              </p>
-            </div>
-
-          </div>
+          <p class="govuk-body">
+            <%= govuk_link_to 'New search', root_path, class: 'govuk-link--no-visited-state' %>
+          </p>
         </div>
       <% end %>
     <% end %>
 
     <% if @results_view.suggested_search_visible? %>
       <div data-qa="suggested_searches">
-        <h3 class="govuk-heading-m" data-qa="suggested_search_heading">Suggested searches</h3>
+        <h3 class="govuk-heading-s" data-qa="suggested_search_heading">Suggested searches</h3>
         <p class="govuk-body" data-qa="suggested_search_description">You can find:</p>
         <ul class="govuk-list govuk-list--bullet">
           <%- @results_view.suggested_search_links.each do |link| %>
             <li data-qa="suggested_search_link">
-              <a href="<%=link.url%>" class="govuk-link" data-qa="link"><%=link.text%></a><%=link.suffix%>
+              <%= govuk_link_to link.text, link.url, data: { qa: 'link' } %><%= link.suffix %>
             </li>
           <%- end -%>
         </ul>
       </div>
     <% end %>
 
-    <ul class="govuk-list search-results">
-      <% @courses.each do |course| %>
-        <li data-qa="course">
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
-            <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link search-result-link", rel: "prev", data: { qa: "course__link" } do %>
-              <span data-qa="course__provider_name" class="govuk-heading-s govuk-!-margin-bottom-0">
-                <%= smart_quotes(course.provider.provider_name) %>
-              </span>
-              <span data-qa="course__name" class="search-result-link-name govuk-!-font-size-24"><%= course.decorate.display_title %></span>
-            <% end %>
-          </h3>
-          <dl class="govuk-list--description">
-            <dt class="govuk-list--description__label">Course</dt>
-            <dd data-qa="course__description"><%= course.description%></dd>
-            <% if @results_view.location_filter? && @results_view.has_sites?(course) %>
-              <% if course.university_based? %>
-                <%= render partial: 'results/university', locals: { course: course } %>
-              <% else %>
-                <%= render partial: 'results/non_university', locals: { course: course } %>
+    <% if @results_view.has_results? %>
+      <ul class="app-search-results">
+        <% @courses.each do |course| %>
+          <li class="app-search-results__item" data-qa="course">
+            <h2 class="app-search-result__item-title">
+              <%= govuk_link_to course_path(provider_code: course.provider_code, course_code: course.course_code), data: { qa: 'course__link' } do %>
+                <span class="app-search-result__provider-name" data-qa="course__provider_name"><%= smart_quotes(course.provider.provider_name) %></span>
+                <span class="app-search-result__course-name" data-qa="course__name"><%= course.decorate.display_title %></span>
               <% end %>
-            <% end %>
-            <dt class="govuk-list--description__label">Financial support</dt>
-            <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
-            <% if course['accrediting_provider'].present? %>
-              <dt class="govuk-list--description__label">Accredited body</dt>
-              <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>
-            <% end %>
-            <% unless @results_view.location_filter?  %>
-              <dt class="govuk-list--description__label">Locations</dt>
-              <dd data-qa="course__main_address">
-                <%= smart_quotes(course.provider.decorate.short_address) %>
+            </h2>
+            <dl class="govuk-list--description">
+              <dt class="govuk-list--description__label">Course</dt>
+              <dd data-qa="course__description"><%= course.description%></dd>
+              <% if @results_view.location_filter? && @results_view.has_sites?(course) %>
+                <% if course.university_based? %>
+                  <%= render partial: 'results/university', locals: { course: course } %>
+                <% else %>
+                  <%= render partial: 'results/non_university', locals: { course: course } %>
+                <% end %>
+              <% end %>
+              <dt class="govuk-list--description__label">Financial support</dt>
+              <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
+              <% if course['accrediting_provider'].present? %>
+                <dt class="govuk-list--description__label">Accredited body</dt>
+                <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>
+              <% end %>
+              <% unless @results_view.location_filter?  %>
+                <dt class="govuk-list--description__label">Locations</dt>
+                <dd data-qa="course__main_address">
+                  <%= smart_quotes(course.provider.decorate.short_address) %>
+                </dd>
+              <% end %>
+              <dt class="govuk-list--description__label">Vacancies</dt>
+              <dd data-qa="course__has_vacancies">
+                <%= course.decorate.has_vacancies? %>
               </dd>
-            <% end %>
-            <dt class="govuk-list--description__label">Vacancies</dt>
-            <dd data-qa="course__has_vacancies">
-              <%= course.decorate.has_vacancies? %>
-            </dd>
-          </dl>
-        </li>
-      <% end %>
-    </ul>
+            </dl>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
     <%= paginate(@courses, total_pages: @results_view.total_pages) %>
   </div>
 </div>

--- a/app/webpacker/styles/components/_search-results.scss
+++ b/app/webpacker/styles/components/_search-results.scss
@@ -1,93 +1,86 @@
-// Search results view
-.search-results-filters {
+.app-search-results {
+  @include govuk-responsive-padding(4, "top");
+  margin: 0;
+  padding-left: 0;
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-search-results__item {
+  @include govuk-responsive-margin(4, "bottom");
+  border-bottom: 1px solid $govuk-border-colour;
   display: block;
 }
 
-.search-results {
-  border-top: 1px solid $govuk-border-colour;
+.app-search-result__item-title {
+  @include govuk-font($size: 24, $weight: bold);
+  @include govuk-responsive-margin(4, "bottom");
+  margin-top: 0;
 
-  > li {
-    @include govuk-responsive-padding(4, "top");
-    @include govuk-responsive-padding(4, "bottom");
-    border-bottom: 1px solid $govuk-border-colour;
-    margin: 0;
-  }
-
-  &__count {
-    float: left;
-  }
-
-  &__new-search {
-    float: right;
-    margin-bottom: 0;
+  a {
+    text-decoration: none;
   }
 }
 
-.search-result-link {
-  text-decoration: none;
+.app-search-result__provider-name {
+  @include govuk-font($size: 19, $weight: "bold");
+}
 
-  * {
-    color: inherit;
+.app-search-result__course-name {
+  display: block;
+  text-decoration: underline;
+}
+
+.app-search-results-header {
+  border-top: 1px solid $govuk-border-colour;
+
+  @include govuk-media-query($from: "desktop") {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding: govuk-spacing(2) 0;
   }
 
-  .search-result-link-name {
-    text-decoration: underline;
+  .govuk-body {
+    margin: govuk-spacing(2) 0;
   }
 }
 
-.search-results-header {
-  border-top: 1px solid $govuk-border-colour;
-  padding-bottom: govuk-spacing(2);
+.app-search-results-header__sort {
+  display: flex;
+  flex: 1;
+  flex-wrap: wrap;
+  align-items: center;
 
-  @include govuk-media-query($from: desktop) {
-    padding-top: govuk-spacing(2);
+  .govuk-label {
+    padding: govuk-spacing(2) 0;
+    margin: 0 govuk-spacing(2) 0 0;
+    white-space: nowrap;
+    vertical-align: middle;
   }
 
-  &__cta {
-    margin: govuk-spacing(1) 0;
-    display: none;
+  .govuk-select {
+    flex: 1 1 auto;
+    margin: govuk-spacing(2);
+    margin-left: 0;
 
-    .js-enabled & {
-      display: block;
-    }
-  }
-
-  .govuk-form-group {
-    clear: both;
-    display: inline-block;
-    margin-bottom: 0;
-    margin-top: govuk-spacing(2);
-
-    @include mq($from: desktop) {
-      margin: 0;
+    @include govuk-media-query($from: "desktop") {
+      flex: 0;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 
   .govuk-button {
-    float: right;
-    margin: govuk-spacing(2) 0 0 0;
+    flex: 1 0 0;
+    margin: 0 govuk-spacing(2) 0 0;
+    width: auto;
 
-    @include mq($from: desktop) {
-      margin: 0 0 0 govuk-spacing(2);
+    @include govuk-media-query($from: "desktop") {
+      flex: 0;
     }
 
     .js-enabled & {
       display: none;
-    }
-  }
-
-  select {
-    width: 100%;
-
-    @include mq($from: desktop) {
-      width: 220px;
-    }
-  }
-
-  .sortedby-label {
-    @include mq($from: desktop) {
-      display: inline;
-      margin-right: 0.5em;
     }
   }
 }

--- a/app/webpacker/styles/components/_toggle.scss
+++ b/app/webpacker/styles/components/_toggle.scss
@@ -21,7 +21,7 @@
     display: block;
 
     // hide for desktop only
-    @include mq ($from: desktop) {
+    @include mq ($from: tablet) {
       display: none;
 
       &.map-results {
@@ -38,7 +38,7 @@
     display: none;
 
     // always show for desktop
-    @include mq ($from: desktop) {
+    @include mq ($from: tablet) {
       display: block;
     }
 

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -105,7 +105,7 @@ module PageObjects
 
       section :sort_form, SortFormSection, '[data-qa="sort-form"]'
 
-      element :sorted_by_distance, '.search-results-header', text: 'Sorted by distance'
+      element :sorted_by_distance, '.app-search-results-header', text: 'Sorted by distance'
       element :feedback_link, '[data-qa=feedback-link]'
     end
   end

--- a/spec/site_prism/page_objects/page/results_with_new_filters.rb
+++ b/spec/site_prism/page_objects/page/results_with_new_filters.rb
@@ -103,7 +103,7 @@ module PageObjects
 
       section :sort_form, SortFormSection, '[data-qa="sort-form"]'
 
-      element :sorted_by_distance, '.search-results-header', text: 'Sorted by distance'
+      element :sorted_by_distance, '.app-search-results-header', text: 'Sorted by distance'
       element :feedback_link, '[data-qa=feedback-link]'
 
       element :apply_filters_button, '[data-qa=apply-filters]'


### PR DESCRIPTION
### Context

Cleans up design, markup and styles around the search results page.

### Changes proposed in this pull request

* Use `app-*` prefixed CSS classes
* Refactor classes for search results (list, list item etc.)
* Update markup and review heading sizes for messages that show in different search states
* Remove `rel="prev"` on links to course pages – no idea why that was being used
* Review design of no-JS fallback sort submit button across different viewports
* Use no-visited style for various search UI links
* Fix alignment of ‘New search’ link
* Don’t render `ul` if there are no results to show
* Fix the breakpoint at which toggler shows (for legacy filter sidebar)

| Before | After |
| - | - |
| <img width="1038" alt="desktop-before" src="https://user-images.githubusercontent.com/813383/108120851-d1607980-7099-11eb-92d8-738db3ca27db.png"> | <img width="1036" alt="desktop-after" src="https://user-images.githubusercontent.com/813383/108120850-cf96b600-7099-11eb-9479-2a11c5f952fa.png"> |
| <img width="316" alt="mobile-before" src="https://user-images.githubusercontent.com/813383/108120857-d3c2d380-7099-11eb-9c75-9ac383f56e76.png"> | <img width="316" alt="mobile-after" src="https://user-images.githubusercontent.com/813383/108120853-d291a680-7099-11eb-9f1e-c97c417e028c.png"> |
| <img width="660" alt="no-courses-before" src="https://user-images.githubusercontent.com/813383/108120865-d4f40080-7099-11eb-8dc0-dbc5d157365b.png"> | <img width="653" alt="no-courses-after" src="https://user-images.githubusercontent.com/813383/108120862-d45b6a00-7099-11eb-85d8-d0773b501904.png"> |
| <img width="646" alt="no-js-sort-desktop-before" src="https://user-images.githubusercontent.com/813383/108120868-d6252d80-7099-11eb-8677-65bfe84b9cb8.png"> | <img width="646" alt="no-js-sort-desktop-after" src="https://user-images.githubusercontent.com/813383/108120867-d58c9700-7099-11eb-94b2-af3eaa8f38e4.png"> | 
| <img width="306" alt="no-js-sort-mobile-before" src="https://user-images.githubusercontent.com/813383/108120871-d6bdc400-7099-11eb-8517-c859d2c8fcb3.png"> | <img width="304" alt="no-js-sort-mobile-after" src="https://user-images.githubusercontent.com/813383/108120869-d6bdc400-7099-11eb-978c-41ae2dd33abf.png"> |
| <img width="655" alt="suggested-search-before" src="https://user-images.githubusercontent.com/813383/108120877-d7eef100-7099-11eb-9476-d510b001d2de.png"> | <img width="655" alt="suggested-search-after" src="https://user-images.githubusercontent.com/813383/108120873-d7565a80-7099-11eb-8969-372e2ea5cae2.png"> |

### Guidance to review

### Trello card

https://trello.com/c/Za2awSWs/

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
