### PR TITLE
Conditionally render course qualification guidance

### DIFF
--- a/app/views/courses/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/_entry_requirements_qualifications.html.erb
@@ -1,14 +1,14 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
   <% if course.required_qualifications.present? %>
-    <%= render AdviceComponent.new(title: 'Qualifications') do %>
-      <%= render partial: 'courses/entry_requirements' %>
-    <% end %>
-
     <h3 class="govuk-heading-m">Qualifications needed</h3>
     <div data-qa="course__required_qualifications">
       <%= markdown(course.required_qualifications) %>
     </div>
+  <% else %>
+    <%= render AdviceComponent.new(title: 'The qualifications you need') do %>
+      <%= render partial: 'courses/entry_requirements' %>
+    <% end %>
   <% end %>
 
   <% if course.personal_qualities.present? %>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -300,6 +300,24 @@ describe 'Course show', type: :feature do
     end
   end
 
+  describe 'A course without qualification requirements' do
+    let(:course) do
+      build(:course,
+            course_code: 'X130',
+            fee_uk_eu: '9250.0',
+            fee_international: nil,
+            provider: provider,
+            provider_code: provider.provider_code,
+            provider_type: provider.provider_type,
+            recruitment_cycle: current_recruitment_cycle,
+            accrediting_provider: accrediting_provider)
+    end
+
+    it 'renders GIT advice box' do
+      expect(course_page).to have_content('The qualifications you need')
+    end
+  end
+
   def jsonapi_site_status(name, study_mode, status)
     build(:site_status, study_mode, site: build(:site, location_name: name, travel_to_work_area: 'Leeds'), status: status)
   end


### PR DESCRIPTION
### Context

Under entry requirements, for the qualifications currently both the GIT advice box and the provider content is rendered on the page. So that candidates can better understand the course requirements, it will now render the provider generated content - if they have entered it. If they haven't, then the page will render the standard GIT qualifications advice box.

### Changes proposed in this pull request

* Update title from **Qualifications** to **The qualifications you need**
* Page will only render the qualifications boxout if a provider *has not* provided a value for `required_qualifications`.

### Guidance to review

|Provider generated content|GIT content|
|----|----|
|![Screenshot 2021-03-10 at 14 42 06](https://user-images.githubusercontent.com/47917431/110646496-d99a6900-81ae-11eb-9a07-d6b37d3daf8b.png)|![Screenshot 2021-03-10 at 14 41 48](https://user-images.githubusercontent.com/47917431/110646537-e1f2a400-81ae-11eb-82b2-621ce727cd05.png)|

### Trello card

https://trello.com/c/THthgZ7U/3146-remove-structured-qualifications-boxout-from-course-pages-that-have-requiredqualifications-value

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
