### PR TITLE
Display age range on the course details page

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -33,6 +33,10 @@
     <dd data-qa="course__qualifications">
       <%= render partial: 'courses/qualification' %>
     </dd>
+    <% if course.age_range_in_years.present? %>
+      <dt class="app-description-list__label">Age range</dt>
+      <dd data-qa="course__age_range"><%= course.age_range_in_years.humanize %></dd>
+    <% end %>
     <% if course.length.present? %>
       <dt class="app-description-list__label">Course length</dt>
       <dd data-qa="course__length"><%= course.length %></dd>

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -23,6 +23,7 @@ describe 'Course show', type: :feature do
       provider_type: provider.provider_type,
       recruitment_cycle: current_recruitment_cycle,
       accrediting_provider: accrediting_provider,
+      age_range_in_years: '11_to_16',
       course_length: 'OneYear',
       applications_open_from: '2019-01-01T00:00:00Z',
       start_date: '2019-09-01T00:00:00Z',
@@ -112,6 +113,10 @@ describe 'Course show', type: :feature do
 
       expect(course_page.qualifications).to have_content(
         'PGCE with QTS',
+      )
+
+      expect(course_page.age_range).to have_content(
+        '11 to 16',
       )
 
       expect(course_page.funding_option).to have_content(

--- a/spec/site_prism/page_objects/page/course.rb
+++ b/spec/site_prism/page_objects/page/course.rb
@@ -47,6 +47,7 @@ module PageObjects
       element :end_of_cycle_notice, '[data-qa=course__end_of_cycle_notice]'
       element :training_location_guidance, '[data-qa=course__training_location_guidance]'
       element :feedback_link, '[data-qa=feedback-link]'
+      element :age_range, '[data-qa=course__age_range]'
     end
   end
 end


### PR DESCRIPTION
### Context

Some providers offer the same course but for different age groups. They input this information on Publish but it is not surfaced on Find automatically. This means that the courses look identical on Find to candidates.

### Changes proposed in this pull request

Added the age range metadata to the summary list, on the course details page:

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/47917431/118519567-25c6d400-b731-11eb-9358-d6e025b0b16c.png)|![image](https://user-images.githubusercontent.com/47917431/118780085-9a118c80-b883-11eb-95e8-38f5a998077d.png)|

### Guidance to review

### Trello card

https://trello.com/c/7GGhiNZp/3387-find-surface-age-range-metadata-from-publish

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
