### PR TITLE
Attempt to fix provider autocomplete

### DIFF
--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -52,6 +52,7 @@ initAutocomplete({
   element: "provider-autocomplete",
   input: "provider",
   path: "/provider-suggestions",
+  selectNameAndCode: true,
 });
 
 loadAnalytics();

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -32,7 +32,7 @@ export const request = endpoint => {
   };
 };
 
-const initAutocomplete = ({element, input, path}) => {
+const initAutocomplete = ({element, input, path, selectNameAndCode}) => {
   const $input = document.getElementById(input);
   const $el = document.getElementById(element);
   const inputValueTemplate = result => (typeof result === "string" ? result : result && result.name);
@@ -50,7 +50,7 @@ const initAutocomplete = ({element, input, path}) => {
         minLength: 3,
         source: throttle(request(path), 500),
         templates: {
-          inputValue: inputValueTemplate,
+          inputValue: selectNameAndCode ? suggestionTemplate : inputValueTemplate,
           suggestion: suggestionTemplate
         },
         onConfirm: option => ($input.value = option ? option.code : ""),


### PR DESCRIPTION
### Context

When a user searches for a provider on the initial search page on Find, when they select a provider they are taken to a page where it shows all the providers which contain the search term they were using. e.g. with search term _Oxford University_.

This is happening because of the way the autocomplete works in concert with the ResultFilters::ProviderController. The values displayed in the 'dropdown' are a combination of the provider name and code but only the name is used to populate the text field that is posted to the controller. The controller then uses the name to search for matches, only when there is one exact match do you get the expected behaviour. In the case of Oxford University the name matches two providers (returned by the TTAPI) hence you don't go straight to the courses for the provider that you selected in the autocomplete.

### Changes proposed in this pull request

Use the same template for input and suggestion in provider autocomplete. This leads to the code as well as the name being searched for using the TTAPI which should return a unique match (whereas the name alone can return multiple matches).

### Guidance to review

- Does this make sense?
- How can we test this? We need to verify that the search is not too selective to match the selected provider (i.e. the TTAPI returns 0 matches).

### Trello card

https://trello.com/c/FDqiUFeo/3078-bug-provider-autocomplete-not-working-as-expected-on-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
