### PR TITLE
Adapt header based on environment

### DIFF
--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,4 +1,28 @@
 module ViewHelper
+  def environment_colour
+    case Rails.env
+    when 'development'
+      'grey'
+    when 'sandbox'
+      'purple'
+    end
+  end
+
+  def environment_label
+    case Rails.env
+    when 'development'
+      'Development'
+    when 'sandbox'
+      'Sandbox'
+    when 'production'
+      'Beta'
+    end
+  end
+
+  def environment_header_class
+    "app-header--#{Rails.env}"
+  end
+
   def permitted_referrer?
     return false if request.referer.blank?
 
@@ -10,8 +34,14 @@ module ViewHelper
     Settings.service_support.contact_email_address
   end
 
-  def bat_contact_mail_to(name = nil, subject: nil)
-    govuk_mail_to bat_contact_email_address, name || bat_contact_email_address, subject: subject
+  def bat_contact_email_address_with_wrap
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
+    # The <wbr> element will not be copied when copying and pasting the email address
+    bat_contact_email_address.gsub('@', '<wbr>@').html_safe
+  end
+
+  def bat_contact_mail_to(name = nil, **kwargs)
+    govuk_mail_to bat_contact_email_address, name || bat_contact_email_address_with_wrap, **kwargs
   end
 
   def title_with_error_prefix(title, error)

--- a/app/views/courses/_about_schools.html.erb
+++ b/app/views/courses/_about_schools.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
   <div data-qa="course__about_schools">
-    <% if course.program_type == 'higher_education_programme' && course.provider.provider_code != 'B31'  %>
+    <% if course.program_type == 'higher_education_programme' && course.provider.provider_code != 'B31' %>
       <%= render AdviceComponent.new(title: 'Where you will train') do %>
         <%= render partial: 'courses/placement/hei', locals: { course: course } %>
       <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -97,7 +97,6 @@
         <%= render partial: 'courses/about_schools' %>
       <% end %>
 
-
       <%= render partial: 'courses/entry_requirements_qualifications' %>
 
       <% if course.salaried? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -94,17 +94,17 @@
       logo: 'GOV.UK',
       service_name: 'Find postgraduate teacher training',
       service_name_href: root_path,
+      classes: "govuk-!-display-none-print app-header #{environment_header_class}",
     ) %>
 
     <div class="govuk-width-container">
-      <% if Rails.env.sandbox? %>
-        <%= govuk_phase_banner(phase_tag: { text: 'Sandbox', colour: 'purple' }) do %>
-          This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
-        <% end %>
-      <% else %>
-        <%= govuk_phase_banner(phase_tag: { text: 'Beta' }) do %>
-          This is a new service – <%= govuk_link_to 'give feedback or report a problem', 'mailto:becomingateacher@digital.education.gov.uk?subject=Feedback%20about%20Find%20postgraduate%20teacher%20training', class: 'govuk-link--no-visited-state' %>
-        <% end %>
+      <%= govuk_phase_banner(
+        phase_tag: {
+          text: environment_label,
+          colour: environment_colour,
+        },
+      ) do %>
+        This is a new service – <%= bat_contact_mail_to 'give feedback or report a problem', subject: 'Feedback about Find postgraduate teacher training', class: 'govuk-link--no-visited-state' %>
       <% end %>
 
       <%= yield(:before_content) %>

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -19,6 +19,7 @@ $git-brand-colour: #159964;
 @import "components/feedback";
 @import "components/filter";
 @import "components/filter-layout";
+@import "components/header";
 @import "components/list";
 @import "components/map";
 @import "components/pagination";

--- a/app/webpacker/styles/components/_header.scss
+++ b/app/webpacker/styles/components/_header.scss
@@ -1,0 +1,9 @@
+.govuk-header__container {
+  .app-header--development & {
+    border-bottom-color: govuk-colour("dark-grey");
+  }
+
+  .app-header--sandbox & {
+    border-bottom-color: govuk-colour("purple");
+  }
+}


### PR DESCRIPTION
### Context

Find is increasingly including support for different environments. We should adapt the header as we do on other BAT services so that it’s clear which environment is being shown.

### Changes proposed in this pull request

* Updates the header (colour of border, phase tag and phase label) for `development`, `sandbox` and `production` environments
* Updates `bat_contact_mail_to` helper so that can accept `class` and other params available to set on the underlying Rails `mail_to` helper

<img width="1015" alt="Screenshot 2021-05-26 at 15 40 02" src="https://user-images.githubusercontent.com/813383/119680036-c0619a00-be38-11eb-828d-85af22f9552a.png">
<img width="1015" alt="Screenshot 2021-05-26 at 15 39 32" src="https://user-images.githubusercontent.com/813383/119680030-bf306d00-be38-11eb-8cd1-7081a9659484.png">
<img width="1015" alt="Screenshot 2021-05-26 at 15 40 26" src="https://user-images.githubusercontent.com/813383/119680041-c0fa3080-be38-11eb-9c10-97c14eb498ae.png">


### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
