### PR TITLE
Validate secrets in deploy workflow before running terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,11 @@ jobs:
         run: |
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
           echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
+          
+          . terraform/workspace_variables/$DEPLOY_ENV.sh
+          echo "TF_VAR_key_vault_name=$TF_VAR_key_vault_name" >> $GITHUB_ENV
+          echo "TF_VAR_key_vault_app_secret_name=$TF_VAR_key_vault_app_secret_name" >> $GITHUB_ENV
+          echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV
         env:
           DOCKER_IMAGE: ${{ format('dfedigital/find-teacher-training:{0}', github.event.inputs.sha) }}
           DEPLOY_ENV: ${{ matrix.environment }}
@@ -71,6 +76,18 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.13.5
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
+
+      - name: Validate Azure Key Vault secrets
+        uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+        with:
+          KEY_VAULT: ${{ env.TF_VAR_key_vault_name }}
+          SECRETS: |
+            ${{ env.TF_VAR_key_vault_app_secret_name }}
+            ${{ env.TF_VAR_key_vault_infra_secret_name }}
 
       - name: Terraform init, plan & apply
         id: terraform_deploy

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@
 yarn-debug.log*
 .yarn-integrity
 
+#Ignore the fetch_config.rb script
+bin/fetch_config.rb
+
 .env
 *.log
 

--- a/terraform/workspace_variables/production.sh
+++ b/terraform/workspace_variables/production.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name="s121p01-shared-kv-01"
+export TF_VAR_key_vault_app_secret_name="FIND-APP-SECRETS-PRODUCTION"
+export TF_VAR_key_vault_infra_secret_name="BAT-INFRA-SECRETS-PRODUCTION"

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -6,10 +6,7 @@ paas_web_app_instances = 2
 paas_web_app_memory    = 1024
 
 # KeyVault
-key_vault_name              = "s121p01-shared-kv-01"
 key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "FIND-APP-SECRETS-PRODUCTION"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/qa.sh
+++ b/terraform/workspace_variables/qa.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name="s121d01-shared-kv-01"
+export TF_VAR_key_vault_app_secret_name="FIND-APP-SECRETS-QA"
+export TF_VAR_key_vault_infra_secret_name="BAT-INFRA-SECRETS-QA"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -6,10 +6,7 @@ paas_web_app_instances = 1
 paas_web_app_memory    = 512
 
 # KeyVault
-key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = "FIND-APP-SECRETS-QA"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/sandbox.sh
+++ b/terraform/workspace_variables/sandbox.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name="s121p01-shared-kv-01"
+export TF_VAR_key_vault_app_secret_name="FIND-APP-SECRETS-SANDBOX"
+export TF_VAR_key_vault_infra_secret_name="BAT-INFRA-SECRETS-SANDBOX"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -6,10 +6,7 @@ paas_web_app_instances = 2
 paas_web_app_memory    = 512
 
 # KeyVault
-key_vault_name              = "s121p01-shared-kv-01"
 key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "FIND-APP-SECRETS-SANDBOX"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/staging.sh
+++ b/terraform/workspace_variables/staging.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name="s121t01-shared-kv-01"
+export TF_VAR_key_vault_app_secret_name="FIND-APP-SECRETS-STAGING"
+export TF_VAR_key_vault_infra_secret_name="BAT-INFRA-SECRETS-STAGING"

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -6,10 +6,7 @@ paas_web_app_instances = 2
 paas_web_app_memory    = 512
 
 # KeyVault
-key_vault_name              = "s121t01-shared-kv-01"
 key_vault_resource_group    = "s121t01-shared-rg"
-key_vault_app_secret_name   = "FIND-APP-SECRETS-STAGING"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
 
 #StatusCake
 statuscake_alerts = {


### PR DESCRIPTION
### Context

Secrets not in correct YAML format might lead to terraform erroring and outputting the values when running the deploy worklow.
To prevent such leaks we validate the secrets for correct YAML before running terraform.

### Changes proposed in this pull request

Run secrets validation step before running terraform.
Set key_vault variables as env variables to reuse in make commands.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
