### PR TITLE
Don't log to file in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,6 +43,9 @@ Rails.application.configure do
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
+  
+  # Disable file logging in production
+  config.rails_semantic_logger.add_file_appender = false
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
### Context

see https://ukgovernmentdfe.slack.com/archives/CL1ETJHLN/p1619961403012900
Currently logs are being logged to STDOUT and also to {env}.log

### Changes proposed in this pull request
Disable file logging in prod

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
