### PR TITLE
Don't push to DockerHub for dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Login to DockerHub
+        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.9.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -35,13 +36,14 @@ jobs:
             ${{ runner.os }}-buildx-
       
       - name: Set Environment Variable
-        run:  echo "DOCKER_IMAGE=dfedigital/find-teacher-training:${{ github.sha }}" >> $GITHUB_ENV
+        run: echo "DOCKER_IMAGE=dfedigital/find-teacher-training:${{ github.sha }}" >> $GITHUB_ENV
 
       - name: Build Docker Image
         uses: docker/build-push-action@v2.4.0
         with:
           tags: ${{ env.DOCKER_IMAGE}}
-          push: true
+          push: ${{ github.actor != 'dependabot[bot]' }}
+          load: ${{ github.actor == 'dependabot[bot]' }}
           builder: ${{ steps.buildx.outputs.name }}
           cache-to:   type=local,dest=/tmp/.buildx-cache
           cache-from: type=local,src=/tmp/.buildx-cache
@@ -63,8 +65,8 @@ jobs:
         run: make js.test
 
       - name: Publish Test Coverage to Code Climate
-        run: |
-          make publish.codeclimate
+        if: github.actor != 'dependabot[bot]'
+        run: make publish.codeclimate
         env:
           GIT_BRANCH: ${{ github.ref }}
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}


### PR DESCRIPTION
### Context
Dependabot PRs don't have access to pipeline secrets.

### Changes proposed in this pull request

Don't access secrets when running dependabot PR checks.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
