### PR TITLE
Use helpers provided by govuk-components

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -38,24 +38,6 @@ module ViewHelper
     link_to(body, url, html_options)
   end
 
-  def govuk_button_to(name, options = {}, html_options = {}, &_block)
-    if block_given?
-      html_options = options
-      options = name
-    end
-
-    html_options = {
-      class: prepend_css_class('govuk-button', html_options[:class]),
-      role: 'button',
-      data: { module: 'govuk-button' },
-      draggable: false,
-    }.merge(html_options)
-
-    return button_to(options, html_options) { yield } if block_given?
-
-    button_to(name, options, html_options)
-  end
-
   def govuk_back_link_to(url, link_text = 'Back')
     link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -10,8 +10,8 @@ module ViewHelper
     Settings.service_support.contact_email_address
   end
 
-  def bat_contact_mail_to(name = nil, subject: nil, link_class: 'govuk-link')
-    mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject, class: link_class
+  def bat_contact_mail_to(name = nil, subject: nil)
+    govuk_mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject
   end
 
   def title_with_error_prefix(title, error)

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,8 +1,4 @@
 module ViewHelper
-  def govuk_mail_to(email, name = nil, html_options = {}, &block)
-    mail_to(email, name, html_options.merge(class: 'govuk-link'), &block)
-  end
-
   def govuk_back_link_to(url, link_text = 'Back')
     link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -3,41 +3,6 @@ module ViewHelper
     mail_to(email, name, html_options.merge(class: 'govuk-link'), &block)
   end
 
-  def govuk_link_to(body = nil, url = nil, html_options = nil, &block)
-    if block_given?
-      html_options = url
-      url = body
-      body = block
-    end
-    html_options ||= {}
-
-    html_options[:class] = prepend_css_class('govuk-link', html_options[:class])
-
-    return link_to(url, html_options) { yield } if block_given?
-
-    link_to(body, url, html_options)
-  end
-
-  def govuk_button_link_to(body = nil, url = nil, html_options = nil, &block)
-    if block_given?
-      html_options = url
-      url = body
-      body = block
-    end
-    html_options ||= {}
-
-    html_options = {
-      class: prepend_css_class('govuk-button', html_options[:class]),
-      role: 'button',
-      data: { module: 'govuk-button' },
-      draggable: false,
-    }.merge(html_options)
-
-    return link_to(url, html_options) { yield } if block_given?
-
-    link_to(body, url, html_options)
-  end
-
   def govuk_back_link_to(url, link_text = 'Back')
     link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
   end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,8 +1,4 @@
 module ViewHelper
-  def govuk_back_link_to(url, link_text = 'Back')
-    link_to link_text, url, class: 'govuk-back-link', data: { qa: 'page-back' }
-  end
-
   def permitted_referrer?
     return false if request.referer.blank?
 

--- a/app/views/cookie_preferences/new.html.erb
+++ b/app/views/cookie_preferences/new.html.erb
@@ -35,9 +35,7 @@
 
       <h3 class="govuk-heading-m">Analytics cookies (optional)</h3>
 
-
       <%= render partial: 'cookie_preferences_form' %>
-
     </div>
   </div>
 </div>

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -12,6 +12,6 @@
   <% end %>
   <% if course.how_school_placements_work.present? %>
     <%= markdown(course.how_school_placements_work) %>
-  <%end%>
+  <% end %>
   </div>
 </div>

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -8,5 +8,5 @@
     <%= t('get_into_teaching.opening_times') %> (except public holidays).</p>
 
   <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
-  <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to 'contact us by email', subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>
+  <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to('contact us by email', subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})") %>.</p>
 </div>

--- a/app/views/courses/_apply_button.html.erb
+++ b/app/views/courses/_apply_button.html.erb
@@ -1,15 +1,15 @@
 <% if FeatureFlag.active?(:display_apply_button) %>
   <p class="govuk-body">
-  <%= render GovukComponent::StartNowButton.new(
-    text: 'Apply for this course',
-    href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
-    html_attributes: { 'data-qa': 'course__apply_link' },
-  ) %>
+    <%= govuk_start_now_button(
+      text: 'Apply for this course',
+      href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
+      html_attributes: {
+        data: { qa: 'course__apply_link' },
+      },
+    ) %>
   </p>
 <% else %>
   <div data-qa="course__end_of_cycle_notice">
-    <p class="govuk-body">
-    You can apply to this course from 13 October.
-    </p>
+    <p class="govuk-body">You can apply to this course from 13 October.</p>
   </div>
 <% end %>

--- a/app/views/courses/_contact_details.html.erb
+++ b/app/views/courses/_contact_details.html.erb
@@ -6,7 +6,7 @@
       <% if course.provider.email.present? %>
         <dt class="app-description-list__label">Email</dt>
         <dd data-qa="provider__email">
-          <%= mail_to course.provider.email, course.provider.email, title: 'Send email to course contact', aria: { label: 'Send email to course contact' }, class: 'govuk-link' %>
+          <%= govuk_mail_to course.provider.email, course.provider.email, title: 'Send email to course contact', aria: { label: 'Send email to course contact' } %>
         </dd>
       <% end %>
 

--- a/app/views/courses/_no_vacancies_warning.html.erb
+++ b/app/views/courses/_no_vacancies_warning.html.erb
@@ -1,3 +1,3 @@
-<%= render GovukComponent::Warning.new(
+<%= govuk_warning(
   text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.',
 ) %>

--- a/app/views/courses/_no_vacancies_warning.html.erb
+++ b/app/views/courses/_no_vacancies_warning.html.erb
@@ -1,3 +1,1 @@
-<%= govuk_warning(
-  text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.',
-) %>
+<%= govuk_warning(text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.') %>

--- a/app/views/courses/qualification/_pgce.html.erb
+++ b/app/views/courses/qualification/_pgce.html.erb
@@ -1,4 +1,4 @@
-<%= render GovukComponent::Details.new(summary: 'PGCE') do %>
+<%= govuk_details(summary: 'PGCE') do %>
   <p class="govuk-body">
     A postgraduate certificate in education (PGCE) is an academic qualification in education.
   </p>

--- a/app/views/courses/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgce_with_qts.html.erb
@@ -1,4 +1,4 @@
-<%= render GovukComponent::Details.new(summary: 'PGCE with QTS') do %>
+<%= govuk_details(summary: 'PGCE with QTS') do %>
   <p class="govuk-body">
     A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>

--- a/app/views/courses/qualification/_pgde.html.erb
+++ b/app/views/courses/qualification/_pgde.html.erb
@@ -1,4 +1,4 @@
-<%= render GovukComponent::Details.new(summary: 'PGDE') do %>
+<%= govuk_details(summary: 'PGDE') do %>
   <p class="govuk-body">
     A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
   </p>

--- a/app/views/courses/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgde_with_qts.html.erb
@@ -1,4 +1,4 @@
-<%= render GovukComponent::Details.new(summary: 'PGDE with QTS') do %>
+<%= govuk_details(summary: 'PGDE with QTS') do %>
   <p class="govuk-body">
     A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -1,4 +1,4 @@
-<%= render GovukComponent::Details.new(summary: 'QTS') do %>
+<%= govuk_details(summary: 'QTS') do %>
   <p class="govuk-body">
     Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
   </p>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -2,7 +2,13 @@
 
 <% if permitted_referrer? %>
   <%= content_for(:before_content) do %>
-    <%= govuk_back_link_to(request.referer, 'Back to search results') %>
+    <%= govuk_back_link({
+      text: 'Back to search results',
+      href: request.referer,
+      html_attributes: {
+        data: { qa: 'page-back' },
+      },
+    }) %>
   <% end %>
 <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
         <%= cookie_banner.with(:actions) do %>
           <button type="button" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
           <button type="button" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
-          <%= govuk_link_to('View cookies', cookie_preferences_path, { data: { qa: 'cookie-banner__preference-link' } }) %>
+          <%= govuk_link_to('View cookies', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) %>
         <% end %>
       <% end %>
 
@@ -62,7 +62,7 @@
         },
       ) do |cookie_banner| %>
         <%= cookie_banner.with(:body) do %>
-          <p>You’ve <span id="user-answer"></span> analytics cookies. You can <%= govuk_link_to('change your cookie settings', cookie_preferences_path, { data: { qa: 'cookie-banner__preference-link' } }) %> at any time.</p>
+          <p>You’ve <span id="user-answer"></span> analytics cookies. You can <%= govuk_link_to('change your cookie settings', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) %> at any time.</p>
         <% end %>
         <%= cookie_banner.with(:actions) do %>
           <button type="button" class="govuk-button" data-accept-cookie="hide-banner">Hide this message</button>
@@ -105,7 +105,12 @@
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if flash[:success] %>
-          <%= govuk_notification_banner(title: 'Success', success: true, title_id: 'success-message', html_attributes: { role: 'alert' }) do |notification_banner| %>
+          <%= govuk_notification_banner(
+            title: 'Success',
+            success: true,
+            title_id: 'success-message',
+            html_attributes: { role: 'alert' },
+          ) do |notification_banner| %>
             <%= notification_banner.slot(:heading, text: flash[:success]) %>
           <% end %>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,19 @@
     </script>
 
     <% unless current_page?(cookie_preferences_path) %>
-      <%= render GovukComponent::CookieBanner.new(title: 'Cookies on Find postgraduate teacher training', html_attributes: { hidden: true, 'aria-label': 'Cookies on Find postgraduate teacher training', 'data-module': 'govuk-cookie-banner', 'data-qa': 'cookie-banner' }) do |cookie_banner| %>
+      <%= govuk_cookie_banner(
+        title: 'Cookies on Find postgraduate teacher training',
+        html_attributes: {
+          hidden: true,
+          aria: {
+            label: 'Cookies on Find postgraduate teacher training',
+          },
+          data: {
+            module: 'govuk-cookie-banner',
+            qa: 'cookie-banner',
+          },
+        },
+      ) do |cookie_banner| %>
         <%= cookie_banner.with(:body) do %>
           <p class="govuk-body">We use some essential cookies to make this service work.</p>
           <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
@@ -37,7 +49,18 @@
         <% end %>
       <% end %>
 
-      <%= render GovukComponent::CookieBanner.new(html_attributes: { hidden: true, 'aria-label': 'Cookies on Find postgraduate teacher training', 'data-module': 'govuk-hide-cookie-banner', 'data-qa': 'hide-cookie-banner' }) do |cookie_banner| %>
+      <%= govuk_cookie_banner(
+        html_attributes: {
+          hidden: true,
+          aria: {
+            label: 'Cookies on Find postgraduate teacher training',
+          },
+          data: {
+            module: 'govuk-hide-cookie-banner',
+            qa: 'hide-cookie-banner',
+          },
+        },
+      ) do |cookie_banner| %>
         <%= cookie_banner.with(:body) do %>
           <p>You’ve <span id="user-answer"></span> analytics cookies. You can <%= govuk_link_to('change your cookie settings', cookie_preferences_path, { data: { qa: 'cookie-banner__preference-link' } }) %> at any time.</p>
         <% end %>
@@ -46,7 +69,19 @@
         <% end %>
       <% end %>
 
-      <%= render GovukComponent::CookieBanner.new(title: 'Cookies on Find postgraduate teacher training', html_attributes: { hidden: false, 'aria-label': 'Cookies on Find postgraduate teacher training', 'data-module': 'govuk-fallback-cookie-banner', 'data-qa': 'fallback-cookie-banner' }) do |cookie_banner| %>
+      <%= govuk_cookie_banner(
+        title: 'Cookies on Find postgraduate teacher training',
+        html_attributes: {
+          hidden: false,
+          aria: {
+            label: 'Cookies on Find postgraduate teacher training',
+          },
+          data: {
+            module: 'govuk-fallback-cookie-banner',
+            qa: 'fallback-cookie-banner',
+          },
+        },
+      ) do |cookie_banner| %>
         <%= cookie_banner.with(:body) do %>
           <p class="govuk-body">We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
       <% end %>
     <% end %>
 
-    <a href="#main-content" class="govuk-skip-link">Skip to main content</a>
+    <%= govuk_skip_link %>
 
     <%= render GovukComponent::Header.new(
       logo: 'GOV.UK',

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,7 @@
     ) %>
 
     <div class="govuk-width-container">
-      <%= render GovukComponent::PhaseBanner.new(phase: 'Beta') do %>
+      <%= render govuk_phase_banner(phase: 'Beta') do %>
         This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
       <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,7 +97,7 @@
     ) %>
 
     <div class="govuk-width-container">
-      <%= render govuk_phase_banner(phase: 'Beta') do %>
+      <%= govuk_phase_banner(phase: 'Beta') do %>
         This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
       <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
 
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if flash[:success] %>
-          <%= render GovukComponent::NotificationBanner.new(title: 'Success', success: true, title_id: 'success-message', html_attributes: { role: 'alert' }) do |notification_banner| %>
+          <%= govuk_notification_banner(title: 'Success', success: true, title_id: 'success-message', html_attributes: { role: 'alert' }) do |notification_banner| %>
             <%= notification_banner.slot(:heading, text: flash[:success]) %>
           <% end %>
         <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
 
     <%= govuk_skip_link %>
 
-    <%= render GovukComponent::Header.new(
+    <%= govuk_header(
       logo: 'GOV.UK',
       service_name: 'Find postgraduate teacher training',
       service_name_href: root_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,7 +88,7 @@
       ) %>
     <% end %>
 
-    <%= render GovukComponent::Footer.new do |footer| %>
+    <%= govuk_footer do |footer| %>
       <%= footer.slot(:meta) do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="govuk-heading-m">Get support</h2>

--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -5,9 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Find postgraduate teacher training</h1>
 
-      <%= govuk_warning(
-        text: 'It’s no longer possible to apply for courses for the 2020 to 2021 academic year',
-      ) %>
+      <%= govuk_warning(text: 'It’s no longer possible to apply for courses for the 2020 to 2021 academic year') %>
 
       <h2 class="govuk-heading-m">Find courses starting in the 2021 to 2022 academic year</h2>
       <p class="govuk-body">Come back from 6 October 2020 to find courses.</p>

--- a/app/views/pages/cycle_ending_soon.html.erb
+++ b/app/views/pages/cycle_ending_soon.html.erb
@@ -5,7 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Find postgraduate teacher training</h1>
 
-      <%= render GovukComponent::Warning.new(
+      <%= govuk_warning(
         text: 'It’s no longer possible to apply for courses for the 2020 to 2021 academic year',
       ) %>
 

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -9,7 +9,7 @@
       <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Find postgraduate teacher training’.</p>
 
       <h2 class="govuk-heading-l">How we will use your information</h2>
-      <p class="govuk-body">We receive your personal data in the form of your IP address and are processing it in order to track traffic to the service and continuously improve our service to better meet users’ needs. In some instances, we may also collect your email address for similar purposes. More information about this work is available if you wish to contact us at <a href="mailto:becomingateacher@digital.education.gov.uk" class='govuk-link'>becomingateacher@digital.education.gov.uk</a>.</p>
+      <p class="govuk-body">We receive your personal data in the form of your IP address and are processing it in order to track traffic to the service and continuously improve our service to better meet users’ needs. In some instances, we may also collect your email address for similar purposes. More information about this work is available if you wish to contact us at <%= bat_contact_mail_to %>.</p>
 
       <h3 class="govuk-heading-m">The nature of your personal data we will be using</h3>
       <p class="govuk-body">The categories of your personal data that we will be using for this project are: IP address and contact information - email address.</p>

--- a/app/views/result_filters/_vacancy_filter.html.erb
+++ b/app/views/result_filters/_vacancy_filter.html.erb
@@ -3,14 +3,13 @@
   <div class="govuk-checkboxes govuk-checkboxes--small">
     <div class="govuk-checkboxes__item">
       <%= form.check_box(
-        :hasvacancies,
-        {
+        :hasvacancies, {
           checked: @filters_view.has_vacancies_checked? || @filters_view.default_with_vacancies_to_true,
           data: { qa: 'with_vacancies' },
-          class: 'govuk-checkboxes__input'
+          class: 'govuk-checkboxes__input',
         },
         'true',
-          'false',
+        'false'
       ) %>
       <%= form.label(:hasvacancies_true, { for: 'hasvacancies' }, class: 'govuk-label govuk-checkboxes__label') do %>
         Only show courses with vacancies

--- a/app/views/result_filters/location/new.html.erb
+++ b/app/views/result_filters/location/new.html.erb
@@ -1,5 +1,11 @@
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), 'Back to search results') %>
+  <%= govuk_back_link({
+    text: 'Back to search results',
+    href: results_path(@results_filter_query_parameters),
+    html_attributes: {
+      data: { qa: 'page-back' },
+    },
+  }) %>
 <% end %>
 
 <%= render 'result_filters/location/form', submit_button_text: 'Find courses' %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -20,7 +20,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <div>
-      <%= render GovukComponent::Details.new(summary: 'Try another provider') do %>
+      <%= govuk_details(summary: 'Try another provider') do %>
         <%= form_with url: provider_path, method: :get, data: { 'ga-event-form' => 'Provider' } do |form| %>
           <fieldset class="govuk-fieldset">
             <div class="govuk-form-group">

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -13,7 +13,9 @@
           <%= accordion.add_section(
             title: subject_area.name,
             expanded: subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?),
-            html_attributes: { 'data-qa': 'subject_area' },
+            html_attributes: {
+              data: { qa: 'subject_area' },
+            },
           ) do %>
             <fieldset class="govuk-fieldset">
               <legend class="govuk-fieldset__legend govuk-visually-hidden" data-qa="subject_area__legend">
@@ -70,7 +72,9 @@
         <%= accordion.add_section(
           title: 'Special educational needs and disability (SEND)',
           expanded: params[:senCourses] == 'true',
-          html_attributes: { 'data-qa': 'send_area' },
+          html_attributes: {
+            data: { qa: 'send_area' },
+          },
         ) do %>
           <div class="govuk-checkboxes" id="send-content">
             <div class="govuk-checkboxes__item" data-qa="subject">

--- a/app/views/result_filters/subject/new.html.erb
+++ b/app/views/result_filters/subject/new.html.erb
@@ -1,5 +1,11 @@
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(results_path(@results_filter_query_parameters), 'Back to search results') %>
+  <%= govuk_back_link({
+    text: 'Back to search results',
+    href: results_path(@results_filter_query_parameters),
+    html_attributes: {
+      data: { qa: 'page-back' },
+    },
+  }) %>
 <% end %>
 
 <%= render 'result_filters/subject/form', submit_button_text: 'Find courses' %>

--- a/app/views/result_filters/subject/start.html.erb
+++ b/app/views/result_filters/subject/start.html.erb
@@ -1,5 +1,11 @@
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(root_path(@results_filter_query_parameters), 'Back to location') %>
+  <%= govuk_back_link({
+    text: 'Back to location',
+    href: root_path(@results_filter_query_parameters),
+    html_attributes: {
+      data: { qa: 'page-back' },
+    },
+  }) %>
 <% end %>
 
 <%= render 'result_filters/subject/form', submit_button_text: 'Continue' %>

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -7,9 +7,7 @@
         <span class="app-description-list__hint govuk-!-margin-top-0">University</span>
       <% else %>
         <span class="app-description-list__hint govuk-!-margin-top-0">Placement schools</span>
-        <%= render GovukComponent::Details.new(
-          summary: @results_view.placement_schools_summary(course),
-        ) do %>
+        <%= govuk_details(summary: @results_view.placement_schools_summary(course)) do %>
           <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
           <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
           <%= govuk_link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools') %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -26,16 +26,16 @@
               <%= render 'shared/hidden_fields', form: form, exclude_keys: %w[sortby] %>
               <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
               <%= form.select(
-                    :sortby,
-                    options_for_select(@results_view.sort_options, selected: params['sortby'].to_i || 0),
-                    {},
-                    {
-                      class: 'govuk-select',
-                      onchange: 'this.form.submit()',
-                      role: 'listbox',
-                      'data-qa': 'sort-form__options',
-                    },
-                  ) %>
+                :sortby,
+                options_for_select(@results_view.sort_options, selected: params['sortby'].to_i || 0),
+                {},
+                {
+                  class: 'govuk-select',
+                  onchange: 'this.form.submit()',
+                  role: 'listbox',
+                  data: { qa: 'sort-form__options' },
+                },
+              ) %>
               <%= form.submit('Update', name: nil, class: 'govuk-button', data: { qa: 'sort-form__submit' }) %>
             <% end %>
           <% end %>

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -5,7 +5,7 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :link_to
 
-          add_offense(node, message: 'Use govuk_link_to, govuk_back_link_to or govuk_button_link_to instead of link_to')
+          add_offense(node, message: 'Use govuk_link_to or govuk_back_link_to instead of link_to')
         end
       end
     end

--- a/lib/rubocop/cop/govuk/govuk_link_to.rb
+++ b/lib/rubocop/cop/govuk/govuk_link_to.rb
@@ -5,7 +5,7 @@ module RuboCop
         def on_send(node)
           return unless node.method_name == :link_to
 
-          add_offense(node, message: 'Use govuk_link_to or govuk_back_link_to instead of link_to')
+          add_offense(node, message: 'Use govuk_link_to instead of link_to')
         end
       end
     end

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,12 +1,6 @@
 require 'rails_helper'
 
 describe 'View helpers', type: :helper do
-  describe '#govuk_link_to' do
-    it 'returns an anchor tag with the govuk-link class' do
-      expect(helper.govuk_link_to('ACME SCITT', 'https://localhost:3000/organisations/A0')).to eq('<a class="govuk-link" href="https://localhost:3000/organisations/A0">ACME SCITT</a>')
-    end
-  end
-
   describe '#govuk_back_link_to' do
     it 'renders a link to the provided URL' do
       expect(helper.govuk_back_link_to('https://localhost:3000/organisations/A0'))
@@ -18,13 +12,6 @@ describe 'View helpers', type: :helper do
         expect(helper.govuk_back_link_to('https://localhost:3000/organisations/A0', 'Booyah'))
           .to eq('<a class="govuk-back-link" data-qa="page-back" href="https://localhost:3000/organisations/A0">Booyah</a>')
       end
-    end
-  end
-
-  describe '#govuk_button_link_to' do
-    it 'returns an anchor tag with the govuk-button class' do
-      expect(helper.govuk_button_link_to('ACME SCITT', 'https://localhost:3000/organisations/A0'))
-        .to eq('<a class="govuk-button" role="button" data-module="govuk-button" draggable="false" href="https://localhost:3000/organisations/A0">ACME SCITT</a>')
     end
   end
 

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -1,20 +1,6 @@
 require 'rails_helper'
 
 describe 'View helpers', type: :helper do
-  describe '#govuk_back_link_to' do
-    it 'renders a link to the provided URL' do
-      expect(helper.govuk_back_link_to('https://localhost:3000/organisations/A0'))
-        .to eq('<a class="govuk-back-link" data-qa="page-back" href="https://localhost:3000/organisations/A0">Back</a>')
-    end
-
-    context 'when passed alternative link text' do
-      it 'renders the text in the link' do
-        expect(helper.govuk_back_link_to('https://localhost:3000/organisations/A0', 'Booyah'))
-          .to eq('<a class="govuk-back-link" data-qa="page-back" href="https://localhost:3000/organisations/A0">Booyah</a>')
-      end
-    end
-  end
-
   describe '#permitted_referrer?' do
     context 'With a blank referrer' do
       it 'Returns false' do

--- a/spec/helpers/view_helper_spec.rb
+++ b/spec/helpers/view_helper_spec.rb
@@ -28,13 +28,6 @@ describe 'View helpers', type: :helper do
     end
   end
 
-  describe '#govuk_button_to' do
-    it 'returns a form containing a single button' do
-      expect(helper.govuk_button_to('ACME SCITT', 'https://localhost:3000/organisations/A0'))
-        .to eq('<form class="button_to" method="post" action="https://localhost:3000/organisations/A0"><input class="govuk-button" role="button" data-module="govuk-button" draggable="false" type="submit" value="ACME SCITT" /></form>')
-    end
-  end
-
   describe '#permitted_referrer?' do
     context 'With a blank referrer' do
       it 'Returns false' do


### PR DESCRIPTION
### Context

In addition to individual components, `govuk-components` provides a number of link helpers that replicate those we had created. It also provides helpers that call component rendering methods.

### Changes proposed in this pull request

* Remove helpers and tests for `govuk_button_to`, `govuk_link_to` and `govuk_mail_to` helpers
* Replace `govuk_back_link_to` helper with `GovukComponent::BackLink` component (via `govuk_back_link` helper) and remove associated tests
* Use `govuk_skip_link` helper
* Use component helper methods from `govuk-components` instead of rendering components directly
* Refactor `bat_contact_mail_to` helper to call `govuk_mail_to` helper (and use it where it should be used)
* Use consistent syntax style for listing component attributes 
* Fix linting errors

### Guidance to review

Is using the helper shortcuts instead of calling component methods desirable? For example, instead of using:

```erb
<%= render GovukComponent::BackLink.new(
  text: 'Department for Education',
  href: 'https://www.gov.uk/government/organisations/department-for-education',
) %>
```

changed to using:

```erb
<%= govuk_back_link(
  text: 'Department for Education',
  href: 'https://www.gov.uk/government/organisations/department-for-education',
) %>
```

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
