### PR TITLE
Remove schools placement guidance

### DIFF
--- a/app/views/courses/placement/_scitt.html.erb
+++ b/app/views/courses/placement/_scitt.html.erb
@@ -1,2 +1,1 @@
-<p class="govuk-body">This course has placement schools in <%= course.travel_to_work_areas %>. Most of your time will be spent in the classroom with experienced teachers.</p>
 <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -149,10 +149,6 @@ describe 'Course show', type: :feature do
         course.how_school_placements_work,
       )
 
-      expect(course_page.school_placements).to have_content(
-        'This course has placement schools in Leeds',
-      )
-
       expect(course_page.uk_fees).to have_content(
         '£9,250',
       )


### PR DESCRIPTION
### Context
We've received some concerns from providers about the new schools placement guidance on the course show page

### Changes proposed in this pull request
- Offending paragraph removed whilst further user testing is undertaken

### Trello card
https://trello.com/c/lpBrddjm/3080-remove-school-placement-guidance-from-find-and-publish

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
