### PR TITLE
Show a Sandbox phase banner on Sandbox

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -97,8 +97,14 @@
     ) %>
 
     <div class="govuk-width-container">
-      <%= govuk_phase_banner(phase_tag: { text: 'Beta' }) do %>
-        This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
+      <% if Rails.env.sandbox? %>
+        <%= govuk_phase_banner(phase_tag: { text: 'Sandbox', colour: 'purple' }) do %>
+          This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
+        <% end %>
+      <% else %>
+        <%= govuk_phase_banner(phase_tag: { text: 'Beta' }) do %>
+          This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
+        <% end %>
       <% end %>
 
       <%= yield(:before_content) %>


### PR DESCRIPTION
### Changes proposed in this pull request

On Sandbox, show a Sandbox phase banner in the header

<img width="823" alt="Screenshot 2021-05-25 at 21 36 30" src="https://user-images.githubusercontent.com/642279/119564992-4c27e780-bda1-11eb-9c4e-18bec83be3b1.png">

### Checklist

- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
