### PR TITLE
Add a heading for Apply section on course pages

### DIFF
--- a/app/views/courses/_apply.html.erb
+++ b/app/views/courses/_apply.html.erb
@@ -2,7 +2,9 @@
   <script src="https://maps.googleapis.com/maps/api/js?key=<%= Settings.google.maps_api_key %>&callback=initLocationsMap" async defer></script>
 <% end %>
 
-<div class="govuk-!-margin-bottom-8" id="section-apply">
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
+
   <% if @course.has_vacancies? %>
     <%= render 'apply_button' %>
 


### PR DESCRIPTION
### Context

Since we decided to always show locations in this section, it is no longer the case that this section shows the button alone. This means we should add a section heading, to differentiate it from the section above.

### Changes proposed in this pull request

| Before | After |
| - | - |
| <img width="680" alt="Screenshot 2021-06-28 at 13 22 39" src="https://user-images.githubusercontent.com/813383/123636961-59f3e100-d815-11eb-8a24-0f5216f637f7.png"> | <img width="680" alt="Screenshot 2021-06-28 at 13 31 37" src="https://user-images.githubusercontent.com/813383/123636969-5c563b00-d815-11eb-9392-6da3acf1e241.png"> |
| <img width="670" alt="Screenshot 2021-06-28 at 13 23 10" src="https://user-images.githubusercontent.com/813383/123636966-5b250e00-d815-11eb-8558-980fa99b2983.png"> | <img width="680" alt="Screenshot 2021-06-28 at 13 30 49" src="https://user-images.githubusercontent.com/813383/123636967-5bbda480-d815-11eb-9738-fedaf97afd3a.png"> |

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
