### PR TITLE
Only use sites with vacancies for info on results page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -162,7 +162,7 @@ class ResultsView
   end
 
   def site_distance(course)
-    distances = new_or_running_sites_for(course).map do |site|
+    distances = new_or_running_sites_with_vacancies_for(course).map do |site|
       lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
     end
 
@@ -190,11 +190,11 @@ class ResultsView
   end
 
   def has_sites?(course)
-    !new_or_running_sites_for(course).empty?
+    !new_or_running_sites_with_vacancies_for(course).empty?
   end
 
   def sites_count(course)
-    new_or_running_sites_for(course).count
+    new_or_running_sites_with_vacancies_for(course).count
   end
 
   def nearest_location_name(course)
@@ -277,7 +277,7 @@ class ResultsView
 private
 
   def nearest_location(course)
-    new_or_running_sites_for(course).min_by do |site|
+    new_or_running_sites_with_vacancies_for(course).min_by do |site|
       lat_long.distance_to("#{site[:latitude]},#{site[:longitude]}")
     end
   end
@@ -295,10 +295,11 @@ private
     qualification
   end
 
-  def new_or_running_sites_for(course)
+  def new_or_running_sites_with_vacancies_for(course)
     sites = course
       .site_statuses
       .select(&:new_or_running?)
+      .select(&:has_vacancies?)
       .map(&:site)
       .reject do |site|
         # Sites that have no address details whatsoever are not to be considered

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -664,6 +664,19 @@ describe ResultsView do
       )
     end
 
+    let(:site5) do
+      build(
+        :site,
+        latitude: 51.4985,
+        longitude: 0.1358,
+        address1: 'No vacancies road',
+        address2: 'Witham',
+        address3: 'Essex',
+        address4: 'UK',
+        postcode: 'CM8 2SD',
+      )
+    end
+
     let(:course) do
       build(
         :course,
@@ -672,6 +685,7 @@ describe ResultsView do
           build(:site_status, :full_time_and_part_time, site: site2),
           build(:site_status, :full_time_and_part_time, site: site3),
           build(:site_status, :full_time_and_part_time, site: site4, status: 'suspended'),
+          build(:site_status, :full_time_and_part_time, site: site5, has_vacancies?: false),
         ],
       )
     end
@@ -681,7 +695,7 @@ describe ResultsView do
     end
 
     describe '#nearest_address' do
-      it 'returns the address to the nearest site' do
+      it 'returns the address to the nearest site with vacancies' do
         allow(Geokit::LatLng).to receive(:new).and_return(geocoder)
         allow(geocoder).to receive(:distance_to).with('51.4985,0.1367')
         allow(geocoder).to receive(:distance_to).with(',').and_raise(Geokit::Geocoders::GeocodeError)
@@ -701,13 +715,13 @@ describe ResultsView do
     end
 
     describe '#sites_count' do
-      it 'returns the running or new sites count' do
+      it 'returns the running or new sites with vacancies count' do
         expect(results_view.sites_count(course)).to eq(1)
       end
     end
 
     describe '#site_distance' do
-      it 'returns the running or new sites count' do
+      it 'returns the running or new sites with vacancies count' do
         expect(results_view.site_distance(course)).to eq(0.1)
       end
     end


### PR DESCRIPTION
### Context

At the moment, we only filter by whether a sites site status is new or running before calculating things like the nearest site and how many sites are available.

We should also be filtering out sites with no vacancies.

### Changes proposed in this pull request

- Only use sites with vacancies for site related info on the results page 

Locations for course
![image](https://user-images.githubusercontent.com/42515961/117961643-44366500-b316-11eb-95c7-32b294c91ebe.png)

|Before|After|
|------------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/117961905-8c558780-b316-11eb-8b20-15f22a13b1bc.png) |![image](https://user-images.githubusercontent.com/42515961/117961451-0c2f2200-b316-11eb-99e8-aeb76fb8c05d.png)|

### Guidance to review

I checked with Paul and he agrees with the general approach. Am i missing anything?

### Trello card

https://trello.com/c/1tPhJM0Z/3391-bug-find-locations-returned-incorrectly-searching-by-town-name-but-not-by-postcode

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
