### PR TITLE
TTAPI PaaS for testing

### DIFF
--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,5 +1,5 @@
 base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 teacher_training_api:
-  base_url: https://api.publish-teacher-training-courses.service.gov.uk
+  base_url: https://teacher-training-api-prod.london.cloudapps.digital
 valid_referers:
   - https://staging.find-postgraduate-teacher-training.education.gov.uk


### PR DESCRIPTION
Test connection from Find to TTAPI on PaaS before migrating TTAPI over to PaaS

### Changes proposed in this pull request

Point staging to https://teacher-training-api-prod.london.cloudapps.digital (TTAPI Paas Prod) for testing.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
