### PR TITLE
Attempt to use Accordion component for subject selection

### DIFF
--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -14,7 +14,7 @@ module ResultFilters
     def subject_area_is_selected?(subject_area:)
       return false if params['subjects'].nil?
 
-      (params['subjects'] & subject_area.subjects.map(&:id)).any?
+      (params['subjects'] & subject_area.subjects.map(&:subject_code)).any?
     end
 
     def no_subject_selected_error?

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -7,17 +7,14 @@
     <%= form_with(url: subject_path, method: :post, data: { 'ga-event-form' => 'Subject' }) do |f| %>
       <%= render 'shared/hidden_fields', exclude_keys: %w[subjects senCourses], form: f %>
       <h1 class="govuk-heading-l" data-qa="heading"><%= I18n.t('page_titles.subjects_filter') %></h1>
-      <div class="accordion govuk-form-group" data-module="govuk-accordion">
+
+      <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
         <% @subject_areas.each_with_index do |subject_area, counter| %>
-          <div class="govuk-accordion__section<%= if subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?) then ' govuk-accordion__section--expanded' end %>" data-qa="subject_area">
-            <div class="govuk-accordion__section-header">
-              <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-                <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-<%= subject_area.typename %>" aria-controls="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-button" aria-expanded="<%= subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?) ? 'true' : 'false' %>">
-                  <%= subject_area.name %>
-                </button>
-              </h2>
-              <span class="govuk-accordion__icon" aria-hidden="true"></span>
-            </div>
+          <%= accordion.add_section(
+            title: subject_area.name,
+            expanded: subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?),
+            html_attributes: { 'data-qa': 'subject_area' },
+          ) do %>
             <div id="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
               <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-visually-hidden" data-qa="subject_area__legend">
@@ -70,32 +67,26 @@
                 </div>
               </fieldset>
             </div>
-          </div>
+          <% end %>
         <% end %>
-        <div class="govuk-accordion__section<%= if params[:senCourses] == 'true' then ' govuk-accordion__section--expanded' end %>" data-qa="send_area">
-          <div class="govuk-accordion__section-header">
-            <h2 class="govuk-accordion__section-heading" data-qa="subject_area__name">
-              <button type="button" data-qa="subject_area__accordion_button" id="accordion-heading-send" aria-controls="send-content" class="govuk-accordion__section-button" aria-expanded="<%= params[:senCourses] == 'true' ? 'true' : 'false' %>">
-                Special educational needs and disability (SEND)
-              </button>
-            </h2>
-            <span class="govuk-accordion__icon" aria-hidden="true"></span>
-          </div>
-          <div id="send-content" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-send">
-            <div class="govuk-checkboxes">
-              <div class="govuk-checkboxes__item" data-qa="subject">
-                <%= f.check_box(:senCourses, { checked: params[:senCourses] == 'true', data: { qa: 'subject__checkbox' }, id: 'subject_send', class: 'govuk-checkboxes__input' }, 'true', nil) %>
-                <%= f.label(:subjects, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
-                  <span class="govuk-checkboxes__label-text">
-                    Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
-                  </span>
-                  <span class="govuk-!-display-block"></span>
-                <% end %>
-              </div>
+        <%= accordion.add_section(
+          title: 'Special educational needs and disability (SEND)',
+          expanded: params[:senCourses] == 'true',
+          html_attributes: { 'data-qa': 'send_area' },
+        ) do %>
+          <div class="govuk-checkboxes" id="send-content">
+            <div class="govuk-checkboxes__item" data-qa="subject">
+              <%= f.check_box(:senCourses, { checked: params[:senCourses] == 'true', data: { qa: 'subject__checkbox' }, id: 'subject_send', class: 'govuk-checkboxes__input' }, 'true', nil) %>
+              <%= f.label(:subjects, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
+                <span class="govuk-checkboxes__label-text">
+                  Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
+                </span>
+                <span class="govuk-!-display-block"></span>
+              <% end %>
             </div>
           </div>
-        </div>
-      </div>
+        <% end %>
+      <% end %>
 
       <%= f.submit(local_assigns[:submit_button_text], name: nil, data: { qa: 'continue' }, class: 'govuk-button') %>
     <% end %>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -15,58 +15,56 @@
             expanded: subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?),
             html_attributes: { 'data-qa': 'subject_area' },
           ) do %>
-            <div id="<%= subject_area.typename.downcase %>-content-<%= counter %>" class="govuk-accordion__section-content" aria-labelledby="accordion-heading-<%= subject_area.typename.downcase %>">
-              <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-visually-hidden" data-qa="subject_area__legend">
-                  Choose from the following <%= subject_area.name %> subjects
-                </legend>
-                <% if subject_area.name == 'Primary' %>
-                  <p class="govuk-body">Trainee primary school teachers learn to teach all subjects across the national curriculum.</p>
-                  <p class="govuk-body">You can choose to add a specialist subject to your training. This could be a subject you have qualifications or experience in.</p>
-                  <p class="govuk-body">Your training will develop your knowledge of your specialist subject. This is so you can support other teachers to teach that subject.</p>
-                <% end %>
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-visually-hidden" data-qa="subject_area__legend">
+                Choose from the following <%= subject_area.name %> subjects
+              </legend>
+              <% if subject_area.name == 'Primary' %>
+                <p class="govuk-body">Trainee primary school teachers learn to teach all subjects across the national curriculum.</p>
+                <p class="govuk-body">You can choose to add a specialist subject to your training. This could be a subject you have qualifications or experience in.</p>
+                <p class="govuk-body">Your training will develop your knowledge of your specialist subject. This is so you can support other teachers to teach that subject.</p>
+              <% end %>
 
-                <div class="govuk-checkboxes">
-                  <% subject_area.subjects.sort_by(&:subject_name).each do |subject| %>
-                    <%# C# doesn't have a distinct modern languages subject %>
-                    <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
-                      <div class="govuk-checkboxes__item" data-qa="subject">
-                        <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
-                        <%= f.label(:subjects, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
-                          <span class="govuk-checkboxes__label-text" data-qa="subject__name">
-                            <%= subject.subject_name %>
-                            <% if subject.subject_name == "Design and technology" %>
-                              – also includes food, product design, textiles, and systems and control
-                            <% end %>
-                          </span>
+              <div class="govuk-checkboxes">
+                <% subject_area.subjects.sort_by(&:subject_name).each do |subject| %>
+                  <%# C# doesn't have a distinct modern languages subject %>
+                  <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
+                    <div class="govuk-checkboxes__item" data-qa="subject">
+                      <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
+                      <%= f.label(:subjects, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
+                        <span class="govuk-checkboxes__label-text" data-qa="subject__name">
+                          <%= subject.subject_name %>
+                          <% if subject.subject_name == "Design and technology" %>
+                            – also includes food, product design, textiles, and systems and control
+                          <% end %>
+                        </span>
 
-                          <% if subject.decorate.has_scholarship_and_bursary? %>
-                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} are available" %>
-                          <% elsif subject.decorate.has_scholarship? %>
-                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} are available" %>
-                          <% elsif subject.decorate.has_bursary? %>
-                            <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} available" %>
-                          <% end %>
-                          <% if subject.decorate.early_career_payments? %>
-                            <% financial_info.concat(', \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).') %>
-                          <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
-                            <% financial_info.concat('.') %>
-                          <% end %>
-                          <span class="govuk-hint govuk-!-margin-bottom-0" data-qa="subject__info"><%= financial_info %></span>
-
-                          <% if subject.subject_knowledge_enhancement_course_available %>
-                            <span class="govuk-!-display-block" data-qa="subject__ske_course">
-                              You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
-                              <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
-                            </span>
-                          <% end %>
+                        <% if subject.decorate.has_scholarship_and_bursary? %>
+                          <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} are available" %>
+                        <% elsif subject.decorate.has_scholarship? %>
+                          <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} are available" %>
+                        <% elsif subject.decorate.has_bursary? %>
+                          <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} available" %>
                         <% end %>
-                      </div>
-                    <% end %>
+                        <% if subject.decorate.early_career_payments? %>
+                          <% financial_info.concat(', \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).') %>
+                        <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
+                          <% financial_info.concat('.') %>
+                        <% end %>
+                        <span class="govuk-hint govuk-!-margin-bottom-0" data-qa="subject__info"><%= financial_info %></span>
+
+                        <% if subject.subject_knowledge_enhancement_course_available %>
+                          <span class="govuk-!-display-block" data-qa="subject__ske_course">
+                            You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
+                            <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://beta-getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
+                          </span>
+                        <% end %>
+                      <% end %>
+                    </div>
                   <% end %>
-                </div>
-              </fieldset>
-            </div>
+                <% end %>
+              </div>
+            </fieldset>
           <% end %>
         <% end %>
         <%= accordion.add_section(

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -162,10 +162,10 @@ RSpec.feature 'Results page new subject filter' do
 
     it 'has aria-control set to the section-content id' do
       expected_control_ids = %w[
-        primarysubject-content-0
-        secondarysubject-content-1
-        modernlanguagessubject-content-2
-        furthereducationsubject-content-3
+        primary-content
+        secondary-content
+        secondary-modern-languages-content
+        further-education-content
       ]
 
       filter_page.subject_areas.each_with_index do |accordion_section, counter|

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -169,13 +169,10 @@ RSpec.feature 'Results page new subject filter' do
       ]
 
       filter_page.subject_areas.each_with_index do |accordion_section, counter|
-        section_button = accordion_section.find('.govuk-accordion__section-button')
-        expect(section_button['aria-controls']).to eq(expected_control_ids[counter])
         expect(accordion_section.root_element).to have_selector("##{expected_control_ids[counter]}")
       end
 
       # Check SEND section
-      expect(filter_page.send_area.accordion_button['aria-controls']).to eq('send-content')
       expect(filter_page.send_area.root_element).to have_selector('div#send-content')
     end
 

--- a/spec/site_prism/page_objects/page/result_filters/subject_page.rb
+++ b/spec/site_prism/page_objects/page/result_filters/subject_page.rb
@@ -13,8 +13,8 @@ module PageObjects
           end
 
           element :legend, '[data-qa="subject_area__legend"]'
-          element :name, '[data-qa="subject_area__name"]'
-          element :accordion_button, '[data-qa="subject_area__accordion_button"]'
+          element :name, '.govuk-accordion__section-heading'
+          element :accordion_button, '.govuk-accordion__section-button'
           sections :subjects, Subject, '[data-qa="subject"]'
         end
 


### PR DESCRIPTION
### Context

We have been using `govuk-components` to simplify (and standardise) some of the markup (see https://github.com/DFE-Digital/find-teacher-training/pull/610). Originally we were unable to use the `Accordion` component because it didn't have an `expanded` option. Now that's been added (see https://github.com/DFE-Digital/govuk-components/pull/115) we can used it.

### Changes proposed in this pull request
- [x] Replace markup for subject selection Accordion with component.

### Guidance to review

- There should be no visible changes.
- Had to change the `subject_area_is_selected?` helper - I'm not sure how this worked with the old markup either because it was comparing ids with subject codes.
- Also lost a few `data-qa` attributes (because they are not part of the govuk-components markup). This required a few tweaks to the SitePrism page selectors - these are now using a selector based on an existing CSS class rather than a
`data-qa` attribute.

### Trello card
https://trello.com/c/0fMYPksT/2862-dev-use-govuk-view-components-in-find-to-replace-accordion-markup

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
