### PR TITLE
Fix filters when location is selected

### DIFF
--- a/app/views/new_filters/_hidden_fields.html.erb
+++ b/app/views/new_filters/_hidden_fields.html.erb
@@ -1,2 +1,4 @@
 <%= form.hidden_field(:l, value: request.params[:l]) %>
 <%= form.hidden_field(:lq, value: request.params[:lq]) %>
+<%= form.hidden_field(:lat, value: request.params[:lat]) %>
+<%= form.hidden_field(:lng, value: request.params[:lng]) %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,4 +22,4 @@ feature_flags:
   cycle_has_ended: false
   display_apply_button: true
   ucas_only_locations: false
-  new_filters: false
+  new_filters: true


### PR DESCRIPTION
### Context

We forgot to pass lat and long through as hidden fields when someone updates the filters on the results page. As a result of this, if a candidate tries to select additional filters and click apply, no courses are returned as we don't provide the backend with the necessary values for the search.

### Changes proposed in this pull request

- Pass lat/long through as hidden fields

### Guidance to review

I feel like we should be testing that we've got all the required fields before hitting the API.
Not 100% sure where it should live though. Maybe we could add a valid? method to the filter view?

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
