### PR TITLE
Update headings for no result states

### DIFF
--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -1,5 +1,5 @@
 <% if devolved_nation %>
-  <h2 class="govuk-heading-l">This service is for courses in England</h2>
+  <h2 class="govuk-heading-m">This service is for courses in England</h2>
 <% end %>
 
 <% case country

--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -16,6 +16,5 @@
     <%= govuk_link_to 'Learn more about teacher training in Northern Ireland', 'https://www.education-ni.gov.uk/articles/initial-teacher-education-courses-northern-ireland' %>
   </p>
 <% else %>
-  <h2 class="govuk-heading-l">There are no courses matching your&nbsp;search</h2>
   <%= render partial: 'try_another_search_text' %>
 <% end %>

--- a/spec/views/results/no_results_spec.rb
+++ b/spec/views/results/no_results_spec.rb
@@ -41,7 +41,7 @@ describe 'results/no_results.html.erb', type: :view do
 
     it 'renders try another search text' do
       assign(:results_view, ResultsView.new(query_parameters: { 'c' => 'England', 'lat' => '51.4975', 'lng' => '0.1357' }))
-      expect(html).to match('There are no courses matching your&nbsp;search')
+      expect(html).to have_link('try another search', href: '/')
     end
   end
 end


### PR DESCRIPTION
### Context

Few tweaks to ensure app matches design

### Changes proposed in this pull request

* Use medium heading size for heading shown for devolved nation result
* Remove extraneous heading for no results (message already shown in page title)

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
