### PR TITLE
Turn on 'new_filters' feature flag on in all deployed environments

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,4 +22,4 @@ feature_flags:
   cycle_has_ended: false
   display_apply_button: true
   ucas_only_locations: false
-  new_filters: false
+  new_filters: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -2,3 +2,5 @@ teacher_training_api:
   base_url: http://localhost:3001
 valid_referers:
   - http://localhost:9000
+feature_flags:
+  new_filters: false

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -8,7 +8,6 @@ qa:
   RAILS_ENV: qa
   RACK_ENV: qa
   SETTINGS__FEATURE_FLAGS__UCAS_ONLY_LOCATIONS: true
-  SETTINGS__FEATURE_FLAGS__NEW_FILTERS: true
 
 staging:
   <<: *default


### PR DESCRIPTION
### Context
We have created new filters for the search results page

### Changes proposed in this pull request
- Turn on `new_filters` feature flag in all deployed environments
- Note that the default for 'test' remains as `false` and is turned on as an where required

### Guidance to review
- Once the new filters are testing ok a followup PR will be raised to remove the feature flag and any dead code

### Trello card
https://trello.com/c/sZDbLLB9/3059-turn-on-new-filters-feature-flag-in-all-deployed-environments

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
