### PR TITLE
Fix styling in results page (with new filters)

### DIFF
--- a/app/views/results/index_new_filters.html.erb
+++ b/app/views/results/index_new_filters.html.erb
@@ -13,107 +13,100 @@
   </div>
   <div class="app-filter-layout__content">
     <% if @results_view.no_results_found? %>
-      <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
-      <%= render partial: "try_another_search_text" %>
-    <% else %>
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__count" data-qa="course-count">
-            <%= "#{@results_view.number_of_courses_string} found#{' within 50 miles' if @results_view.location_filter?}" %>
-          </p>
-        </div>
-        <div class="govuk-grid-column-one-half">
-          <p class="govuk-body search-results__new-search">
-            <%= link_to "New search", root_path, class: "govuk-link" %>
-          </p>
-        </div>
+      <div class="app-search-results">
+        <h2 class="govuk-heading-m">There are no courses matching your&nbsp;search</h2>
+        <%= render partial: 'try_another_search_text' %>
       </div>
+    <% else %>
       <% unless @results_view.provider_filter? %>
         <div class="app-search-results-header">
           <% if @results_view.location_filter? %>
-            <p class="govuk-body govuk-!-margin-bottom-0">Sorted by distance</p>
+            <p class="govuk-body">Sorted by distance</p>
           <% else %>
-            <%= form_with(url: results_path, method: "get", skip_enforcing_utf8: true, class: "govuk-form", data: {qa: "sort-form"}) do |form| %>
+            <%= form_with(url: results_path, method: 'get', skip_enforcing_utf8: true, class: 'app-search-results-header__sort', data: { qa: 'sort-form' }) do |form| %>
               <%= render 'shared/hidden_fields',
                 form: form,
-                exclude_keys: ["sortby"]
+                exclude_keys: ['sortby']
               %>
-              <div class="govuk-form-group">
-                <%= form.label(:sortby, "Sorted by", class: "govuk-label govuk-label--inline sortedby-label") %>
-                <%= form.select(
-                      :sortby,
-                      options_for_select(@results_view.sort_options, selected: params["sortby"].to_i || 0),
-                      {},
-                      {
-                        class: "govuk-select trigger-result-update sortby-selector",
-                        onchange: "this.form.submit()",
-                        role: "listbox",
-                        "data-qa": "sort-form__options"
-                      }
-                    ) %>
-              </div>
-              <%= form.submit("Update", name: nil, class: "govuk-button", data: { qa: "sort-form__submit" })%>
+              <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
+              <%= form.select(
+                    :sortby,
+                    options_for_select(@results_view.sort_options, selected: params['sortby'].to_i || 0),
+                    {},
+                    {
+                      class: 'govuk-select',
+                      onchange: 'this.form.submit()',
+                      role: 'listbox',
+                      'data-qa': 'sort-form__options',
+                    }
+                  ) %>
+              <%= form.submit('Update', name: nil, class: 'govuk-button', data: { qa: 'sort-form__submit' }) %>
             <% end %>
           <% end %>
+
+          <p class="govuk-body">
+            <%= govuk_link_to 'New search', root_path, class: 'govuk-link--no-visited-state' %>
+          </p>
         </div>
       <% end %>
     <% end %>
 
     <% if @results_view.suggested_search_visible? %>
       <div data-qa="suggested_searches">
-        <h3 class="govuk-heading-m" data-qa="suggested_search_heading">Suggested searches</h3>
+        <h3 class="govuk-heading-s" data-qa="suggested_search_heading">Suggested searches</h3>
         <p class="govuk-body" data-qa="suggested_search_description">You can find:</p>
         <ul class="govuk-list govuk-list--bullet">
           <%- @results_view.suggested_search_links.each do |link| %>
             <li data-qa="suggested_search_link">
-              <a href="<%=link.url%>" class="govuk-link" data-qa="link"><%=link.text%></a><%=link.suffix%>
+              <%= govuk_link_to link.text, link.url, data: { qa: 'link' } %><%= link.suffix %>
             </li>
           <%- end -%>
         </ul>
       </div>
     <% end %>
 
-    <ul class="govuk-list search-results">
-      <% @courses.each do |course| %>
-        <li data-qa="course">
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-6">
-            <%= link_to course_path(provider_code: course.provider_code, course_code: course.course_code), class: "govuk-link search-result-link", rel: "prev", data: { qa: "course__link" } do %>
-              <span data-qa="course__provider_name" class="govuk-heading-s govuk-!-margin-bottom-0">
-                <%= smart_quotes(course.provider.provider_name) %>
-              </span>
-              <span data-qa="course__name" class="search-result-link-name govuk-!-font-size-24"><%= course.decorate.display_title %></span>
-            <% end %>
-          </h3>
-          <dl class="govuk-list--description">
-            <dt class="govuk-list--description__label">Course</dt>
-            <dd data-qa="course__description"><%= course.description%></dd>
-            <% if @results_view.location_filter? && @results_view.has_sites?(course) %>
-              <% if course.university_based? %>
-                <%= render partial: 'results/university', locals: { course: course } %>
-              <% else %>
-                <%= render partial: 'results/non_university', locals: { course: course } %>
+    <% if @results_view.has_results? %>
+      <ul class="app-search-results">
+        <% @courses.each do |course| %>
+          <li class="app-search-results__item" data-qa="course">
+            <h2 class="app-search-result__item-title">
+              <%= govuk_link_to course_path(provider_code: course.provider_code, course_code: course.course_code), data: { qa: 'course__link' } do %>
+                <span class="app-search-result__provider-name" data-qa="course__provider_name"><%= smart_quotes(course.provider.provider_name) %></span>
+                <span class="app-search-result__course-name" data-qa="course__name"><%= course.decorate.display_title %></span>
               <% end %>
-            <% end %>
-            <dt class="govuk-list--description__label">Financial support</dt>
-            <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
-            <% if course['accrediting_provider'].present? %>
-              <dt class="govuk-list--description__label">Accredited body</dt>
-              <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>
-            <% end %>
-            <% unless @results_view.location_filter?  %>
-              <dt class="govuk-list--description__label">Locations</dt>
-              <dd data-qa="course__main_address">
-                <%= smart_quotes(course.provider.decorate.short_address) %>
+            </h2>
+            <dl class="govuk-list--description">
+              <dt class="govuk-list--description__label">Course</dt>
+              <dd data-qa="course__description"><%= course.description%></dd>
+              <% if @results_view.location_filter? && @results_view.has_sites?(course) %>
+                <% if course.university_based? %>
+                  <%= render partial: 'results/university', locals: { course: course } %>
+                <% else %>
+                  <%= render partial: 'results/non_university', locals: { course: course } %>
+                <% end %>
+              <% end %>
+              <dt class="govuk-list--description__label">Financial support</dt>
+              <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
+              <% if course['accrediting_provider'].present? %>
+                <dt class="govuk-list--description__label">Accredited body</dt>
+                <dd data-qa="course__accrediting_provider"><%= smart_quotes(course['accrediting_provider']['provider_name']) %></dd>
+              <% end %>
+              <% unless @results_view.location_filter?  %>
+                <dt class="govuk-list--description__label">Locations</dt>
+                <dd data-qa="course__main_address">
+                  <%= smart_quotes(course.provider.decorate.short_address) %>
+                </dd>
+              <% end %>
+              <dt class="govuk-list--description__label">Vacancies</dt>
+              <dd data-qa="course__has_vacancies">
+                <%= course.decorate.has_vacancies? %>
               </dd>
-            <% end %>
-            <dt class="govuk-list--description__label">Vacancies</dt>
-            <dd data-qa="course__has_vacancies">
-              <%= course.decorate.has_vacancies? %>
-            </dd>
-          </dl>
-        </li>
-      <% end %>
-    </ul>
+            </dl>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
+
     <%= paginate(@courses, total_pages: @results_view.total_pages) %>
   </div>
 </div>


### PR DESCRIPTION
### Context
- In https://trello.com/c/Za2awSWs/3050-find-clean-up we forgot to also update the styles in `app/views/results/index_new_filters.html.erb` which is currently feature-flagged

### Changes proposed in this pull request
Styles / markup updated

### Trello card
https://trello.com/c/Za2awSWs/3050-find-clean-up

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
