### PR TITLE
Add custom cops and fix resulting violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,11 @@ inherit_from:
 Govuk/GovukSubmit:
   Enabled: false
 
+Govuk/GovukLinkTo:
+  Exclude:
+    # link_to in footer
+    - 'app/views/layouts/application.html.erb'
+
 # The following cops were present before adding Apply cops above
 Rails/HasManyOrHasOneDependent:
  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 inherit_from:
   - https://raw.githubusercontent.com/DFE-Digital/apply-for-teacher-training/master/.rubocop.yml
 
+# Disabled because this project doesn’t use GOV.UK Design System Form Builder
+Govuk/GovukSubmit:
+  Enabled: false
+
 # The following cops were present before adding Apply cops above
 Rails/HasManyOrHasOneDependent:
  Enabled: false

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -18,6 +18,44 @@ module ViewHelper
     link_to(body, url, html_options)
   end
 
+  def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)
+    if block_given?
+      html_options = url
+      url = body
+      body = block
+    end
+    html_options ||= {}
+
+    html_options = {
+      class: prepend_css_class('govuk-button', html_options[:class]),
+      role: 'button',
+      data: { module: 'govuk-button' },
+      draggable: false,
+    }.merge(html_options)
+
+    return link_to(url, html_options) { yield } if block_given?
+
+    link_to(body, url, html_options)
+  end
+
+  def govuk_button_to(name, options = {}, html_options = {}, &_block)
+    if block_given?
+      html_options = options
+      options = name
+    end
+
+    html_options = {
+      class: prepend_css_class('govuk-button', html_options[:class]),
+      role: 'button',
+      data: { module: 'govuk-button' },
+      draggable: false,
+    }.merge(html_options)
+
+    return button_to(options, html_options) { yield } if block_given?
+
+    button_to(name, options, html_options)
+  end
+
   def govuk_back_link_to(url, link_text = 'Back')
     link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
   end

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For questions about this course you should contact the training provider using <%= link_to 'the contact details above', '#contact_section', class: 'govuk-link' %>.</p>
+  <p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to 'the contact details above', '#contact_section' %>.</p>
 
   <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
   <p class="govuk-body">You can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %> adviser for free. They’re all experienced teachers who can help you prepare your application, book school experience, and access exclusive teaching events.</p>

--- a/app/views/courses/_contact_details.html.erb
+++ b/app/views/courses/_contact_details.html.erb
@@ -20,7 +20,7 @@
       <% if course.provider.decorate.website.present? %>
         <dt class="app-description-list__label">Website</dt>
         <dd data-qa="provider__website">
-          <%= link_to course.provider.decorate.website, course.provider.decorate.website, class: 'govuk-link' %>
+          <%= govuk_link_to course.provider.decorate.website, course.provider.decorate.website %>
         </dd>
       <% end %>
 

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -13,15 +13,15 @@
 
   <p class="govuk-body">
   You don’t have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
-  Find out about <%= link_to 'eligibility', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships', class: 'govuk-link' %> and
-  <%= link_to 'how you’ll be paid', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary', class: 'govuk-link' %>.
+  Find out about <%= govuk_link_to 'eligibility', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %> and
+  <%= govuk_link_to 'how you’ll be paid', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
   </p>
 
   <p class="govuk-body">
-    You may be eligible for a <%= link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans', class: 'govuk-link' %> – note that you’ll have to apply for <%= link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance', class: 'govuk-link' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates', class: 'govuk-link' %>.
+    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %>.
   </p>
 </div>

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,8 +1,8 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans', class: 'govuk-link' %> – note that you’ll have to apply for <%= link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance', class: 'govuk-link' %>.
+    You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates', class: 'govuk-link' %>.
+    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %>.
   </p>
 </div>

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -10,7 +10,7 @@
 
   <% if course.has_early_career_payments? %>
     <p class="govuk-body" data-qa="course__early_career_payment_details">
-      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= link_to 'some areas of England', 'https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools', class: 'govuk-link' %>).
+      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= govuk_link_to 'some areas of England', 'https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools' %>).
     </p>
   <% end %>
 
@@ -23,14 +23,14 @@
   </p>
 
   <p class="govuk-body">
-  Find out how to <%= link_to 'apply for a scholarship', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships', class: 'govuk-link' %>. You don’t need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= link_to 'how you’ll be paid', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary', class: 'govuk-link' %>.
+  Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You don’t need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to 'how you’ll be paid', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
   </p>
 
   <p class="govuk-body">
-    You may also be eligible for a <%= link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans', class: 'govuk-link' %> – note that you’ll have to apply for <%= link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance', class: 'govuk-link' %>.
+    You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://beta-getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates', class: 'govuk-link' %>.
+    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://beta-getintoteaching.education.gov.uk/international-candidates' %>.
   </p>
 </div>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -3,7 +3,7 @@
     Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
   </p>
   <p class="govuk-body">
-    It may also allow you to teach in <%= link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>, though this could change after 2020.
+    It may also allow you to teach in <%= govuk_link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea' %>, though this could change after 2020.
   </p>
   <p class="govuk-body">
     If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -42,7 +42,7 @@
     <% if course.provider.decorate.website.present? %>
       <dt class="app-description-list__label">Website</dt>
       <dd data-qa="course__provider_website">
-        <%= link_to course.provider.decorate.website, course.provider.decorate.website, class: 'govuk-link' %>
+        <%= govuk_link_to course.provider.decorate.website, course.provider.decorate.website %>
       </dd>
     <% end %>
   </dl>
@@ -52,28 +52,28 @@
       <h2 class="govuk-heading-m">Contents</h2>
       <ul class="govuk-list app-list--dash course-contents govuk-!-margin-bottom-8">
         <% if course.about_course.present? %>
-          <li><%= link_to 'About the course', '#section-about', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to 'About the course', '#section-about' %></li>
         <% end %>
         <% if course.how_school_placements_work.present? %>
-          <li><%= link_to course.placements_heading, '#section-schools', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to course.placements_heading, '#section-schools' %></li>
         <% end %>
-        <li><%= link_to 'Entry requirements', '#section-entry', class: 'govuk-link' %></li>
+        <li><%= govuk_link_to 'Entry requirements', '#section-entry' %></li>
         <% if course.provider.train_with_us.present? ||  course.about_accrediting_body.present? %>
-          <li><%= link_to 'About the training provider', '#section-about-provider', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to 'About the training provider', '#section-about-provider' %></li>
         <% end %>
         <% if course.salaried? %>
-          <li><%= link_to 'Salary', '#section-salary', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to 'Salary', '#section-salary' %></li>
         <% end %>
-        <li><%= link_to 'Fees and financial support', '#section-financial-support', class: 'govuk-link' %></li>
+        <li><%= govuk_link_to 'Fees and financial support', '#section-financial-support' %></li>
         <% if course.interview_process.present? %>
-          <li><%= link_to 'Interview process', '#section-interviews', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to 'Interview process', '#section-interviews' %></li>
         <% end %>
         <% if course.provider.train_with_disability.present? %>
-          <li><%= link_to 'Training with disabilities and other needs', '#section-train-with-disabilities', class: 'govuk-link' %></li>
+          <li><%= govuk_link_to 'Training with disabilities and other needs', '#section-train-with-disabilities' %></li>
         <% end %>
-        <li><%= link_to 'Contact details', '#section-contact', class: 'govuk-link' %></li>
-        <li><%= link_to 'Support and advice', '#section-advice', class: 'govuk-link' %></li>
-        <li><%= link_to 'Apply', '#section-apply', class: 'govuk-link' %></li>
+        <li><%= govuk_link_to 'Contact details', '#section-contact' %></li>
+        <li><%= govuk_link_to 'Support and advice', '#section-advice' %></li>
+        <li><%= govuk_link_to 'Apply', '#section-apply' %></li>
       </ul>
 
       <% if course.about_course.present? %>

--- a/app/views/layouts/_cookie_banner.html.erb
+++ b/app/views/layouts/_cookie_banner.html.erb
@@ -1,8 +1,8 @@
 <div class="app-cookie-banner app-cookie-banner--hidden" data-module="app-cookie-banner" aria-label="Cookie banner" role="region" data-qa="cookie-banner">
   <div class="govuk-width-container">
     <p class="govuk-body">
-      We use cookies to <%= link_to('collect information', cookie_preferences_path,
-                                    { class: 'govuk-link app-cookie-banner__link',
+      We use cookies to <%= govuk_link_to('collect information', cookie_preferences_path,
+                                    { class: 'app-cookie-banner__link',
                                       data: { qa: 'cookie-banner__info-link' } }) %>
       about how you use this service.
     </p>
@@ -10,8 +10,8 @@
       <button type="button" class="govuk-button govuk-!-margin-bottom-2"
               data-qa="cookie-banner__accept">Accept all cookies</button>
       <span class="app-cookie-banner__line-message">
-        or <%= link_to('set your cookie preferences', cookie_preferences_path,
-                       { class: 'govuk-link app-cookie-banner__link',
+        or <%= govuk_link_to('set your cookie preferences', cookie_preferences_path,
+                       { class: 'app-cookie-banner__link',
                          data: { qa: 'cookie-banner__preference-link' } }) %>
       </span>
     </p>

--- a/app/views/result_filters/qualification/new.html.erb
+++ b/app/views/result_filters/qualification/new.html.erb
@@ -40,7 +40,7 @@
                   QTS (qualified teacher status) allows you to teach in state schools in England and may allow you to teach in other parts of the UK.
                 </p>
                 <p class="govuk-body">
-                  It may also allow you to teach in <%= link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>, though this could change after 2020. If you&rsquo;re planning to teach overseas, you should always check what’s needed in the country you&rsquo;d like to teach in.
+                  It may also allow you to teach in <%= govuk_link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea' %>, though this could change after 2020. If you&rsquo;re planning to teach overseas, you should always check what’s needed in the country you&rsquo;d like to teach in.
                 </p>
               <% end %>
             </div>
@@ -63,7 +63,7 @@
                   A PGCE (postgraduate certificate in education) is an academic qualification in education. PGCE with QTS allows you to teach in state schools in England and may allow you to teach in other parts of the UK.
                 </p>
                 <p class="govuk-body">
-                  It may also allow you to teach in <%= link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea', class: 'govuk-link' %>, though this could change after 2020. If you&rsquo;re planning to teach overseas, you should always check what&rsquo;s needed in the country you&rsquo;d like to teach in.
+                  It may also allow you to teach in <%= govuk_link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea' %>, though this could change after 2020. If you&rsquo;re planning to teach overseas, you should always check what&rsquo;s needed in the country you&rsquo;d like to teach in.
                 </p>
                 <p class="govuk-body">
                   Many PGCE courses include credits towards a Master&rsquo;s degree. Some providers offer a PGDE (postgraduate diploma in education) with QTS, which is equivalent to a PGCE. In some cases these offer more Master&rsquo;s credits than PGCE courses.

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -60,7 +60,7 @@
                           <% if subject.subject_knowledge_enhancement_course_available %>
                             <span class="govuk-!-display-block" data-qa="subject__ske_course">
                               You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
-                              <%= link_to 'subject knowledge enhancement (SKE) course', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses', class: 'govuk-link' %>.
+                              <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
                             </span>
                           <% end %>
                         <% end %>

--- a/app/views/results/_funding.html.erb
+++ b/app/views/results/_funding.html.erb
@@ -13,5 +13,5 @@
       </li>
     <% end %>
   </ul>
-  <%= link_to 'Change salary option', @results_view.filter_path_with_unescaped_commas(funding_path), class: 'govuk-link', data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change salary option', @results_view.filter_path_with_unescaped_commas(funding_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_location.html.erb
+++ b/app/views/results/_location.html.erb
@@ -16,8 +16,5 @@
       <% end %>
     </li>
   </ul>
-  <%= link_to 'Change location or choose a provider',
-             @results_view.filter_path_with_unescaped_commas(location_path),
-             class: 'govuk-link',
-             data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change location or choose a provider', @results_view.filter_path_with_unescaped_commas(location_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -5,15 +5,15 @@
 <% case country
    when "Scotland" %>
   <p class="govuk-body">
-    <%= govuk_link_to "Learn more about teacher training in Scotland", "https://teachinscotland.scot/" %>
+    <%= govuk_link_to 'Learn more about teacher training in Scotland', 'https://teachinscotland.scot/' %>
   </p>
-<% when "Wales"%>
+<% when "Wales" %>
   <p class="govuk-body">
-    <%= govuk_link_to "Learn more about teacher training in Wales", "https://www.discoverteaching.wales/routes-into-teaching/" %>
+    <%= govuk_link_to 'Learn more about teacher training in Wales', 'https://www.discoverteaching.wales/routes-into-teaching/' %>
   </p>
-<% when "Northern Ireland"%>
+<% when "Northern Ireland" %>
   <p class="govuk-body">
-    <%= govuk_link_to "Learn more about teacher training in Northern Ireland", "https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" %>
+    <%= govuk_link_to 'Learn more about teacher training in Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' %>
   </p>
 <% else %>
   <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>

--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -5,15 +5,15 @@
 <% case country
    when "Scotland" %>
   <p class="govuk-body">
-    <%= link_to "Learn more about teacher training in Scotland", "https://teachinscotland.scot/", class: "govuk-link" %>
+    <%= govuk_link_to "Learn more about teacher training in Scotland", "https://teachinscotland.scot/" %>
   </p>
 <% when "Wales"%>
   <p class="govuk-body">
-    <%= link_to "Learn more about teacher training in Wales", "https://www.discoverteaching.wales/routes-into-teaching/", class: "govuk-link" %>
+    <%= govuk_link_to "Learn more about teacher training in Wales", "https://www.discoverteaching.wales/routes-into-teaching/" %>
   </p>
 <% when "Northern Ireland"%>
   <p class="govuk-body">
-    <%= link_to "Learn more about teacher training in Northern Ireland", "https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland", class: "govuk-link" %>
+    <%= govuk_link_to "Learn more about teacher training in Northern Ireland", "https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland" %>
   </p>
 <% else %>
   <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>

--- a/app/views/results/_provider.html.erb
+++ b/app/views/results/_provider.html.erb
@@ -7,8 +7,5 @@
       <%= smart_quotes(@results_view.provider) %>
     </li>
   </ul>
-  <%= link_to 'Change provider or choose a location',
-             @results_view.filter_path_with_unescaped_commas(location_path),
-             class: 'govuk-link',
-             data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change provider or choose a location', @results_view.filter_path_with_unescaped_commas(location_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_qualifications.html.erb
+++ b/app/views/results/_qualifications.html.erb
@@ -17,5 +17,5 @@
       <% end %>
     <% end %>
   </ul>
-  <%= link_to 'Change qualifications', @results_view.filter_path_with_unescaped_commas(qualification_path), class: 'govuk-link', data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change qualifications', @results_view.filter_path_with_unescaped_commas(qualification_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_study_type.html.erb
+++ b/app/views/results/_study_type.html.erb
@@ -11,5 +11,5 @@
       <li data-qa="parttime">Part time (18 - 24 months)</li>
     <% end %>
     </ul>
-  <%= link_to 'Change study type', @results_view.filter_path_with_unescaped_commas(studytype_path), class: 'govuk-link', data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change study type', @results_view.filter_path_with_unescaped_commas(studytype_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_subjects.html.erb
+++ b/app/views/results/_subjects.html.erb
@@ -15,5 +15,5 @@
       <li data-qa="extra_subjects">and <%= @results_view.number_of_extra_subjects %> more...</li>
     <% end %>
   </ul>
-  <%= link_to 'Change subjects', @results_view.filter_path_with_unescaped_commas(subject_path), class: 'govuk-link', data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change subjects', @results_view.filter_path_with_unescaped_commas(subject_path), data: { qa: 'link' } %>
 </div>

--- a/app/views/results/_try_another_search_text.html.erb
+++ b/app/views/results/_try_another_search_text.html.erb
@@ -1,3 +1,3 @@
 <p class="govuk-body">
-  You can <%= link_to 'try another search', root_path, class: 'govuk-link' %>, for example by changing subject or location<% if @results_view.with_salaries? %> or searching for courses that do not offer a salary<% end %>.
+  You can <%= govuk_link_to 'try another search', root_path %>, for example by changing subject or location<% if @results_view.with_salaries? %> or searching for courses that do not offer a salary<% end %>.
 </p>

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -12,7 +12,7 @@
         ) do %>
           <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
           <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
-          <%= link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools'), class: 'govuk-link' %>
+          <%= govuk_link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools') %>
         <% end %>
         You’ll be placed in schools for most of your course
         <span class="app-description-list__hint govuk-!-padding-top-2">University</span>

--- a/app/views/results/_vacancy.html.erb
+++ b/app/views/results/_vacancy.html.erb
@@ -11,5 +11,5 @@
       <% end %>
     </li>
   </ul>
-  <%= link_to 'Change vacancies', @results_view.filter_path_with_unescaped_commas(vacancy_path), class: 'govuk-link', data: { qa: 'link' } %>
+  <%= govuk_link_to 'Change vacancies', @results_view.filter_path_with_unescaped_commas(vacancy_path), data: { qa: 'link' } %>
 </div>

--- a/lib/rubocop/cop/govuk/govuk_button_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_button_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukButtonTo < Base
+        def on_send(node)
+          return unless node.method_name == :button_to
+
+          add_offense(node, message: 'Use govuk_button_to instead of button_to')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukLinkTo < Base
+        def on_send(node)
+          return unless node.method_name == :link_to
+
+          add_offense(node, message: 'Use govuk_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/govuk/govuk_submit.rb
+++ b/lib/rubocop/cop/govuk/govuk_submit.rb
@@ -1,0 +1,13 @@
+module RuboCop
+  module Cop
+    module Govuk
+      class GovukSubmit < Base
+        def on_send(node)
+          return unless node.method_name == :submit
+
+          add_offense(node, message: 'Use govuk_submit instead of submit')
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'simplecov'
 SimpleCov.minimum_coverage 95
 SimpleCov.start 'rails' do
   add_filter 'spec'
+  add_filter 'lib/rubocop'
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Context

Follows on from #669.

### Changes proposed in this pull request

As Find’s Rubocop inherits from Apply’s config, and now that Apply has added 3 new custom cops to check for various `govuk_` helpers, we need to:

* Add the same custom cops to this project
* Fix the resulting violations
* Disable checks for use of `govuk_submit` (this project doesn’t use the form builder gem)
* Exclude checks for use of `govuk_link_to` in the application layout (footer links don’t use the `govuk-link` class)

### Guidance to review

For completeness, and given errors will be raised if they are not used, I have also added the following helpers, even though they are currently not used by this project:

* `govuk_button_link_to`
* `govuk_button_to`

Are we fine with this?

### Trello card

https://trello.com/c/Za2awSWs/

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
