### PR TITLE
Split course description row

### DIFF
--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -72,8 +72,8 @@
               <% end %>
             </h2>
             <dl class="app-description-list">
-              <dt class="app-description-list__label">Course</dt>
-              <dd data-qa="course__description"><%= course.description %></dd>
+              <dt class="app-description-list__label">Qualification</dt>
+              <dd data-qa="course__qualification"><%= course.qualification.humanize %></dd>
               <% if @results_view.location_filter? && @results_view.has_sites?(course) %>
                 <% if course.university_based? %>
                   <%= render partial: 'results/university', locals: { course: course } %>
@@ -81,6 +81,8 @@
                   <%= render partial: 'results/non_university', locals: { course: course } %>
                 <% end %>
               <% end %>
+              <dt class="app-description-list__label">Study type</dt>
+              <dd data-qa="course__study_mode"><%= course.study_mode.humanize %></dd>
               <dt class="app-description-list__label">Financial support</dt>
               <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
               <% if course['accrediting_provider'].present? %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections
 # are locale specific, and you may define rules for as many different
 # locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'QTS'
+  inflect.acronym 'PGCE'
+  inflect.acronym 'PGDE'
+end
 
 # These inflection rules are supported but not enabled by default:
 # ActiveSupport::Inflector.inflections(:en) do |inflect|

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -46,7 +46,8 @@ describe 'Search results', type: :feature do
       results_page.courses.first.then do |first_course|
         expect(first_course.name.text).to eq('Geography (385N)')
         expect(first_course.provider_name.text).to eq('BHSSA')
-        expect(first_course.description.text).to eq('PGCE with QTS full time')
+        expect(first_course.qualification.text).to eq('PGCE with QTS')
+        expect(first_course.study_mode.text).to eq('Full time')
         expect(first_course.accrediting_provider.text).to eq('University of Brighton')
         expect(first_course.funding_options.text).to eq('Student finance if you’re eligible')
         expect(first_course.main_address.text).to eq('Hove Park School, Hangleton Way, Hove, East Sussex, BN3 8AA')

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -10,7 +10,8 @@ module PageObjects
 
       class CourseSection < SitePrism::Section
         element :provider_name, '[data-qa="course__provider_name"]'
-        element :description, '[data-qa="course__description"]'
+        element :qualification, '[data-qa="course__qualification"]'
+        element :study_mode, '[data-qa="course__study_mode"]'
         element :name, '[data-qa="course__name"]'
         element :accrediting_provider, '[data-qa="course__accrediting_provider"]'
         element :funding_options, '[data-qa="course__funding_options"]'


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

On the results page, we split the course description row into two rows.

Before

![image](https://user-images.githubusercontent.com/33458055/113273396-8199e280-92d4-11eb-9caa-d7c3787f7fcd.png)

After

![image](https://user-images.githubusercontent.com/33458055/113273253-616a2380-92d4-11eb-8c14-ad087ba09073.png)


### Guidance to review

I've used the `inflections.rb` file so that when we `humanize` the strings like `pgce_with_qts` it knows that they're acronyms and is able to correctly render this as `PGCE with QTS`.

### Trello card

https://trello.com/c/JjxzkEW0/3246-dev-split-course-row-into-qualification-and-study-type-rows

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
