### PR TITLE
Wire up provider autocomplete on 'pick a provider' page

### DIFF
--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -28,7 +28,12 @@
                 <strong>School, university or other training provider</strong>
                 <span class="govuk-hint govuk-!-margin-bottom-0">Enter the name or provider code</span>
               <% end %>
-              <%= form.text_field :query, class: 'govuk-input' %>
+              <%= form.text_field(
+                :query,
+                id: 'provider',
+                class: 'govuk-input',
+              ) %>
+              <div id="provider-autocomplete" class="govuk-body"></div>
             </div>
 
             <%= form.submit 'Search again', name: nil, class: 'govuk-button' %>


### PR DESCRIPTION
### Context

The provider autocomplete is not wired up on the Visit the _try another provider_ page.

### Changes proposed in this pull request

Wire up the provider autocomplete using the same markup as elsewhere in the application.

<img width="716" alt="image" src="https://user-images.githubusercontent.com/450843/108997815-fb1c3080-7697-11eb-86d7-7c91db008284.png">

### Guidance to review

- How should we test this? It's not covered by the JS tests and we don't have JS enabled feature specs?
- Note that the fix applied to the other provider autocomplete in https://github.com/DFE-Digital/find-teacher-training/pull/679 will also apply to this one.

### Trello card

https://trello.com/c/04BwX3x4/2004-find-provider-autocomplete-not-wired-up

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
