### PR TITLE
Update govuk-components to v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ gem 'skylight'
 
 # Allows the creation of components which encapsulate and test logic in views
 gem 'view_component'
-gem 'govuk-components'
+gem 'govuk-components', '~> 2.0.1'
 
 # Data integration with BigQuery
 gem 'google-cloud-bigquery'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,10 +210,10 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (~> 0.14)
-    govuk-components (1.2.0)
+    govuk-components (2.0.1)
       activemodel (>= 6.0)
       railties (>= 6.0)
-      view_component (~> 2.20)
+      view_component (~> 2.36.0)
     govuk_design_system_formbuilder (2.7.2)
       actionview (>= 6.0)
       activemodel (>= 6.0)
@@ -278,7 +278,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nio4r (2.5.8)
-    nokogiri (1.12.3)
+    nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     os (1.1.1)
@@ -449,7 +449,7 @@ GEM
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unicode-display_width (2.0.0)
-    view_component (2.38.0)
+    view_component (2.36.0)
       activesupport (>= 5.0.0, < 8.0)
       method_source (~> 1.0)
     web-console (4.1.0)
@@ -498,7 +498,7 @@ DEPENDENCIES
   geocoder
   geokit
   google-cloud-bigquery
-  govuk-components
+  govuk-components (~> 2.0.1)
   govuk_design_system_formbuilder (~> 2.7.2)
   httparty
   json-schema

--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -1,13 +1,13 @@
 <% if CycleTimetable.show_apply_1_deadline_banner? %>
-  <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year") %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year") %>
     <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
     <p class="govuk-body">If you’re applying for the first time since applications opened in <%= CycleTimetable.find_opens.to_s(:month_and_year) %>, apply no later than <%= apply_1_deadline %>.</p>
     <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_apply_2_deadline_banner? %>
-  <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{find_opens}") %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "If you’re applying for the first time since applications opened in #{find_opens}") %>
     <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= CycleTimetable.cycle_year_range %> academic year.</p>
     <p class="govuk-body">You can <%= govuk_link_to('start or continue your application', Settings.apply_base_url) %> to get it ready for courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
     <p class="govuk-body">You’ll be able to find courses from <%= find_reopens %> and submit your application from <%= apply_reopens %>.</p>
@@ -16,8 +16,8 @@
     <p class="govuk-body">You can continue to view and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_cycle_closed_banner? %>
-  <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "Courses are currently closed but you can get your application ready") %>
+  <%= govuk_notification_banner(title_text: "Important") do |notification_banner| %>
+    <% notification_banner.heading(text: "Courses are currently closed but you can get your application ready") %>
     <p class="govuk-body">Courses starting in the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
     <p class="govuk-body">You can <%= govuk_link_to('start or continue your application', Settings.apply_base_url) %> to get it ready for courses starting in the <%= CycleTimetable.next_cycle_year_range %> academic year.</p>
     <p class="govuk-body">You’ll be able to find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> and submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.</p>

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -1,11 +1,12 @@
-<%= govuk_summary_list do |component| %>
+<%= govuk_summary_list do |summary_list| %>
   <% rows.each do |row| %>
-    <%= component.slot(
-      :row,
-      key: row[:key],
-      value: value(row),
-      action: action(row),
-      html_attributes: html_attributes(row),
-    ) %>
+    <% summary_list.row(html_attributes: html_attributes(row)) do |summary_list_row| %>
+      <% summary_list_row.key { row[:key] } %>
+      <% summary_list_row.value { value(row) } %>
+
+      <% Array.wrap(row[:action] || row[:actions] || { href: '' }).each do |action| %>
+        <% summary_list_row.action(classes: 'govuk-!-display-none-print', **action) %>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -10,39 +10,20 @@ class SummaryListComponent < ViewComponent::Base
     if row[:value].is_a?(Array)
       if row[:bulleted_format]
         format_list_with_bullets(row[:value])
+      elsif row[:paragraph_format]
+        format_list_as_paragraphs(row[:value])
       else
         row[:value].map { |s| ERB::Util.html_escape(s) }.join('<br>').html_safe
       end
     elsif row[:value].html_safe?
-      row[:value]
+      row[:value].to_s
     else
       simple_format(row[:value], class: 'govuk-body')
     end
   end
 
-  def action(row)
-    if row[:change_path]
-      govuk_link_to(row[:change_path], class: 'govuk-!-display-none-print') do
-        "Change<span class=\"govuk-visually-hidden\"> #{row[:action]}</span>".html_safe
-      end
-    elsif row[:action_path]
-      govuk_link_to(row[:action], row[:action_path], class: 'govuk-!-display-none-print')
-    elsif row[:actions]
-      links = row[:actions].map do |action|
-        govuk_link_to(action[:path], class: 'govuk-!-display-none-print') do
-          "#{action[:verb]}<span class=\"govuk-visually-hidden\"> #{action[:object]}</span>".html_safe
-        end
-      end
-      links.join('<br>').html_safe
-    end
-  end
-
   def html_attributes(row)
-    if row[:data_qa]
-      { 'data-qa' => row[:data_qa] }
-    else
-      {}
-    end
+    row[:html_attributes] || {}
   end
 
 private
@@ -59,10 +40,12 @@ private
   end
 
   def format_list_with_bullets(list)
-    markup = '<ul class="govuk-list govuk-list--bullet">'.html_safe
-    list.map do |list_item|
-      markup << '<li>'.html_safe << list_item << '</li>'.html_safe
+    tag.ul(class: 'govuk-list govuk-list--bullet') do
+      safe_join(list.map { |item| tag.li(item) })
     end
-    markup + '</ul>'.html_safe
+  end
+
+  def format_list_as_paragraphs(list)
+    safe_join(list.map { |s| tag.p(class: 'govuk-body') { ERB::Util.html_escape(s) } })
   end
 end

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -9,13 +9,10 @@ module ViewHelper
   end
 
   def environment_label
-    case Rails.env
-    when 'development'
-      'Development'
-    when 'sandbox'
-      'Sandbox'
-    when 'production'
+    if Rails.env.production?
       'Beta'
+    else
+      Rails.env.humanize
     end
   end
 

--- a/app/views/courses/_apply_button.html.erb
+++ b/app/views/courses/_apply_button.html.erb
@@ -1,5 +1,5 @@
 <p class="govuk-body">
-  <%= govuk_start_now_button(
+  <%= govuk_start_button(
     text: 'Apply for this course',
     href: apply_path(provider_code: course.provider.provider_code, course_code: course.course_code),
     html_attributes: {

--- a/app/views/courses/_no_vacancies_warning.html.erb
+++ b/app/views/courses/_no_vacancies_warning.html.erb
@@ -1,1 +1,1 @@
-<%= govuk_warning(text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.') %>
+<%= govuk_warning_text(text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.') %>

--- a/app/views/courses/qualification/_pgce.html.erb
+++ b/app/views/courses/qualification/_pgce.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary: 'PGCE') do %>
+<%= govuk_details(summary_text: 'PGCE') do %>
   <p class="govuk-body">
     A postgraduate certificate in education (PGCE) is an academic qualification in education.
   </p>

--- a/app/views/courses/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgce_with_qts.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary: 'PGCE with QTS') do %>
+<%= govuk_details(summary_text: 'PGCE with QTS') do %>
   <p class="govuk-body">
     A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>

--- a/app/views/courses/qualification/_pgde.html.erb
+++ b/app/views/courses/qualification/_pgde.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary: 'PGDE') do %>
+<%= govuk_details(summary_text: 'PGDE') do %>
   <p class="govuk-body">
     A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
   </p>

--- a/app/views/courses/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgde_with_qts.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary: 'PGDE with QTS') do %>
+<%= govuk_details(summary_text: 'PGDE with QTS') do %>
   <p class="govuk-body">
     A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_details(summary: 'QTS') do %>
+<%= govuk_details(summary_text: 'QTS') do %>
   <p class="govuk-body">
     Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
   </p>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,5 +1,5 @@
 <li class="app-pagination__item app-pagination__item--next">
-  <%= govuk_link_to url, rel: 'next', remote: remote, class: 'govuk-link--no-visited-state app-pagination__link' do %>
+  <%= govuk_link_to url, rel: 'next', remote: remote, no_visited_state: true, class: 'app-pagination__link' do %>
     <span class="app-pagination__link-title">
       Next page
       <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,5 +1,5 @@
 <li class="app-pagination__item app-pagination__item--previous">
-  <%= govuk_link_to url, rel: 'prev', remote: remote, class: 'govuk-link--no-visited-state app-pagination__link' do %>
+  <%= govuk_link_to url, rel: 'prev', remote: remote, no_visited_state: true, class: 'app-pagination__link' do %>
     <span class="app-pagination__link-title">
       <svg class="app-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
         <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,20 +91,19 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-      logo: 'GOV.UK',
       service_name: 'Find postgraduate teacher training',
-      service_name_href: root_path,
+      service_url: root_path,
       classes: "govuk-!-display-none-print app-header #{environment_header_class}",
     ) %>
 
     <div class="govuk-width-container">
       <%= govuk_phase_banner(
-        phase_tag: {
+        tag: {
           text: environment_label,
           colour: environment_colour,
         },
       ) do %>
-        This is a new service – <%= bat_contact_mail_to 'give feedback or report a problem', subject: 'Feedback about Find postgraduate teacher training', class: 'govuk-link--no-visited-state' %>
+        This is a new service – <%= bat_contact_mail_to 'give feedback or report a problem', subject: 'Feedback about Find postgraduate teacher training', no_visited_state: true %>
       <% end %>
 
       <%= yield(:before_content) %>
@@ -112,12 +111,12 @@
       <main class="govuk-main-wrapper" id="main-content" role="main">
         <% if flash[:success] %>
           <%= govuk_notification_banner(
-            title: 'Success',
+            title_text: 'Success',
             success: true,
             title_id: 'success-message',
             html_attributes: { role: 'alert' },
           ) do |notification_banner| %>
-            <%= notification_banner.slot(:heading, text: flash[:success]) %>
+            <% notification_banner.heading(text: flash[:success]) %>
           <% end %>
         <% end %>
 
@@ -137,7 +136,7 @@
     <% end %>
 
     <%= govuk_footer do |footer| %>
-      <%= footer.slot(:meta) do %>
+      <%= footer.meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
           <h2 class="govuk-heading-m">Get support</h2>
           <div class="govuk-grid-row govuk-!-margin-bottom-5">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,65 +25,61 @@
     </script>
 
     <% unless current_page?(cookie_preferences_path) %>
+      <% heading_text = 'Cookies on Find postgraduate teacher training' %>
       <%= govuk_cookie_banner(
-        title: 'Cookies on Find postgraduate teacher training',
         html_attributes: {
-          hidden: true,
           aria: {
-            label: 'Cookies on Find postgraduate teacher training',
+            label: heading_text,
           },
+          classes: 'govuk-!-display-none-print',
           data: {
             module: 'govuk-cookie-banner',
             qa: 'cookie-banner',
           },
         },
       ) do |cookie_banner| %>
-        <%= cookie_banner.body do %>
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-        <% end %>
-        <%= cookie_banner.actions do %>
-          <button type="button" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
-          <button type="button" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
-          <%= govuk_link_to('View cookies', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) %>
-        <% end %>
-      <% end %>
-
-      <%= govuk_cookie_banner(
-        html_attributes: {
+        <% cookie_banner.message(
+          heading_text: heading_text,
           hidden: true,
-          aria: {
-            label: 'Cookies on Find postgraduate teacher training',
-          },
-          data: {
-            module: 'govuk-hide-cookie-banner',
-            qa: 'hide-cookie-banner',
-          },
-        },
-      ) do |cookie_banner| %>
-        <%= cookie_banner.body do %>
-          <p>You’ve <span id="user-answer"></span> analytics cookies. You can <%= govuk_link_to('change your cookie settings', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) %> at any time.</p>
+          html_attributes: {
+            data: {
+              module: 'govuk-cookie-banner-choice-message',
+              qa: 'cookie-banner-choice-message',
+            },
+          }
+        ) do |message| %>
+          <p>We use some essential cookies to make this service work.</p>
+          <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
+          <% message.action { button_tag('Accept analytics cookies', class: 'govuk-button', data: { 'accept-cookie': 'true' }) } %>
+          <% message.action { button_tag('Reject analytics cookies', class: 'govuk-button', data: { 'accept-cookie': 'false' }) } %>
+          <% message.action { govuk_link_to('View cookies', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) } %>
         <% end %>
-        <%= cookie_banner.actions do %>
-          <button type="button" class="govuk-button" data-accept-cookie="hide-banner">Hide this message</button>
-        <% end %>
-      <% end %>
 
-      <%= govuk_cookie_banner(
-        title: 'Cookies on Find postgraduate teacher training',
-        html_attributes: {
+        <% cookie_banner.message(
+          heading_text: heading_text,
+          hidden: true,
+          html_attributes: {
+            data: {
+              module: 'govuk-cookie-banner-confirmation-message',
+              qa: 'cookie-banner-confirmation-message',
+            },
+          }
+        ) do |message| %>
+          <p>You’ve <span id="user-answer"></span> analytics cookies. You can <%= govuk_link_to('change your cookie settings', cookie_preferences_path, data: { qa: 'cookie-banner__preference-link' }) %> at any time.</p>
+          <% message.action { button_tag('Hide this message', class: 'govuk-button', data: { 'accept-cookie': 'hide-banner' }) } %>
+        <% end %>
+
+        <% cookie_banner.message(
+          heading_text: heading_text,
           hidden: false,
-          aria: {
-            label: 'Cookies on Find postgraduate teacher training',
-          },
-          data: {
-            module: 'govuk-fallback-cookie-banner',
-            qa: 'fallback-cookie-banner',
-          },
-        },
-      ) do |cookie_banner| %>
-        <%= cookie_banner.body do %>
-          <p class="govuk-body">We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
+          html_attributes: {
+            data: {
+              module: 'govuk-cookie-banner-fallback-message',
+              qa: 'cookie-banner-fallback-message',
+            },
+          }
+        ) do |message| %>
+          <p>We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/result_filters/provider/new.html.erb
+++ b/app/views/result_filters/provider/new.html.erb
@@ -20,7 +20,7 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
     <div>
-      <%= govuk_details(summary: 'Try another provider') do %>
+      <%= govuk_details(summary_text: 'Try another provider') do %>
         <%= form_with url: provider_path, method: :get, data: { 'ga-event-form' => 'Provider' } do |form| %>
           <fieldset class="govuk-fieldset">
             <div class="govuk-form-group">

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -10,8 +10,8 @@
 
       <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
         <% @subject_areas.each_with_index do |subject_area, counter| %>
-          <%= accordion.add_section(
-            title: subject_area.name,
+          <%= accordion.section(
+            heading_text: subject_area.name,
             expanded: subject_area_is_selected?(subject_area: subject_area) || (counter.zero? && no_subject_selected_error?),
             html_attributes: {
               data: { qa: 'subject_area' },
@@ -69,8 +69,8 @@
             </fieldset>
           <% end %>
         <% end %>
-        <%= accordion.add_section(
-          title: 'Special educational needs and disability (SEND)',
+        <%= accordion.section(
+          heading_text: 'Special educational needs and disability (SEND)',
           expanded: params[:senCourses] == 'true',
           html_attributes: {
             data: { qa: 'send_area' },

--- a/app/views/results/_university.html.erb
+++ b/app/views/results/_university.html.erb
@@ -7,7 +7,7 @@
         <span class="app-description-list__hint govuk-!-margin-top-0">University</span>
       <% else %>
         <span class="app-description-list__hint govuk-!-margin-top-0">Placement schools</span>
-        <%= govuk_details(summary: @results_view.placement_schools_summary(course)) do %>
+        <%= govuk_details(summary_text: @results_view.placement_schools_summary(course)) do %>
           <p>You can’t pick which schools you want to be in, but your university will try to place you in schools you can commute to.</p>
           <p>Universities usually work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
           <%= govuk_link_to 'More about placements on this course', course_path(provider_code: course.provider_code, course_code: course.course_code, anchor: 'section-schools') %>

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -42,7 +42,6 @@
               <%= form.submit('Update', name: nil, class: 'govuk-button', data: { qa: 'sort-form__submit' }) %>
             <% end %>
           <% end %>
-
         </div>
       <% end %>
     <% end %>

--- a/app/webpacker/scripts/cookie-banner.js
+++ b/app/webpacker/scripts/cookie-banner.js
@@ -5,30 +5,21 @@ import {setConsentedToCookie,
 
 export default class CookieBanner {
   constructor() {
-    this.$fallbackModule = document.querySelector('[data-module="govuk-fallback-cookie-banner"]')
+    this.$fallbackMessageModule = document.querySelector('[data-module="govuk-cookie-banner-fallback-message"]')
 
-    //If the page doesn't have the fallback banner then stop
-    if (!this.$fallbackModule) {
+    // If the page doesn't have the fallback banner then stop
+    if (!this.$fallbackMessageModule) {
       return;
     }
 
-    this.$fallbackModule.hidden = true;
+    this.$fallbackMessageModule.hidden = true;
 
-    this.$cookieModule = document.querySelector('[data-module="govuk-cookie-banner"]');
-
-    this.$hideMessageModule = document.querySelector('[data-module="govuk-hide-cookie-banner"]');
-
-    this.acceptButton = this.$cookieModule.querySelector(
-      '[data-accept-cookie="true"]'
-    );
-
-    this.rejectButton = this.$cookieModule.querySelector(
-      '[data-accept-cookie="false"]'
-    );
-
-    this.hideMessageButton = this.$hideMessageModule.querySelector(
-      '[data-accept-cookie="hide-banner"]'
-    );
+    this.$cookieBannerModule = document.querySelector('[data-module="govuk-cookie-banner"]');
+    this.$choiceMessageModule = document.querySelector('[data-module="govuk-cookie-banner-choice-message"]');
+    this.$confirmationMessageModule = document.querySelector('[data-module="govuk-cookie-banner-confirmation-message"]');
+    this.acceptButton = this.$choiceMessageModule.querySelector('[data-accept-cookie="true"]');
+    this.rejectButton = this.$choiceMessageModule.querySelector('[data-accept-cookie="false"]');
+    this.hideMessageButton = this.$confirmationMessageModule.querySelector('[data-accept-cookie="hide-banner"]');
 
     // consentCookie is false if user has not accept/rejected cookies
     if (!checkConsentedToCookieExists()) {
@@ -36,42 +27,45 @@ export default class CookieBanner {
       removeAllPreviousUsedCookies()
       this.showCookieMessage();
       this.bindEvents();
+    } else {
+      // TODO: Remove this once this is hidden server side
+      this.hideModule(this.$cookieBannerModule);
     }
   }
 
   bindEvents() {
     this.acceptButton.addEventListener("click", () => this.acceptCookie());
-    this.acceptButton.addEventListener("click", () => this.showHideMessage("accepted"));
+    this.acceptButton.addEventListener("click", () => this.showConfirmationMessage("accepted"));
     this.rejectButton.addEventListener("click", () => this.rejectCookie());
-    this.rejectButton.addEventListener("click", () => this.showHideMessage("rejected"));
-    this.hideMessageButton.addEventListener("click", () => this.hideMessage());
+    this.rejectButton.addEventListener("click", () => this.showConfirmationMessage("rejected"));
+    this.hideMessageButton.addEventListener("click", () => this.hideCookieBanner());
   }
 
   acceptCookie() {
-    this.hideBannerMessage(this.$cookieModule);
+    this.hideModule(this.$choiceMessageModule);
     setConsentedToCookie(true);
     loadAnalytics();
   }
 
   rejectCookie() {
-    this.hideBannerMessage(this.$cookieModule);
+    this.hideModule(this.$choiceMessageModule);
     setConsentedToCookie(false);
   }
 
-  showHideMessage(content) {
-    this.$hideMessageModule.hidden = false;
-    this.$hideMessageModule.querySelector('[id="user-answer"]').textContent=`${content}`;
+  showConfirmationMessage(content) {
+    this.$confirmationMessageModule.hidden = false;
+    this.$confirmationMessageModule.querySelector('[id="user-answer"]').textContent=`${content}`;
   }
 
-  hideMessage(){
-    this.hideBannerMessage(this.$hideMessageModule);
+  hideCookieBanner() {
+    this.hideModule(this.$cookieBannerModule);
   }
 
   showCookieMessage() {
-    this.$cookieModule.hidden = false;
+    this.$choiceMessageModule.hidden = false;
   }
 
-  hideBannerMessage(module) {
+  hideModule(module) {
     module.hidden = true;
   }
 }

--- a/app/webpacker/scripts/cookie-banner.spec.js
+++ b/app/webpacker/scripts/cookie-banner.spec.js
@@ -9,76 +9,57 @@ jest.mock('./analytics', () => {
 jest.mock('./cookie-helper')
 
 import CookieBanner from './cookie-banner'
-import { loadAnalytics } from './analytics'
-import {setConsentedToCookie, fetchConsentedToCookieValue,checkConsentedToCookieExists} from './cookie-helper'
+import {checkConsentedToCookieExists} from './cookie-helper'
 
 const templateHTML = `
-<div class="govuk-cookie-banner" role="region" aria-label="Cookie banner" data-module="govuk-cookie-banner" data-qa="cookie-banner" hidden>
-  <div class="govuk-cookie-banner__message govuk-width-container">
+<div class="govuk-cookie-banner" role="region" aria-label="Cookies on Find postgraduate teacher training" data-module="govuk-cookie-banner" data-qa="cookie-banner">
+  <div class="govuk-cookie-banner__message govuk-width-container" hidden="hidden" data-module="govuk-cookie-banner-choice-message" data-qa="cookie-banner-choice-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-            Cookies on Find postgraduate teacher training
-          </h2>
-
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
         <div class="govuk-cookie-banner__content">
-
-          <p class="govuk-body">We use some essential cookies to make this service work.</p>
-          <p class="govuk-body">We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
-
+          <p>We use some essential cookies to make this service work.</p>
+          <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
         </div>
       </div>
     </div>
 
     <div class="govuk-button-group">
-
-          <button type="button" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
-          <button type="button" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
-          <a data-qa="cookie-banner__preference-link" class="govuk-link" href="/cookies">View cookies</a>
-
+      <button name="button" type="submit" class="govuk-button" data-accept-cookie="true">Accept analytics cookies</button>
+      <button name="button" type="submit" class="govuk-button" data-accept-cookie="false">Reject analytics cookies</button>
+      <a data-qa="cookie-banner__preference-link" class="govuk-link" href="/cookies">View cookies</a>
     </div>
   </div>
-</div>
 
-<div class="govuk-cookie-banner" role="region" aria-label="Cookie banner" hidden="hidden" data-module="govuk-hide-cookie-banner" data-qa="cookie-banner">
-  <div class="govuk-cookie-banner__message govuk-width-container">
+  <div class="govuk-cookie-banner__message govuk-width-container" hidden="hidden" data-module="govuk-cookie-banner-confirmation-message" data-qa="cookie-banner-confirmation-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
         <div class="govuk-cookie-banner__content">
-
-          <p>You’ve <span id="user-answer"></span> analytics cookies. You can <a data-qa="cookie-banner__preference-link" class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
-
+          <p>
+            You’ve
+            <span id="user-answer"></span>
+              analytics cookies. You can
+            <a data-qa="cookie-banner__preference-link" class="govuk-link" href="/cookies">change your cookie settings</a>
+              at any time.
+          </p>
         </div>
       </div>
     </div>
 
     <div class="govuk-button-group">
-
-          <button type="button" class="govuk-button" data-accept-cookie="hide-banner">Hide this message</button>
-
+      <button name="button" type="submit" class="govuk-button" data-accept-cookie="hide-banner">Hide this message</button>
     </div>
   </div>
-</div>
 
-<div class="govuk-cookie-banner" role="region" aria-label="Cookie banner" data-module="govuk-fallback-cookie-banner" data-qa="cookie-banner" hidden="">
-  <div class="govuk-cookie-banner__message govuk-width-container">
+  <div class="govuk-cookie-banner__message govuk-width-container" data-module="govuk-cookie-banner-fallback-message" data-qa="cookie-banner-fallback-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-          <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-            Cookies on Find postgraduate teacher training
-          </h2>
-
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
         <div class="govuk-cookie-banner__content">
-
-          <p class="govuk-body">We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
-
+          <p>We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
         </div>
       </div>
-    </div>
-
-    <div class="govuk-button-group">
-
     </div>
   </div>
 </div>`;
@@ -98,91 +79,96 @@ describe('CookieBanner', () => {
       jest.clearAllMocks()
     })
 
-    it('doesn\'t run if theres no cookie banner markup', () => {
+    it('doesn’t run if theres no cookie banner markup', () => {
       document.body.innerHTML = ''
       const banner = new CookieBanner()
-      expect(banner.$fallbackModule).toBeNull()
-    } )
+
+      expect(banner.$fallbackMessageModule).toBeNull()
+    })
 
     it('binds events to all banner buttons', () => {
       checkConsentedToCookieExists.mockImplementationOnce(() => false);
       jest.spyOn(CookieBanner.prototype, 'bindEvents');
       new CookieBanner()
+
       expect(CookieBanner.prototype.bindEvents).toHaveBeenCalledTimes(1)
     })
 
-    it('displays the Cookie Banner only if user has not consented/rejected', () => {
-
+    it('displays the cookie banner only if user has not consented/rejected', () => {
       checkConsentedToCookieExists.mockImplementationOnce(() => false);
-
       const banner = new CookieBanner()
-      expect(banner.$cookieModule.hidden).toBeFalsy()
-      expect(banner.$fallbackModule.hidden).toBeTruthy()
 
+      expect(banner.$cookieBannerModule.hidden).toBeFalsy()
+      expect(banner.$fallbackMessageModule.hidden).toBeTruthy()
     })
 
-    it('hides the Cookie Banner if user has consented/rejected', () => {
+    it('hides the cookie banner if user has already consented/rejected', () => {
       checkConsentedToCookieExists.mockImplementationOnce(() => true );
-
       const banner = new CookieBanner()
-      expect(banner.$cookieModule.hidden).toBeTruthy()
+
+      expect(banner.$cookieBannerModule.hidden).toBeTruthy()
     })
   })
 
   describe('acceptCookie', () => {
-    it('hides the cookie banner once a user has accepted cookies', () => {
+    it('hides the cookie choice message once a user has accepted cookies', () => {
       const banner = new CookieBanner()
       banner.acceptCookie()
-      expect(banner.$cookieModule.hidden).toBeTruthy()
 
+      expect(banner.$choiceMessageModule.hidden).toBeTruthy()
     })
 
     it('sets consented-to-cookies', () => {
       checkConsentedToCookieExists.mockImplementationOnce(() => null);
       const banner = new CookieBanner()
       banner.acceptCookie()
+
       expect(checkConsentedToCookieExists).toBeTruthy()
     })
   })
 
   describe('rejectCookie', () => {
-    it('hides the cookie banner once a user has rejected cookies', () => {
+    it('hides the cookie choice message once a user has rejected cookies', () => {
       const banner = new CookieBanner()
       banner.rejectCookie()
-      expect(banner.$cookieModule.hidden).toBeTruthy()
+
+      expect(banner.$choiceMessageModule.hidden).toBeTruthy()
     })
 
     it('sets consented-to-cookies', () => {
       checkConsentedToCookieExists.mockImplementationOnce(() => null);
       const banner = new CookieBanner()
       banner.rejectCookie()
+
       expect(checkConsentedToCookieExists).toBeTruthy()
     })
   })
 
-  describe('showAcceptedHideMessage', () => {
-    it('shows the hide message banner with "accepted" content', () => {
+  describe('showConfirmationMessage', () => {
+    it('shows the confirmation message with "accepted" content', () => {
       const banner = new CookieBanner()
-      banner.showHideMessage("accepted")
-      expect(banner.$hideMessageModule.hidden).toBeFalsy()
-      expect(banner.$hideMessageModule.querySelector('[id="user-answer"]').innerHTML).toEqual('accepted')
+      banner.showConfirmationMessage("accepted")
+
+      expect(banner.$confirmationMessageModule.hidden).toBeFalsy()
+      expect(banner.$confirmationMessageModule.querySelector('[id="user-answer"]').innerHTML).toEqual('accepted')
     })
 
-    it('shows the hide message banner with "rejected" content', () => {
+    it('shows the confirmation message with "rejected" content', () => {
       const banner = new CookieBanner()
-      banner.showHideMessage("rejected")
-      expect(banner.$hideMessageModule.hidden).toBeFalsy()
-      expect(banner.$hideMessageModule.querySelector('[id="user-answer"]').innerHTML).toEqual('rejected')
-    })
+      banner.showConfirmationMessage("rejected")
 
+      expect(banner.$confirmationMessageModule.hidden).toBeFalsy()
+      expect(banner.$confirmationMessageModule.querySelector('[id="user-answer"]').innerHTML).toEqual('rejected')
+    })
   })
 
-  describe('hideMessage', () => {
-    it('hides the hide message banner' , () => {
+  describe('hideCookieBanner', () => {
+    it('hides the cookie banner' , () => {
       const banner = new CookieBanner()
-      banner.showHideMessage()
-      banner.hideMessage()
-      expect(banner.$hideMessageModule.hidden).toBeTruthy()
+      banner.showConfirmationMessage()
+      banner.hideCookieBanner()
+
+      expect(banner.$cookieBannerModule.hidden).toBeTruthy()
     })
   })
 })

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -5,39 +5,75 @@ describe SummaryListComponent, type: :component do
     rows = [
       key: 'Name:',
       value: 'Lando Calrissian',
-      action: 'Name',
-      change_path: '/some/url',
+      action: {
+        href: '/some/url',
+        visually_hidden_text: 'name',
+      },
     ]
     result = render_inline(described_class.new(rows: rows))
 
     expect(result.css('.govuk-summary-list__key').text).to include('Name:')
     expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
     expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/some/url')
-    expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
+    expect(result.css('.govuk-summary-list__actions').text).to include('Change name')
   end
 
   describe 'array content' do
     it 'renders array content when passed in' do
       rows = [
-        key: 'Address:',
+        key: 'Address',
         value: ['Whoa Drive', 'Wewvile', 'London'],
-        action: 'Name',
-        change_path: '/some/url',
+        action: {
+          href: '/some/url',
+          visually_hidden_text: 'address',
+        },
       ]
       result = render_inline(described_class.new(rows: rows))
 
       expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
     end
 
+    it 'renders values surrounded by <p> tags if specified for the row' do
+      rows = [
+        key: 'Address',
+        value: %w[A list of items],
+        paragraph_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      html = <<~HTML
+        <p class="govuk-body">A</p>
+        <p class="govuk-body">list</p>
+        <p class="govuk-body">of</p>
+        <p class="govuk-body">items</p>
+      HTML
+
+      expect(result.to_html).to include html.chomp
+    end
+
+    it 'safely escapes markup when rendering values as <p> tags' do
+      rows = [
+        key: 'Address',
+        value: ['<script></script>', '<br>'],
+        paragraph_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <p class="govuk-body">&lt;script&gt;&lt;/script&gt;</p>
+        <p class="govuk-body">&lt;br&gt;</p>
+      HTML
+    end
+
     it 'renders values as bullets if specified for the row' do
       rows = [
-        key: 'Address:',
+        key: 'Address',
         value: %w[A list of items],
         bulleted_format: true,
       ]
       result = render_inline(described_class.new(rows: rows))
 
-      expect(result.to_html).to include(<<~HTML)
+      html = <<~HTML
         <ul class="govuk-list govuk-list--bullet">
         <li>A</li>
         <li>list</li>
@@ -45,22 +81,26 @@ describe SummaryListComponent, type: :component do
         <li>items</li>
         </ul>
       HTML
+
+      expect(result.to_html).to include html.chomp
     end
 
     it 'safely escapes markup when rendering values as bullets' do
       rows = [
-        key: 'Address:',
+        key: 'Address',
         value: ['<script></script>', '<br>'],
         bulleted_format: true,
       ]
       result = render_inline(described_class.new(rows: rows))
 
-      expect(result.to_html).to include(<<~HTML)
+      html = <<~HTML
         <ul class="govuk-list govuk-list--bullet">
         <li>&lt;script&gt;&lt;/script&gt;</li>
         <li>&lt;br&gt;</li>
         </ul>
       HTML
+
+      expect(result.to_html).to include html.chomp
     end
   end
 
@@ -68,8 +108,10 @@ describe SummaryListComponent, type: :component do
     rows = [
       key: 'Please enter the sound a cat makes',
       value: 'Meow',
-      action: 'Enter cat sounds',
-      action_path: '/cat/sounds',
+      action: {
+        text: 'Enter cat sounds',
+        href: '/cat/sounds',
+      },
     ]
     result = render_inline(described_class.new(rows: rows))
 
@@ -102,7 +144,11 @@ describe SummaryListComponent, type: :component do
   it 'supports adding data_qa to rows' do
     rows = [{ key: 'Job',
               value: 'Ice cream man',
-              data_qa: 'ice-cream-man' }]
+              html_attributes: {
+                data: {
+                  qa: 'ice-cream-man',
+                },
+              } }]
 
     result = render_inline(described_class.new(rows: rows))
 
@@ -114,8 +160,8 @@ describe SummaryListComponent, type: :component do
       { key: 'Role',
         value: 'Chef de partie',
         actions: [
-          { verb: 'Change', object: 'role', path: '#change-role' },
-          { verb: 'Remove', object: 'this chef', path: '#remove' },
+          { text: 'Change', visually_hidden_text: 'role', href: '#change-role' },
+          { text: 'Remove', visually_hidden_text: 'this chef', href: '#remove' },
         ] },
     ]
 

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -35,19 +35,19 @@ describe 'cookie banner', type: :feature do
   end
 
   it 'renders a visible js fallback banner' do
-    expect(page).to have_selector('[data-qa="fallback-cookie-banner"]')
+    expect(page).to have_selector('[data-qa="cookie-banner-fallback-message"]')
     expect(page).to have_text('To accept or reject cookies, turn on JavaScript')
   end
 
   it 'renders a hidden cookie banner' do
-    expect(page).to have_selector('[data-qa="cookie-banner"]', visible: :hidden)
+    expect(page).to have_selector('[data-qa="cookie-banner-choice-message"]', visible: :hidden)
     expect(page).to have_button('Accept analytics cookies', visible: :hidden)
     expect(page).to have_button('Reject analytics cookies', visible: :hidden)
     expect(page).to have_link('View cookies', visible: :hidden)
   end
 
   it 'renders a hidden hide message banner' do
-    expect(page).to have_selector('[data-qa="hide-cookie-banner"]', visible: :hidden)
+    expect(page).to have_selector('[data-qa="cookie-banner-confirmation-message"]', visible: :hidden)
     expect(page).to have_link('View cookies', visible: :hidden)
     expect(page).to have_button('Hide this message', visible: :hidden)
   end


### PR DESCRIPTION
### Context

A new version of [`govuk-components`](https://github.com/DFE-Digital/govuk-components) has been released. It contains a number of breaking changes, so this PR addresses any issues caused by moving to the new version.

### Changes proposed in this pull request

* Update Gemfile to point to v2.0.1
* Fix issues arising from breaking changes in the components used by this app
* The cookie banner component is now one component that takes multiple messages; updated the JavaScript (and related tests) to reflect this change. 

### Guidance to review

Might want to pay particular attention to the changes around the cookie banner component.

FYI @peteryates

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
