### PR TITLE
Update which placement partial to render for school placements

### DIFF
--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,13 +1,17 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
+  <% if course.program_type == 'higher_education_programme' %>
     <%= render AdviceComponent.new(title: 'Where you will train') do %>
-      <% if course.provider_type == 'university' %>
-        <%= render partial: 'courses/placement/hei', locals: { course: course } %>
-      <% else %>
-        <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
-      <% end %>
+      <%= render partial: 'courses/placement/hei', locals: { course: course } %>
     <% end %>
+  <% elsif course.program_type == 'scitt_programme' %>
+    <%= render AdviceComponent.new(title: 'Where you will train') do %>
+      <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
+    <% end %>
+  <% end %>
+  <% if course.how_school_placements_work.present? %>
     <%= markdown(course.how_school_placements_work) %>
+  <%end%>
   </div>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -54,7 +54,7 @@
         <% if course.about_course.present? %>
           <li><%= govuk_link_to 'About the course', '#section-about' %></li>
         <% end %>
-        <% if course.how_school_placements_work.present? %>
+        <% if course.how_school_placements_work.present? || course.program_type == 'higher_education_programme' || course.program_type == 'scitt_programme' %>
           <li><%= govuk_link_to course.placements_heading, '#section-schools' %></li>
         <% end %>
         <li><%= govuk_link_to 'Entry requirements', '#section-entry' %></li>
@@ -80,7 +80,7 @@
         <%= render partial: 'courses/about_course' %>
       <% end %>
 
-      <% if course.how_school_placements_work.present? %>
+      <% if course.how_school_placements_work.present? || course.program_type == 'higher_education_programme' || course.program_type == 'scitt_programme' %>
         <%= render partial: 'courses/about_schools' %>
       <% end %>
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -318,6 +318,61 @@ describe 'Course show', type: :feature do
     end
   end
 
+  describe 'Where you will train advice box' do
+    let(:course) do
+      build(:course,
+            course_code: 'X000',
+            fee_uk_eu: '9250.0',
+            fee_international: nil,
+            provider: provider,
+            provider_code: provider.provider_code,
+            provider_type: provider.provider_type,
+            recruitment_cycle: current_recruitment_cycle,
+            accrediting_provider: accrediting_provider,
+            program_type: program_type)
+    end
+
+    context 'higher_education_programme' do
+      let(:program_type) { 'higher_education_programme' }
+
+      it 'renders the HEI where will you train advice box' do
+        expect(course_page).to have_content('Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university')
+      end
+    end
+
+    context 'scitt_programme' do
+      let(:program_type) { 'scitt_programme' }
+
+      it 'renders the SCITT where will you train advice box' do
+        expect(course_page).to have_content('You’ll be placed in different schools during your training. You can’t pick which schools you want to be in')
+      end
+    end
+
+    context 'pg_teaching_apprenticeship' do
+      let(:program_type) { 'pg_teaching_apprenticeship' }
+
+      it 'does not render the where will you train advice box' do
+        expect(course_page).not_to have_content('Advice from Get Into Teaching Where you will train')
+      end
+    end
+
+    context 'school_direct_training_programme' do
+      let(:program_type) { 'school_direct_training_programme' }
+
+      it 'does not render the where will you train advice box' do
+        expect(course_page).not_to have_content('Advice from Get Into Teaching Where you will train')
+      end
+    end
+
+    context 'school_direct_salaried_training_programme' do
+      let(:program_type) { 'school_direct_salaried_training_programme' }
+
+      it 'does not render the where will you train advice box' do
+        expect(course_page).not_to have_content('Advice from Get Into Teaching Where you will train')
+      end
+    end
+  end
+
   def jsonapi_site_status(name, study_mode, status)
     build(:site_status, study_mode, site: build(:site, location_name: name, travel_to_work_area: 'Leeds'), status: status)
   end


### PR DESCRIPTION
### Context

Some school direct providers allow you to pick a location (and they list all of their locations), but our guidance says you can’t choose, which contradicts this.

Until we have a revised solution, remove this box from School Direct providers.

### Changes proposed in this pull request

The ‘Where you will train‘ box does not appear on School Direct or PG apprenticeship courses

### Guidance to review

### Trello card

https://trello.com/c/ZMzl1hFe/3156-find-remove-where-you-will-train-grey-box-from-school-direct-providers

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
