### PR TITLE
Don't show the default  HEI guidance for Beds SCITT

### DIFF
--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
-    <% if course.program_type == 'higher_education_programme' %>
+    <% if course.program_type == 'higher_education_programme'  && course.provider.provider_code != 'B31'  %>
       <%= render AdviceComponent.new(title: 'Where you will train') do %>
         <%= render partial: 'courses/placement/hei', locals: { course: course } %>
       <% end %>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -89,7 +89,6 @@ describe 'Course show', type: :feature do
       resources: course,
       include: ['subjects', 'site_statuses.site', 'provider.sites', 'accrediting_provider'],
     )
-
     visit course_path(course.provider_code, course.course_code)
   end
 
@@ -337,6 +336,24 @@ describe 'Course show', type: :feature do
 
       it 'renders the HEI where will you train advice box' do
         expect(course_page).to have_content('Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university')
+      end
+
+      context 'The Bedfordshire Schools Training Partnership' do
+        let(:provider) do
+          build(
+            :provider,
+            provider_name: 'The Bedfordshire Schools Training Partnership',
+            provider_code: 'B31',
+            provider_type: 'scitt',
+            website: 'https://scitt.org',
+            address1: '1 Long Rd',
+            postcode: 'E1 ABC',
+          )
+        end
+
+        it 'does not render the HEI where will you train advice box' do
+          expect(course_page).not_to have_content('Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university')
+        end
       end
     end
 


### PR DESCRIPTION
### Context

Some of Beds SCITTs courses program_types are `HEI`. As a result, they're getting incorrect content rendered.

They've contacted us directly to complain about this so we're going to remove the content for now.

We\re going to have to do a data audit at some point too!

### Changes proposed in this pull request

- Don't show the HEI guidance for courses with a provider code of 'B31'

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
