### PR TITLE
Revert to using addListener

### DIFF
--- a/app/webpacker/scripts/filter-toggle-button.js
+++ b/app/webpacker/scripts/filter-toggle-button.js
@@ -7,7 +7,7 @@ export const FilterToggleButton = class {
 
   setupResponsiveChecks () {
     this.mq = window.matchMedia(this.options.bigModeMediaQuery)
-    this.mq.addEventListener('change', $.proxy(this, 'checkMode'))
+    this.mq.addListener($.proxy(this, 'checkMode'))
     this.checkMode(this.mq)
   }
 


### PR DESCRIPTION
### Context

_This PR addresses a filter issue on IPhone SE - see https://github.com/DFE-Digital/find-teacher-training-prototype/pull/26_

`addListener` has been deprecated in favour of `addEventListener`, as used in the MOJ frontend version of this component: https://github.com/ministryofjustice/moj-frontend/blob/master/src/moj/components/filter-toggle-button/filter-toggle-button.js#L14

This is because `addEventListener` is only supported in Safari for `MediaQueryList` objects from version 14 onwards: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener – and old iPhones are unable to upgrade to this.

`addListener` seems to have been maintained by browsers for backwards-compatibility, at least for now.

A better longer-term fix might be to feature-detect support for `addEventListener` and then fall back to `addListener` if that is not available. Or alternatively to rewrite the javascript so that the component at least "fails safe" and uses the no-javascript mode if any of the component javascript is unsupported.

### Changes proposed in this pull request

Use `addListener` instead of `addEventListener` to enable the filters to work with older browsers

### Trello card
https://trello.com/c/mZCYoh0K/3327-bug-find-filters-not-working-correctly-on-iphone-se

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
