### PR TITLE
De-emphasise summary labels on the results page

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -71,7 +71,7 @@
                 <span class="app-search-result__course-name" data-qa="course__name"><%= course.decorate.display_title %></span>
               <% end %>
             </h2>
-            <dl class="app-description-list">
+            <dl class="app-description-list app-description-list--course-result">
               <dt class="app-description-list__label">Course</dt>
               <dd data-qa="course__description"><%= course.description %></dd>
               <% if @results_view.location_filter? && @results_view.has_sites?(course) %>

--- a/app/webpacker/styles/components/_description-list.scss
+++ b/app/webpacker/styles/components/_description-list.scss
@@ -4,7 +4,8 @@
 }
 
 %app-description-list > dt {
-  @include govuk-font($size: 19, $weight: bold);
+  @include govuk-font($size: 19, $weight: normal);
+  color: $govuk-secondary-text-colour;
   vertical-align: top;
 
   @include govuk-media-query($from: desktop) {

--- a/app/webpacker/styles/components/_description-list.scss
+++ b/app/webpacker/styles/components/_description-list.scss
@@ -4,8 +4,7 @@
 }
 
 %app-description-list > dt {
-  @include govuk-font($size: 19, $weight: normal);
-  color: $govuk-secondary-text-colour;
+  @include govuk-font($size: 19, $weight: bold);
   vertical-align: top;
 
   @include govuk-media-query($from: desktop) {
@@ -14,6 +13,11 @@
     margin-bottom: govuk-spacing(1);
     width: 30%;
   }
+}
+
+.app-description-list--course-result > dt {
+  @include govuk-font($size: 19, $weight: regular);
+  color: $govuk-secondary-text-colour;
 }
 
 %app-description-list > dd {


### PR DESCRIPTION
The labels within the results list (Course, Financial support, Locations, Vacancies)  are repeated for every item. With the exception of Vacancies (which displays only Yes or No), they're also pretty self-explanatory if you read the values first.

Because of this, perhaps we can de-emphasis them by dropping the bold and using dark grey text, to give more focus to the content which does change for each course?  This is also what the [Teaching vacancies service](https://teaching-vacancies.service.gov.uk/teaching-jobs-in-London) does (albeit using smaller text).

## Before

<img width="636" alt="find-before" src="https://user-images.githubusercontent.com/30665/110632265-5291c480-819f-11eb-9135-7cb1f4e2da23.png">

## After

<img width="631" alt="find-after" src="https://user-images.githubusercontent.com/30665/110632293-5c1b2c80-819f-11eb-8a0d-059c630645f6.png">
