### PR TITLE
Update contact section

### DIFF
--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -2,9 +2,13 @@
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
   <p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to 'the contact details above', '#contact_section' %>.</p>
 
-  <h4 class="govuk-heading-m">Get support and advice about teaching</h4>
-  <p class="govuk-body">You can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %> adviser for free. They’re all experienced teachers who can help you prepare your application, book school experience, and access exclusive teaching events.</p>
-  <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %> <%= t('get_into_teaching.opening_times') %>.</p>
+  <h4 class="govuk-heading-m">For advice about teaching</h4>
+  <p class="govuk-body">Register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>,
+    the Department for Education’s free support and advice service, for personalised guidance from teaching experts.
+    They can help you to prepare your application, book school experience, and access exclusive teaching events. You
+    can also call them free of charge on 0800 389 2500, or speak to an adviser using their
+    <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>, from <%= t('get_into_teaching.opening_times') %>.</p>
+
 
   <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
   <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to 'contact us by email', subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -6,7 +6,7 @@
   <p class="govuk-body">Register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>,
     the Department for Education’s free support and advice service, for personalised guidance from teaching experts.
     They can help you to prepare your application, book school experience, and access exclusive teaching events. You
-    can also call them free of charge on 0800 389 2500, or speak to an adviser using their
+    can also call them free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their
     <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>, from <%= t('get_into_teaching.opening_times') %>.</p>
 
 

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to 'the contact details above', '#contact_section' %>.</p>
+  <p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to 'the contact details above', '#section-contact' %>.</p>
 
   <h4 class="govuk-heading-m">For advice about teaching</h4>
   <p class="govuk-body">Register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>,

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,14 +1,11 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to 'the contact details above', '#section-contact' %>.</p>
-
-  <h4 class="govuk-heading-m">For advice about teaching</h4>
-  <p class="govuk-body">Register with <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>,
-    the Department for Education’s free support and advice service, for personalised guidance from teaching experts.
-    They can help you to prepare your application, book school experience, and access exclusive teaching events. You
-    can also call them free of charge on <%= t('get_into_teaching.tel') %>, or speak to an adviser using their
-    <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>, from <%= t('get_into_teaching.opening_times') %>.</p>
-
+  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>
+    adviser for free. They’re all experienced teachers who can help you to prepare your application, book school
+    experience, and access exclusive teaching events.</p>
+  <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or
+    speak to an adviser using their  <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>
+    <%= t('get_into_teaching.opening_times') %> (except public holidays).</p>
 
   <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
   <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to 'contact us by email', subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/courses/_contact_details.html.erb
+++ b/app/views/courses/_contact_details.html.erb
@@ -1,5 +1,5 @@
 <div id="contact_section" class="govuk-!-margin-bottom-8">
-  <h2 class="govuk-heading-l" id="section-contact">Contact details</h2>
+  <h2 class="govuk-heading-l" id="section-contact">Contact this training provider</h2>
 
   <div class="course-basicinfo">
     <dl class="app-description-list">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -71,7 +71,7 @@
         <% if course.provider.train_with_disability.present? %>
           <li><%= govuk_link_to 'Training with disabilities and other needs', '#section-train-with-disabilities' %></li>
         <% end %>
-        <li><%= govuk_link_to 'Contact details', '#section-contact' %></li>
+        <li><%= govuk_link_to 'Contact this training provider', '#section-contact' %></li>
         <li><%= govuk_link_to 'Support and advice', '#section-advice' %></li>
         <li><%= govuk_link_to 'Apply', '#section-apply' %></li>
       </ul>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
   get_into_teaching:
     # TODO: Update to 0800 389 2500 when GIT leaves beta
     tel: 0800 389 2501
-    opening_times: "8.30am to 5pm, Monday to Friday"
+    opening_times: "Monday to Friday, 8.30am to 5pm"
     # TODO: Update domain names when GIT leaves beta
     url_get_an_advisor: https://beta-adviser-getintoteaching.education.gov.uk
     url_online_chat: https://beta-getintoteaching.education.gov.uk/#talk-to-us

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
   get_into_teaching:
     # TODO: Update to 0800 389 2500 when GIT leaves beta
     tel: 0800 389 2501
-    opening_times: "Monday to Friday, 8.30am to 5pm (except public\u00A0holidays)"
+    opening_times: "8am to 8pm, Monday to Friday"
     # TODO: Update domain names when GIT leaves beta
     url_get_an_advisor: https://beta-adviser-getintoteaching.education.gov.uk
     url_online_chat: https://beta-getintoteaching.education.gov.uk/#talk-to-us

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -74,7 +74,7 @@ en:
   get_into_teaching:
     # TODO: Update to 0800 389 2500 when GIT leaves beta
     tel: 0800 389 2501
-    opening_times: "8am to 8pm, Monday to Friday"
+    opening_times: "8.30am to 5pm, Monday to Friday"
     # TODO: Update domain names when GIT leaves beta
     url_get_an_advisor: https://beta-adviser-getintoteaching.education.gov.uk
     url_online_chat: https://beta-getintoteaching.education.gov.uk/#talk-to-us


### PR DESCRIPTION
### Context

Update the contact details section to be inline with other copy changes.

### Changes proposed in this pull request

- changed "Contact details" to "Contact this training provider"
- updated opening hours from "8am to 8pm" to "8.30am to 5pm"
- changed the opening hours string from "Monday to Friday, 8.30am to 5pm (except public holidays)" to "8am to 8pm, Monday to Friday"
- updated the copy in the "advice about teaching section"
- updated the details in the footer of the page

#### Before

![image](https://user-images.githubusercontent.com/33458055/109954246-0515e300-7cd9-11eb-9701-7d95107b684f.png)
![image](https://user-images.githubusercontent.com/33458055/109954722-96855500-7cd9-11eb-8058-9c7fe1ee7a0a.png)


#### After

![image](https://user-images.githubusercontent.com/33458055/109954145-e0217000-7cd8-11eb-9924-db8ce1d4ec84.png)
![image](https://user-images.githubusercontent.com/33458055/109982220-972de380-7cf9-11eb-8481-f9e2ac435bc4.png)


### Guidance to review

### Trello card

https://trello.com/c/67mWQbAv/3057-changing-contact-details-section-on-provider-page-in-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
