### PR TITLE
Show ‘Advice from Get Into Teaching’ for headings on structured content

### DIFF
--- a/app/components/advice_component.html.erb
+++ b/app/components/advice_component.html.erb
@@ -1,5 +1,8 @@
 <aside class="app-advice">
-  <h3 class="app-advice__title"><%= title %></h3>
+  <h3 class="app-advice__title">
+    <span class="app-advice__caption">Advice from <%= t('service_name.get_into_teaching') %></span>
+    <%= title %>
+  </h3>
   <div class="app-advice__body">
     <%= content %>
   </div>

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,13 +1,13 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
-      <%= render AdviceComponent.new(title: 'Where you will train') do %>
-        <% if course.provider_type == 'university' %>
-          <%= render partial: 'courses/placement/hei', locals: { course: course } %>
-        <% else %>
-          <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
-        <% end %>
+    <%= render AdviceComponent.new(title: 'Where you will train') do %>
+      <% if course.provider_type == 'university' %>
+        <%= render partial: 'courses/placement/hei', locals: { course: course } %>
+      <% else %>
+        <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
       <% end %>
+    <% end %>
     <%= markdown(course.how_school_placements_work) %>
   </div>
 </div>

--- a/app/views/courses/_fees_and_financial_support.html.erb
+++ b/app/views/courses/_fees_and_financial_support.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-l" id="section-financial-support">Fees and financial support</h2>
 
   <%= render AdviceComponent.new(title: 'Financial support') do %>
-      <% if course.salaried? %>
+    <% if course.salaried? %>
       <%= render partial: 'courses/financial_support/salaried' %>
     <% elsif course.excluded_from_bursary? %>
       <%= render partial: 'courses/financial_support/loan', locals: { course: course } %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -9,6 +9,8 @@
 $govuk-font-url-function: frontend-font-url;
 $govuk-image-url-function: frontend-image-url;
 
+$git-brand-colour: #159964;
+
 @import "~govuk-frontend/govuk/all";
 
 @import "components/accordion";

--- a/app/webpacker/styles/components/_advice.scss
+++ b/app/webpacker/styles/components/_advice.scss
@@ -1,9 +1,15 @@
 .app-advice {
   @include govuk-responsive-margin(4, "bottom");
   background: govuk-colour("light-grey");
-  border-left: $govuk-border-width solid $govuk-brand-colour;
+  border-left: $govuk-border-width solid $git-brand-colour;
   clear: both;
   padding: govuk-spacing(4);
+}
+
+.app-advice__caption {
+  @include govuk-font($size: 19);
+  color: govuk-colour("dark-grey");
+  display: block;
 }
 
 .app-advice__title {


### PR DESCRIPTION
### Context

As a... provider
I need to... see where standardised content comes from
So that... I know that this content has not been written by a Publish user

### Changes proposed in this pull request

* Added a caption above boxout titles that says _Advice from Get Into Teaching_
* The left border uses GITs green brand colour

### Guidance to review

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/813383/110515287-22471900-8100-11eb-9416-07782a6fd8aa.png) | ![After](https://user-images.githubusercontent.com/813383/110515282-2115ec00-8100-11eb-9f61-732308f9bad6.png) |

### Trello card

https://trello.com/c/yabdtxxJ/

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
