### PR TITLE
Implement a 24 hour cache for sitemap requests

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,10 +1,18 @@
 class SitemapsController < ApplicationController
   def show
-    @courses = Course
-      .where(recruitment_cycle_year: Settings.current_cycle)
-      .select('course_code', 'provider_code', 'changed_at')
-      .page(1)
-      .per(20_000)
-      .all
+    @courses = fetch_courses
+  end
+
+private
+
+  def fetch_courses
+    Rails.cache.fetch ['sitemap-api-request'], expires_in: 1.day do
+      Course
+        .where(recruitment_cycle_year: Settings.current_cycle)
+        .select('course_code', 'provider_code', 'changed_at')
+        .page(1)
+        .per(20_000)
+        .all
+    end
   end
 end


### PR DESCRIPTION
### Context
Currently Find makes a very expensive call to the API whenever the sitemap is generated - see https://github.com/DFE-Digital/find-teacher-training/blob/master/app/controllers/sitemaps_controller.rb#L1

When the production Teacher Training API was recently migrated over to PAAS this caused outages (502) whenever a call to the sitemap was made on Find.

### Changes proposed in this pull request
- Add a 24 hour cache for sitemap requests

### Trello card
https://trello.com/c/sijB88eS/3129-cache-find-sitemap

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
