### PR TITLE
Remove where you will train guidance from Educate Teacher Training

### DIFF
--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,11 +1,11 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
-    <% if course.program_type == 'higher_education_programme'  && course.provider.provider_code != 'B31'  %>
+    <% if course.program_type == 'higher_education_programme' && course.provider.provider_code != 'B31'  %>
       <%= render AdviceComponent.new(title: 'Where you will train') do %>
         <%= render partial: 'courses/placement/hei', locals: { course: course } %>
       <% end %>
-    <% elsif course.program_type == 'scitt_programme' %>
+    <% elsif course.program_type == 'scitt_programme'  && course.provider.provider_code != 'E65' %>
       <%= render AdviceComponent.new(title: 'Where you will train') do %>
         <%= render partial: 'courses/placement/scitt', locals: { course: course } %>
       <% end %>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -363,6 +363,24 @@ describe 'Course show', type: :feature do
       it 'renders the SCITT where will you train advice box' do
         expect(course_page).to have_content('You’ll be placed in different schools during your training. You can’t pick which schools you want to be in')
       end
+
+      context 'Educate Teacher Training' do
+        let(:provider) do
+          build(
+            :provider,
+            provider_name: 'Educate Teacher Training',
+            provider_code: 'E65',
+            provider_type: 'scitt',
+            website: 'https://scitt.org',
+            address1: '1 Long Rd',
+            postcode: 'E1 ABC',
+          )
+        end
+
+        it 'does not render the SCITT where will you train advice box' do
+          expect(course_page).not_to have_content('You’ll be placed in different schools during your training. You can’t pick which schools you want to be in')
+        end
+      end
     end
 
     context 'pg_teaching_apprenticeship' do


### PR DESCRIPTION
### Context

This provider does not actually find placements for candidates so the guidance is misleading. They've asked us to remove it.

https://www.find-postgraduate-teacher-training.service.gov.uk/results?l=3&query=Educate+Teacher+Training

### Changes proposed in this pull request

- Don't show where you will train default scitt content for Educate Teacher Training

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
