### PR TITLE
Add the location table back in for courses with multiple locations

### DIFF
--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,17 +1,46 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
-  <% if course.program_type == 'higher_education_programme' %>
-    <%= render AdviceComponent.new(title: 'Where you will train') do %>
-      <%= render partial: 'courses/placement/hei', locals: { course: course } %>
+    <% if course.program_type == 'higher_education_programme' %>
+      <%= render AdviceComponent.new(title: 'Where you will train') do %>
+        <%= render partial: 'courses/placement/hei', locals: { course: course } %>
+      <% end %>
+    <% elsif course.program_type == 'scitt_programme' %>
+      <%= render AdviceComponent.new(title: 'Where you will train') do %>
+        <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
+      <% end %>
     <% end %>
-  <% elsif course.program_type == 'scitt_programme' %>
-    <%= render AdviceComponent.new(title: 'Where you will train') do %>
-      <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
+    <% if course.how_school_placements_work.present? %>
+      <%= markdown(course.how_school_placements_work) %>
     <% end %>
-  <% end %>
-  <% if course.how_school_placements_work.present? %>
-    <%= markdown(course.how_school_placements_work) %>
-  <% end %>
+
+    <% if FeatureFlag.active?(:ucas_only_locations) && course.has_vacancies? && course.site_statuses.map(&:site).uniq.many? %>
+      <h2 class="govuk-heading-m">Locations</h2>
+      <p class="govuk-body">You can select one of the following locations when you apply.</p>
+      <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
+        <caption class="govuk-visually-hidden">Choose a training location - List of locations, vacancies and codes</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th class="govuk-table__header" scope="col">Location</th>
+            <th class="govuk-table__header" scope="col">Vacancies</th>
+          </tr>
+        </thead>
+
+        <tbody class="govuk-table__body">
+          <% course.preview_site_statuses.each do |site_status| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+                <br>
+                <%= smart_quotes(site_status.site.decorate.full_address) %>
+              </td>
+              <td class="govuk-table__cell">
+                <%= site_status.has_vacancies? ? 'Yes' : 'No' %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% end %>
   </div>
 </div>

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -14,11 +14,11 @@
       <%= markdown(course.how_school_placements_work) %>
     <% end %>
 
-    <% if FeatureFlag.active?(:ucas_only_locations) && course.has_vacancies? && course.site_statuses.map(&:site).uniq.many? %>
-      <h2 class="govuk-heading-m">Locations</h2>
+    <% if FeatureFlag.active?(:ucas_only_locations) && course.site_statuses.map(&:site).uniq.many? %>
+      <h3 class="govuk-heading-m">Locations</h3>
       <p class="govuk-body">You can select one of the following locations when you apply.</p>
       <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
-        <caption class="govuk-visually-hidden">Choose a training location - List of locations, vacancies and codes</caption>
+        <caption class="govuk-visually-hidden">List of locations and vacancies</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
             <th class="govuk-table__header" scope="col">Location</th>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -86,9 +86,13 @@
         <%= render partial: 'courses/about_course' %>
       <% end %>
 
-      <% if course.how_school_placements_work.present? || course.program_type == 'higher_education_programme' || course.program_type == 'scitt_programme' %>
+      <% if course.how_school_placements_work.present? ||
+        course.program_type == 'higher_education_programme' ||
+        course.program_type == 'scitt_programme' ||
+        (FeatureFlag.active?(:ucas_only_locations) && course.site_statuses.map(&:site).uniq.many?) %>
         <%= render partial: 'courses/about_schools' %>
       <% end %>
+
 
       <%= render partial: 'courses/entry_requirements_qualifications' %>
 

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -373,6 +373,38 @@ describe 'Course show', type: :feature do
     end
   end
 
+  context 'with the :ucas_only_locations flag on' do
+    before do
+      allow(FeatureFlag).to receive(:active?).with(:ucas_only_locations).and_return true
+    end
+
+    context 'with one site' do
+      let(:course) do
+        build(:course,
+              course_code: 'X130',
+              fee_uk_eu: '9250.0',
+              fee_international: nil,
+              provider_code: provider.provider_code,
+              provider_type: provider.provider_type,
+              recruitment_cycle: current_recruitment_cycle,
+              accrediting_provider: accrediting_provider,
+              site_statuses: [jsonapi_site_status('Running site with vacancies', :full_time, 'running')])
+
+        it 'does not render the locations details in the about_schools section' do
+          expect(course_page).not_to have_content(course.site_statuses.first.site.decorate.full_address)
+        end
+      end
+    end
+
+    context 'with many sites' do
+      it 'renders the locations details in the about_schools section' do
+        course.site_statuses.map(&:site).uniq.each do |site|
+          expect(course_page).to have_content(site.decorate.full_address)
+        end
+      end
+    end
+  end
+
   def jsonapi_site_status(name, study_mode, status)
     build(:site_status, study_mode, site: build(:site, location_name: name, travel_to_work_area: 'Leeds'), status: status)
   end


### PR DESCRIPTION
### Context

We're adding back in the locations table for courses with multiple sites. It now should be in the where you will train section instead of the Apply section

### Changes proposed in this pull request

- Add back in the locations table for course with multiple sites and vacancies available

![image](https://user-images.githubusercontent.com/42515961/115748319-f6b97e80-a38d-11eb-9362-c441f69568e1.png)

### Guidance to review

This sits behind the ucas_only_locations feature flag, as when that is switched on the locations render in the Apply section as before.

We should remove that flag.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
