### PR TITLE
Set Cache-Control header in SitemapsController

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,18 +1,12 @@
 class SitemapsController < ApplicationController
   def show
-    @courses = fetch_courses
-  end
+    @courses = Course
+      .where(recruitment_cycle_year: Settings.current_cycle)
+      .select('course_code', 'provider_code', 'changed_at')
+      .page(1)
+      .per(20_000)
+      .all
 
-private
-
-  def fetch_courses
-    Rails.cache.fetch ['sitemap-api-request'], expires_in: 1.day do
-      Course
-        .where(recruitment_cycle_year: Settings.current_cycle)
-        .select('course_code', 'provider_code', 'changed_at')
-        .page(1)
-        .per(20_000)
-        .all
-    end
+    expires_in(1.day, public: true)
   end
 end


### PR DESCRIPTION
### Context
Currently Find makes a very expensive call to the API whenever the sitemap is generated - see https://github.com/DFE-Digital/find-teacher-training/blob/master/app/controllers/sitemaps_controller.rb#L1

### Changes proposed in this pull request
- Previously we were caching the API response used to generate the sitemap, however this can be quite inefficient as we may have up to 4 instances of Find running at one time.
- Instead we now cache the sitemap itself by setting the Cache-Control header, which will be respected by CloudFront

### Trello card
https://trello.com/c/sijB88eS/3129-cache-find-sitemap

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
