### PR TITLE
Default filters to show courses with vacancies by default | Fix missing params

### DIFF
--- a/app/view_objects/result_filters/new_filters_view.rb
+++ b/app/view_objects/result_filters/new_filters_view.rb
@@ -66,6 +66,20 @@ module ResultFilters
       params[:hasvacancies].nil?
     end
 
+    def location_query_params
+      {
+        c: params[:c],
+        l: params[:l],
+        lq: params[:lq],
+        lat: params[:lat],
+        loc: params[:loc],
+        lng: params[:lng],
+        query: params[:query],
+        rad: params[:rad],
+        sortby: params[:sortby],
+      }
+    end
+
   private
 
     attr_reader :params

--- a/app/view_objects/result_filters/new_filters_view.rb
+++ b/app/view_objects/result_filters/new_filters_view.rb
@@ -58,8 +58,12 @@ module ResultFilters
       params[:parttime] == 'true'
     end
 
-    def default_to_true
+    def default_study_types_to_true
       params[:fulltime] != 'true' && params[:parttime] != 'true'
+    end
+
+    def default_with_vacancies_to_true
+      params[:hasvacancies].nil?
     end
 
   private

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -43,7 +43,7 @@ class ResultsView
   end
 
   def hasvacancies?
-    return false if query_parameters['hasvacancies'].nil?
+    return true if query_parameters['hasvacancies'].nil?
 
     query_parameters['hasvacancies'] == 'true'
   end

--- a/app/views/new_filters/_all.html.erb
+++ b/app/views/new_filters/_all.html.erb
@@ -1,4 +1,4 @@
-<%= form_with url: results_path, class: 'app-filter', method: :get do |form| %>
+<%= form_with url: results_path, skip_enforcing_utf8: true, class: 'app-filter', method: :get do |form| %>
   <div class="app-filter__header">
     <h2 class="govuk-heading-m">Filters</h2>
   </div>

--- a/app/views/new_filters/_hidden_fields.html.erb
+++ b/app/views/new_filters/_hidden_fields.html.erb
@@ -1,4 +1,5 @@
-<%= form.hidden_field(:l, value: request.params[:l]) %>
-<%= form.hidden_field(:lq, value: request.params[:lq]) %>
-<%= form.hidden_field(:lat, value: request.params[:lat]) %>
-<%= form.hidden_field(:lng, value: request.params[:lng]) %>
+<% @filters_view.location_query_params.each do |k, v| %>
+  <% if v.present? %>
+    <%= form.hidden_field(k, value: v) %>
+  <% end %>
+<% end %>

--- a/app/views/new_filters/_study_type_filter.html.erb
+++ b/app/views/new_filters/_study_type_filter.html.erb
@@ -4,7 +4,7 @@
     <div class="govuk-checkboxes__item">
       <%= form.check_box(
         :fulltime,
-        { checked: @filters_view.full_time_checked? || @filters_view.default_to_true, class: 'govuk-checkboxes__input' },
+        { checked: @filters_view.full_time_checked? || @filters_view.default_study_types_to_true, class: 'govuk-checkboxes__input' },
         'true',
         nil,
       ) %>

--- a/app/views/new_filters/_study_type_filter.html.erb
+++ b/app/views/new_filters/_study_type_filter.html.erb
@@ -16,7 +16,7 @@
     <div class="govuk-checkboxes__item">
       <%= form.check_box(
         :parttime,
-        { checked: @filters_view.part_time_checked? || @filters_view.default_to_true, class: 'govuk-checkboxes__input' },
+        { checked: @filters_view.part_time_checked? || @filters_view.default_study_types_to_true, class: 'govuk-checkboxes__input' },
         'true',
         nil,
       ) %>

--- a/app/views/new_filters/_vacancy_filter.html.erb
+++ b/app/views/new_filters/_vacancy_filter.html.erb
@@ -4,9 +4,13 @@
     <div class="govuk-checkboxes__item">
       <%= form.check_box(
         :hasvacancies,
-        { checked: @filters_view.has_vacancies_checked?, data: { qa: 'with_vacancies' }, class: 'govuk-checkboxes__input' },
+        {
+          checked: @filters_view.has_vacancies_checked? || @filters_view.default_with_vacancies_to_true,
+          data: { qa: 'with_vacancies' },
+          class: 'govuk-checkboxes__input'
+        },
         'true',
-        nil,
+          'false',
       ) %>
       <%= form.label(:hasvacancies_true, { for: 'hasvacancies' }, class: 'govuk-label govuk-checkboxes__label') do %>
         Only show courses with vacancies

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature 'Results page new area and provider filter' do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'false',
+          'hasvacancies' => 'true',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/new_results_page_filters/location_and_provider_spec.rb
+++ b/spec/features/new_results_page_filters/location_and_provider_spec.rb
@@ -39,22 +39,35 @@ RSpec.feature 'Results page new area and provider filter' do
     end
 
     context 'valid provider search' do
-      it 'displays the courses' do
+      before do
         results_page.load
         results_page.area_and_provider_filter.link.click
         filter_page.by_provider.click
         filter_page.provider_search.fill_in(with: 'ACME')
         filter_page.find_courses.click
-
-        expect(provider_page.heading.text).to eq('Pick a provider')
         provider_page.provider_suggestions[0].hyperlink.click
+      end
 
+      it 'displays the courses' do
         expect(results_page.courses.first).to have_main_address
-
         expect(results_page.heading.text).to eq('Teacher training courses 4 courses found')
         expect(results_page.area_and_provider_filter.name.text).to eq('ACME SCITT 0')
         expect(results_page.area_and_provider_filter.link.text).to eq('Change provider or choose a location')
-        expect(results_page.courses.count).to eq(4)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'false',
+            'parttime' => 'false',
+            'hasvacancies' => 'true',
+            'l' => '3',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'senCourses' => 'false',
+            'query' => 'ACME SCITT 0',
+          },
+        )
       end
     end
 
@@ -100,6 +113,72 @@ RSpec.feature 'Results page new area and provider filter' do
       filter_page.by_postcode_town_or_city.click
       filter_page.location_query.fill_in(with: 'SW1P 3BT')
       filter_page.find_courses.click
+    end
+
+    it 'displays the courses' do
+      expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
+      expect(results_page.area_and_provider_filter.name.text).to eq('SW1P 3BT')
+      expect(results_page.area_and_provider_filter.link.text).to eq('Change location or choose a provider')
+    end
+
+    it 'retains the query parameters' do
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'c' => 'England',
+          'fulltime' => 'false',
+          'parttime' => 'false',
+          'hasvacancies' => 'true',
+          'l' => '1',
+          'lat' => '51.4980188',
+          'lng' => '-0.1300436',
+          'loc' => 'Westminster, London SW1P 3BT, UK',
+          'lq' => 'SW1P 3BT',
+          'rad' => '50',
+          'sortby' => '2',
+          'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          'senCourses' => 'false',
+        },
+      )
+    end
+
+    context 'filtering by location a second time' do
+      before do
+        query = base_parameters.merge(
+          'filter[longitude]' => '-1.0564076',
+          'filter[latitude]' => '53.83365879999999',
+          'filter[radius]' => '50',
+          'sort' => 'distance',
+          'filter[expand_university]' => false,
+        )
+        stub_courses(query: query, course_count: 10)
+      end
+
+      it 'updates and retains the query parameters' do
+        results_page.area_and_provider_filter.link.click
+        filter_page.by_postcode_town_or_city.click
+        filter_page.location_query.fill_in(with: 'Station Rise')
+        filter_page.find_courses.click
+
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'c' => 'England',
+            'fulltime' => 'false',
+            'parttime' => 'false',
+            'hasvacancies' => 'true',
+            'l' => '1',
+            'lat' => '53.83365879999999',
+            'lng' => '-1.0564076',
+            'loc' => 'Station Rise, Ricall, York YO19 2C, UK',
+            'lq' => 'Station Rise',
+            'rad' => '50',
+            'sortby' => '2',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'senCourses' => 'false',
+          },
+        )
+      end
     end
 
     context 'course has sites' do

--- a/spec/features/new_results_page_filters/qualifications_spec.rb
+++ b/spec/features/new_results_page_filters/qualifications_spec.rb
@@ -35,19 +35,30 @@ RSpec.feature 'Results page new qualifications filter' do
           ),
           course_count: 10,
         )
-      end
 
-      it 'list the filtered courses' do
         results_page.load
-
         results_page.qualifications_filter.pgce_checkbox.uncheck
         results_page.qualifications_filter.further_education_checkbox.uncheck
         results_page.apply_filters_button.click
+      end
 
+      it 'list the filtered courses' do
         expect(results_page.qualifications_filter.legend.text).to eq('Qualifications')
         expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(true)
         expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(false)
         expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly],
+          },
+        )
       end
     end
 
@@ -60,19 +71,30 @@ RSpec.feature 'Results page new qualifications filter' do
           ),
           course_count: 10,
         )
-      end
 
-      it 'list the filtered courses' do
         results_page.load
-
         results_page.qualifications_filter.further_education_checkbox.uncheck
         results_page.qualifications_filter.qts_checkbox.uncheck
         results_page.apply_filters_button.click
+      end
 
+      it 'lists the filtered courses' do
         expect(results_page.qualifications_filter.legend.text).to eq('Qualifications')
         expect(results_page.qualifications_filter.pgce_checkbox.checked?).to be(true)
         expect(results_page.qualifications_filter.qts_checkbox.checked?).to be(false)
         expect(results_page.qualifications_filter.further_education_checkbox.checked?).to be(false)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[PgdePgceWithQts],
+          },
+        )
       end
     end
 

--- a/spec/features/new_results_page_filters/salary_spec.rb
+++ b/spec/features/new_results_page_filters/salary_spec.rb
@@ -33,16 +33,28 @@ RSpec.feature 'Results page new funding filter' do
           ),
           course_count: 10,
         )
+
+        results_page.load
+        results_page.funding_filter.checkbox.check
+        results_page.apply_filters_button.click
       end
 
       it 'list the filtered courses' do
-        results_page.load
-
-        results_page.funding_filter.checkbox.check
-        results_page.apply_filters_button.click
-
         expect(results_page.funding_filter.legend.text).to eq('Salary')
         expect(results_page.funding_filter.checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'funding' => '8',
+          },
+        )
       end
     end
   end

--- a/spec/features/new_results_page_filters/send_spec.rb
+++ b/spec/features/new_results_page_filters/send_spec.rb
@@ -32,17 +32,29 @@ RSpec.feature 'Results page new SEND filter' do
         ),
         course_count: 10,
       )
+
+      results_page.load
+      results_page.send_filter.checkbox.check
+      results_page.apply_filters_button.click
     end
 
     context 'selecting courses with a SEND specialism' do
       it 'list the filtered courses' do
-        results_page.load
-
-        results_page.send_filter.checkbox.check
-        results_page.apply_filters_button.click
-
         expect(results_page.send_filter.legend.text).to eq('Special educational needs')
         expect(results_page.send_filter.checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'senCourses' => 'true',
+          },
+        )
       end
     end
   end

--- a/spec/features/new_results_page_filters/study_type_spec.rb
+++ b/spec/features/new_results_page_filters/study_type_spec.rb
@@ -33,17 +33,27 @@ RSpec.feature 'Results page new study type filter' do
           ),
           course_count: 10,
         )
+
+        results_page.load
+        results_page.study_type_filter.parttime_checkbox.uncheck
+        results_page.apply_filters_button.click
       end
 
       it 'list the filtered courses' do
-        results_page.load
-
-        results_page.study_type_filter.parttime_checkbox.uncheck
-        results_page.apply_filters_button.click
-
         expect(results_page.study_type_filter.legend.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(false)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          },
+        )
       end
     end
 
@@ -55,17 +65,27 @@ RSpec.feature 'Results page new study type filter' do
           ),
           course_count: 10,
         )
+
+        results_page.load
+        results_page.study_type_filter.fulltime_checkbox.uncheck
+        results_page.apply_filters_button.click
       end
 
       it 'list the filtered courses' do
-        results_page.load
-
-        results_page.study_type_filter.fulltime_checkbox.uncheck
-        results_page.apply_filters_button.click
-
         expect(results_page.study_type_filter.legend.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(false)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          },
+        )
       end
     end
 
@@ -77,18 +97,27 @@ RSpec.feature 'Results page new study type filter' do
           ),
           course_count: 10,
         )
-      end
 
-      it 'still lists full time and part time courses when both are deselected' do
         results_page.load
-
         results_page.study_type_filter.fulltime_checkbox.uncheck
         results_page.study_type_filter.parttime_checkbox.uncheck
         results_page.apply_filters_button.click
+      end
 
+      it 'still lists full time and part time courses when both are deselected' do
         expect(results_page.study_type_filter.legend.text).to eq('Study type')
         expect(results_page.study_type_filter.parttime_checkbox.checked?).to be(true)
         expect(results_page.study_type_filter.fulltime_checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          },
+        )
       end
     end
   end

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -28,24 +28,34 @@ RSpec.feature 'Results page new subject filter' do
           query: base_parameters.merge('filter[subjects]' => '00,01,F1,Q8,P3'),
           course_count: 10,
         )
-      end
 
-      it 'lists the results' do
         results_page.load
         results_page.subjects_filter.link.click
-
-        expect(filter_page.heading.text).to eq(I18n.t('page_titles.subjects_filter'))
         filter_page.subject_areas.first.subjects[0].checkbox.click
         filter_page.subject_areas.first.subjects[1].checkbox.click
         filter_page.subject_areas.second.subjects[3].checkbox.click
         filter_page.subject_areas.second.subjects[5].checkbox.click
         filter_page.subject_areas.second.subjects[6].checkbox.click
-
         filter_page.continue.click
+      end
 
+      it 'lists the results' do
         expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
         expect(results_page.subjects_filter.subjects.first.text).to eq(
           'Chemistry, Classics, Communication and media studies, Primary, Primary with English',
+        )
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'false',
+            'parttime' => 'false',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'subjects' => %w[31 32 3 5 47],
+          },
         )
       end
     end
@@ -58,22 +68,34 @@ RSpec.feature 'Results page new subject filter' do
         'filter[send_courses]' => 'true',
       )
       stub_courses(query: query, course_count: 10)
-    end
 
-    it 'lists the results' do
       results_page.load
       results_page.subjects_filter.link.click
-
-      expect(filter_page.heading.text).to eq(I18n.t('page_titles.subjects_filter'))
       filter_page.subject_areas.first.subjects[0].checkbox.click
       filter_page.subject_areas.first.subjects[1].checkbox.click
       filter_page.subject_areas.second.subjects[3].checkbox.click
       filter_page.send_area.subjects.first.checkbox.click
       filter_page.continue.click
+    end
 
+    it 'lists the results' do
       expect(results_page.heading.text).to eq('Teacher training courses 10 courses found')
       expect(results_page.subjects_filter.subjects.map.first.text).to eq('Chemistry, Primary, Primary with English')
       expect(results_page.send_filter.checkbox.checked?).to be(true)
+    end
+
+    it 'retains the query parameters' do
+      expect_page_to_be_displayed_with_query(
+        page: results_page,
+        expected_query_params: {
+          'fulltime' => 'false',
+          'parttime' => 'false',
+          'hasvacancies' => 'true',
+          'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          'subjects' => %w[31 32 3],
+          'senCourses' => 'true',
+        },
+      )
     end
   end
 

--- a/spec/features/new_results_page_filters/subjects_spec.rb
+++ b/spec/features/new_results_page_filters/subjects_spec.rb
@@ -127,7 +127,7 @@ RSpec.feature 'Results page new subject filter' do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'false',
+          'hasvacancies' => 'true',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/new_results_page_filters/vacancies_spec.rb
+++ b/spec/features/new_results_page_filters/vacancies_spec.rb
@@ -19,7 +19,7 @@ RSpec.feature 'Results page new vacancies filter' do
       results_page.load
 
       expect(results_page.vacancies_filter.legend.text).to eq('Vacancies')
-      expect(results_page.vacancies_filter.checkbox.checked?).to be(false)
+      expect(results_page.vacancies_filter.checkbox.checked?).to be(true)
     end
   end
 

--- a/spec/features/new_results_page_filters/vacancies_spec.rb
+++ b/spec/features/new_results_page_filters/vacancies_spec.rb
@@ -32,17 +32,29 @@ RSpec.feature 'Results page new vacancies filter' do
         ),
         course_count: 10,
       )
+
+      results_page.load
+
+      results_page.vacancies_filter.checkbox.check
+      results_page.apply_filters_button.click
     end
 
     context 'show courses with vacancies only' do
       it 'list the filtered courses' do
-        results_page.load
-
-        results_page.vacancies_filter.checkbox.check
-        results_page.apply_filters_button.click
-
         expect(results_page.vacancies_filter.legend.text).to eq('Vacancies')
         expect(results_page.vacancies_filter.checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+          },
+        )
       end
     end
   end

--- a/spec/features/result_filters/funding_spec.rb
+++ b/spec/features/result_filters/funding_spec.rb
@@ -36,7 +36,7 @@ describe 'Funding filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'false',
+            'hasvacancies' => 'true',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/location_spec.rb
+++ b/spec/features/result_filters/location_spec.rb
@@ -174,7 +174,7 @@ describe 'Location filter', type: :feature do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'false',
+          'hasvacancies' => 'true',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/result_filters/qualifications_spec.rb
+++ b/spec/features/result_filters/qualifications_spec.rb
@@ -33,7 +33,7 @@ describe 'Qualifications filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'false',
+            'hasvacancies' => 'true',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/study_type_spec.rb
+++ b/spec/features/result_filters/study_type_spec.rb
@@ -53,7 +53,7 @@ describe 'Study type filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'false',
+            'hasvacancies' => 'true',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -176,7 +176,7 @@ describe 'Subject filter', type: :feature do
         page: results_page,
         expected_query_params: {
           'fulltime' => 'false',
-          'hasvacancies' => 'false',
+          'hasvacancies' => 'true',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
           'senCourses' => 'false',

--- a/spec/features/result_filters/vacancy_spec.rb
+++ b/spec/features/result_filters/vacancy_spec.rb
@@ -33,7 +33,7 @@ describe 'Vacancy filter', type: :feature do
           page: results_page,
           expected_query_params: {
             'fulltime' => 'false',
-            'hasvacancies' => 'false',
+            'hasvacancies' => 'true',
             'parttime' => 'false',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'false',
@@ -64,7 +64,7 @@ describe 'Vacancy filter', type: :feature do
     it 'lists only courses with vacancies' do
       results_page.load
 
-      expect(results_page.vacancies_filter.vacancies.text).to eq('Courses with and without vacancies')
+      expect(results_page.vacancies_filter.vacancies.text).to eq('Only courses with vacancies')
       expect(results_page.courses.count).to eq(10)
     end
   end
@@ -75,9 +75,18 @@ describe 'Vacancy filter', type: :feature do
     end
 
     context 'selecting courses with or without vacancies' do
+      let(:filter_parameters) do
+        {
+          'include' => 'site_statuses.site,provider,subjects',
+          'page[page]' => 1,
+          'page[per_page]' => 10,
+          'sort' => 'provider.provider_name,name',
+        }
+      end
+
       before do
         stub_courses(
-          query: base_parameters.merge('filter[has_vacancies]' => 'false'),
+          query: filter_parameters,
           course_count: 10,
         )
       end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -36,7 +36,7 @@ describe 'results', type: :feature do
 
     it 'has vacancies filter' do
       expect(results_page.vacancies_filter.subheading).to have_content('Vacancies:')
-      expect(results_page.vacancies_filter.vacancies).to have_content('Courses with and without vacancies')
+      expect(results_page.vacancies_filter.vacancies).to have_content('Only courses with vacancies')
       expect(results_page.vacancies_filter.link).to have_content('Change vacancies')
     end
 
@@ -49,7 +49,7 @@ describe 'results', type: :feature do
       expect(location_filter_uri.path).to eq('/results/filter/location')
       expect(Rack::Utils.parse_nested_query(location_filter_uri.query)).to eq({
         'fulltime' => 'false',
-        'hasvacancies' => 'false',
+        'hasvacancies' => 'true',
         'parttime' => 'false',
         'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
         'senCourses' => 'false',
@@ -75,7 +75,7 @@ describe 'results', type: :feature do
   end
 
   describe 'filters defaults with query string' do
-    let(:params) { { fulltime: 'false', parttime: 'false', hasvacancies: 'false' } }
+    let(:params) { { fulltime: 'false', parttime: 'false' } }
 
     it 'has study type filter' do
       expect(results_page.study_type_filter.subheading).to have_content('Study type:')
@@ -86,7 +86,7 @@ describe 'results', type: :feature do
 
     it 'has vacancies filter' do
       expect(results_page.vacancies_filter.subheading).to have_content('Vacancies:')
-      expect(results_page.vacancies_filter.vacancies).to have_content('Courses with and without vacancies')
+      expect(results_page.vacancies_filter.vacancies).to have_content('Only courses with vacancies')
       expect(results_page.vacancies_filter.link).to have_content('Change vacancies')
     end
 
@@ -211,7 +211,7 @@ describe 'results', type: :feature do
           qualifications: %w[QtsOnly PgdePgceWithQts Other],
           fulltime: 'false',
           parttime: 'false',
-          hasvacancies: 'false',
+          hasvacancies: 'true',
           senCourses: 'false',
         }
       end
@@ -221,7 +221,7 @@ describe 'results', type: :feature do
         expect(location_filter_uri.path).to eq('/results')
         expect(Rack::Utils.parse_nested_query(location_filter_uri.query)).to eq({
           'fulltime' => 'false',
-          'hasvacancies' => 'false',
+          'hasvacancies' => 'true',
           'l' => '2',
           'parttime' => 'false',
           'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
@@ -243,7 +243,7 @@ describe 'results', type: :feature do
         subjects: '1,2,3',
         fulltime: 'False',
         parttime: 'False',
-        hasvacancies: 'False',
+        hasvacancies: 'True',
         senCourses: 'False',
         funding: '15',
       }
@@ -257,7 +257,7 @@ describe 'results', type: :feature do
       expect(results_page.study_type_filter.parttime).to have_content('Part time (18 - 24 months)')
       expect(results_page.qualifications_filter).to have_content('All qualifications')
       expect(results_page.funding_filter).to have_with_or_without_salary
-      expect(results_page.vacancies_filter).to have_content('Courses with and without vacancies')
+      expect(results_page.vacancies_filter).to have_content('Only courses with vacancies')
     end
   end
 end

--- a/spec/support/geocoder_helper.rb
+++ b/spec/support/geocoder_helper.rb
@@ -30,6 +30,21 @@ def stub_geocoder
   )
 
   Geocoder::Lookup::Test.add_stub(
+    'Station Rise',
+    [
+      {
+        'coordinates' => [53.83365879999999, -1.0564076],
+        'address' => 'Station Rise, Ricall, York YO19 2C, UK',
+        'state' => 'England',
+        'state_code' => 'England',
+        'country' => 'United Kingdom',
+        'country_code' => 'UK',
+        'address_components' => [{ long_name: 'England' }],
+      },
+    ],
+  )
+
+  Geocoder::Lookup::Test.add_stub(
     'Unknown location',
     [],
   )

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -1,5 +1,6 @@
 def results_page_parameters(parameters = {})
   {
+    'filter[has_vacancies]' => 'true',
     'include' => 'site_statuses.site,provider,subjects',
     'page[page]' => 1,
     'page[per_page]' => 10,

--- a/spec/view_objects/result_filters/new_filters_view_spec.rb
+++ b/spec/view_objects/result_filters/new_filters_view_spec.rb
@@ -237,7 +237,7 @@ module ResultFilters
     end
 
     describe '#default_to_true' do
-      subject { described_class.new(params: params).default_to_true }
+      subject { described_class.new(params: params).default_study_types_to_true }
 
       context 'when parameters are not present' do
         let(:params) { {} }

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -11,7 +11,7 @@ describe ResultsView do
       'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
       'fulltime' => false,
       'parttime' => false,
-      'hasvacancies' => false,
+      'hasvacancies' => true,
       'senCourses' => false,
     }
   end
@@ -91,7 +91,17 @@ describe ResultsView do
   end
 
   describe 'filter_path_with_unescaped_commas' do
-    subject(:results_view) { described_class.new(query_parameters: default_output_parameters).filter_path_with_unescaped_commas('/test') }
+    let(:default_query_parameters) do
+      {
+        'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+        'fulltime' => 'false',
+        'parttime' => 'false',
+        'hasvacancies' => 'true',
+        'senCourses' => 'false',
+      }
+    end
+
+    subject(:results_view) { described_class.new(query_parameters: default_query_parameters).filter_path_with_unescaped_commas('/test') }
 
     it 'appends an unescaped querystring to the passed path' do
       allow(UnescapedQueryStringService).to receive(:call).with(


### PR DESCRIPTION
### Context

This PR addresses a couple of issues as they both related to query. 

The first is ensuring that we only show courses with vacancies by default.

The second is a bug fix that occurs when a candidate searches by location, but subsequently courses in the search results are not sorted by distance. This is because the new filters form was not adding all the location params as hidden fields.


### Changes proposed in this pull request
- Change the default behaviour of the search functionality to show courses with vacancies only. 
- Add missing parameters as missing fields and add test missing coverage.

### Guidance to review
- Review by commit
- Spin up the app and run any search. You should see results are automatically filtered by courses with vacancies. Any subsequent filtering by location should result in the expected behaviour - courses should be ordered by distance.

### Trello cards
- https://trello.com/c/4AHWjswy/3062-show-vacancies-by-default-on-find
- https://trello.com/c/nlpAebUf/3070-issue-with-the-find-search-results

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
