### PR TITLE
[3512] update web_request event format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,9 @@ gem 'jsonapi-deserializable'
 gem 'jsonapi-renderer'
 gem 'jsonapi-serializable'
 
+# Validate JSON schema
+gem 'json-schema'
+
 # Settings for the app
 gem 'config'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,8 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     json_api_client (1.18.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -485,6 +487,7 @@ DEPENDENCIES
   google-cloud-bigquery
   govuk-components
   httparty
+  json-schema
   json_api_client
   jsonapi-deserializable
   jsonapi-renderer

--- a/app/job/send_event_to_big_query_job.rb
+++ b/app/job/send_event_to_big_query_job.rb
@@ -1,10 +1,8 @@
 class SendEventToBigQueryJob < ApplicationJob
-  TABLE_NAME = 'events'.freeze
-
   def perform(request_event_json)
     bq = Google::Cloud::Bigquery.new(project: Settings.google.big_query_project_id)
     dataset = bq.dataset(Settings.google.big_query_dataset, skip_lookup: true)
-    bq_table = dataset.table(TABLE_NAME, skip_lookup: true)
+    bq_table = dataset.table(Settings.google.big_query_table_name, skip_lookup: true)
     bq_table.insert([request_event_json])
   end
 end

--- a/app/job/send_event_to_big_query_job.rb
+++ b/app/job/send_event_to_big_query_job.rb
@@ -1,8 +1,8 @@
 class SendEventToBigQueryJob < ApplicationJob
   def perform(request_event_json)
-    bq = Google::Cloud::Bigquery.new(project: Settings.google.big_query_project_id)
-    dataset = bq.dataset(Settings.google.big_query_dataset, skip_lookup: true)
-    bq_table = dataset.table(Settings.google.big_query_table_name, skip_lookup: true)
+    bq = Google::Cloud::Bigquery.new(project: Settings.google.big_query.project_id)
+    dataset = bq.dataset(Settings.google.big_query.dataset, skip_lookup: true)
+    bq_table = dataset.table(Settings.google.big_query.table_name, skip_lookup: true)
     bq_table.insert([request_event_json])
   end
 end

--- a/app/lib/events/web_request.rb
+++ b/app/lib/events/web_request.rb
@@ -15,11 +15,11 @@ module Events
     def with_request_details(rack_request)
       @event_hash.deep_merge!(
         request_uuid: rack_request.uuid,
-        request_data: {
-          path: rack_request.path,
-          method: rack_request.method,
-          user_agent: rack_request.user_agent,
-        },
+        request_path: rack_request.path,
+        request_method: rack_request.method,
+        request_user_agent: rack_request.user_agent,
+        request_referer: rack_request.referer,
+        request_query: query_to_kv_pairs(rack_request.query_string),
       )
 
       self
@@ -27,9 +27,8 @@ module Events
 
     def with_response_details(response)
       @event_hash.deep_merge!(
-        request_data: {
-          status: response.status,
-        },
+        response_status: response.status,
+        response_content_type: response.content_type,
       )
 
       self

--- a/app/lib/events/web_request.rb
+++ b/app/lib/events/web_request.rb
@@ -33,5 +33,14 @@ module Events
 
       self
     end
+
+  private
+
+    def query_to_kv_pairs(query_string)
+      vars = Rack::Utils.parse_query(query_string)
+      vars.map do |(key, value)|
+        { 'key' => key, 'value' => Array.wrap(value) }
+      end
+    end
   end
 end

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "environment": {
+      "type": "string"
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": ["web_request"]
+    },
+    "request_uuid": {
+      "type": "string"
+    },
+    "request_user_agent": {
+      "type": "string"
+    },
+    "request_method": {
+      "type": "string"
+    },
+    "request_path": {
+      "type": "string"
+    },
+    "request_query": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "value"]
+      }
+    },
+    "request_referer": {
+      "anyOf": [
+        {"type": "string"},
+        {"type": "null"}
+      ]
+    },
+    "response_content_type": {
+      "type": "string"
+    },
+    "response_status": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "environment",
+    "occurred_at",
+    "event_type"
+  ]
+}

--- a/config/initializers/big_query.rb
+++ b/config/initializers/big_query.rb
@@ -3,8 +3,11 @@ require 'google/cloud/bigquery'
 BIG_QUERY_API_JSON_KEY = ENV['BIG_QUERY_API_JSON_KEY']
 
 if FeatureFlag.active?(:send_web_requests_to_big_query)
+  # Validate that the JSON key exists and that it is parseable.
+  raise 'BigQuery JSON key missing. Disable feature if not sending events to BigQuery.' if BIG_QUERY_API_JSON_KEY.blank?
+
   Google::Cloud::Bigquery.configure do |config|
-    config.project_id  = Settings.google.bigquery_project_id
+    # This command doesn't actually connect to BigQuery to check authorisation.
     config.credentials = JSON.parse(BIG_QUERY_API_JSON_KEY)
   end
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,8 @@ google:
   gcp_api_key: replace_me
   places_api_host: "https://maps.googleapis.com"
   places_api_path: "/maps/api/place/autocomplete/json"
-  big_query_table_name: events
+  big_query:
+    table_name: events
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 log_level: info

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ google:
   gcp_api_key: replace_me
   places_api_host: "https://maps.googleapis.com"
   places_api_path: "/maps/api/place/autocomplete/json"
+  big_query_table_name: events
 service_support:
   contact_email_address: becomingateacher@digital.education.gov.uk
 log_level: info

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,5 +6,5 @@ feature_flags:
   new_filters: false
   ucas_only_locations: false
 google:
-  bigquery_project_id: bat-find-test
-  bigquery_dataset: bat-find-test-events
+  big_query_project_id: bat-find-test
+  big_query_dataset: bat-find-test-events

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,5 +6,6 @@ feature_flags:
   new_filters: false
   ucas_only_locations: false
 google:
-  big_query_project_id: bat-find-test
-  big_query_dataset: bat-find-test-events
+  big_query:
+    project_id: bat-find-test
+    dataset: bat-find-test-events

--- a/spec/controllers/concerns/emit_request_events_spec.rb
+++ b/spec/controllers/concerns/emit_request_events_spec.rb
@@ -1,16 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe EmitRequestEvents, type: :request, with_bigquery: true do
-  include BigQueryTestHelper
-
-  let(:project) { instance_double(Google::Cloud::Bigquery::Project, dataset: dataset) }
-  let(:dataset) { instance_double(Google::Cloud::Bigquery::Dataset, table: table) }
-  let(:table) { stub_big_query_table }
-
-  before do
-    allow(table).to receive(:insert)
-  end
-
   context 'with send_web_requests_to_big_query enabled' do
     before do
       activate_feature(:send_web_requests_to_big_query)

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe 'viewing the root page' do
 
     page.driver.header 'USER_AGENT', 'test agent'
     page.driver.header 'X_REQUEST_ID', request_uuid
+    page.driver.header 'REFERER', 'http://www.gov.uk'
 
     Timecop.freeze do
       visit '/' # , headers: { 'HTTP_USER_AGENT' => 'test user agent' }
@@ -27,13 +28,13 @@ RSpec.describe 'viewing the root page' do
             'environment' => 'test',
             'event_type' => 'web_request',
             'occurred_at' => Time.now.utc.iso8601,
-            'request_data' => {
-              'method' => 'GET',
-              'path' => '/',
-              'status' => 200,
-              'user_agent' => 'test agent',
-            },
+            'request_method' => 'GET',
+            'request_path' => '/',
+            'request_user_agent' => 'test agent',
+            'request_referer' => 'http://www.gov.uk',
             'request_uuid' => request_uuid,
+            'response_content_type' => 'text/html; charset=utf-8',
+            'response_status' => 200,
           }],
         ),
       )

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe 'viewing the root page' do
             'request_path' => '/',
             'request_user_agent' => 'test agent',
             'request_referer' => 'http://www.gov.uk',
+            'request_query' => [],
             'request_uuid' => request_uuid,
             'response_content_type' => 'text/html; charset=utf-8',
             'response_status' => 200,

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe 'viewing the root page' do
 
       perform_enqueued_jobs
 
+      expect(table).to have_received(:insert) do |*args|
+        schema = File.read('config/event-schema.json')
+        schema_validator = JSONSchemaValidator.new(schema, args.first.first)
+        expect(schema_validator).to be_valid, schema_validator.failure_message
+      end
+
       expect(table).to(
         have_received(:insert).with(
           [{

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'viewing the root page' do
   include BigQueryTestHelper
 
   it 'sends a web request event to BigQuery' do
-    table = stub_big_query_table
+    table = stub_big_query_table(table_name: 'events')
 
     allow(table).to receive(:insert)
 

--- a/spec/jobs/send_event_to_big_query_job_spec.rb
+++ b/spec/jobs/send_event_to_big_query_job_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SendEventToBigQueryJob do
       }
     end
 
-    let(:table) { stub_big_query_table }
+    let(:table) { stub_big_query_table(table_name: 'events') }
 
     before do
       allow(table).to receive(:insert)

--- a/spec/lib/events/web_request_spec.rb
+++ b/spec/lib/events/web_request_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe Events::WebRequest do
     let(:method)       { 'GET' }
     let(:user_agent)   { 'not real test user agent' }
     let(:uuid)         { '19bd4d16-da8f-46ed-b211-874eeac377bd' }
+    let(:referer)      { 'http://127.0.0.1/' }
 
-    let(:rack_request) { instance_double(ActionDispatch::Request, path: path, method: method, user_agent: user_agent, uuid: uuid) }
+    let(:rack_request) { instance_double(ActionDispatch::Request, path: path, method: method, user_agent: user_agent, uuid: uuid, referer: referer) }
     let(:web_request)  { Events::WebRequest.new.with_request_details(rack_request) }
 
     it 'sets request_uuid' do
@@ -48,25 +49,34 @@ RSpec.describe Events::WebRequest do
     end
 
     it 'sets request path' do
-      expect(web_request.as_json['request_data']['path']).to eq path
+      expect(web_request.as_json['request_path']).to eq path
     end
 
     it 'sets request method' do
-      expect(web_request.as_json['request_data']['method']).to eq method
+      expect(web_request.as_json['request_method']).to eq method
     end
 
     it 'sets request user_agent' do
-      expect(web_request.as_json['request_data']['user_agent']).to eq user_agent
+      expect(web_request.as_json['request_user_agent']).to eq user_agent
+    end
+
+    it 'sets request referer' do
+      expect(web_request.as_json['request_referer']).to eq referer
     end
   end
 
   describe '#with_response_data' do
-    it 'sets the response status' do
-      status = instance_double(Integer)
-      response = instance_double(ActionDispatch::Response, status: status)
-      web_request = Events::WebRequest.new.with_response_details(response)
+    let(:status) { instance_double(Integer) }
+    let(:response) { instance_double(ActionDispatch::Response, status: status, content_type: content_type) }
+    let(:content_type) { 'text/htnl' }
+    let(:web_request) { Events::WebRequest.new.with_response_details(response) }
 
-      expect(web_request.as_json['request_data']['status']).to eq status.as_json
+    it 'sets the response status' do
+      expect(web_request.as_json['response_status']).to eq status.as_json
+    end
+
+    it 'sets the response content type' do
+      expect(web_request.as_json['response_content_type']).to eq content_type
     end
   end
 end

--- a/spec/support/big_query_test_helper.rb
+++ b/spec/support/big_query_test_helper.rb
@@ -1,7 +1,8 @@
 module BigQueryTestHelper
-  def stub_big_query_table
+  def stub_big_query_table(table_name:)
     table = instance_double(Google::Cloud::Bigquery::Table)
-    dataset = instance_double(Google::Cloud::Bigquery::Dataset, table: table)
+    dataset = instance_double(Google::Cloud::Bigquery::Dataset)
+    allow(dataset).to receive(:table).with(table_name, skip_lookup: true).and_return(table)
     project = instance_double(Google::Cloud::Bigquery::Project, dataset: dataset)
 
     allow(Google::Cloud::Bigquery).to receive(:new).and_return(project)

--- a/spec/support/json_schema_validator.rb
+++ b/spec/support/json_schema_validator.rb
@@ -1,0 +1,42 @@
+class JSONSchemaValidator
+  attr_reader :schema, :json
+
+  def initialize(schema, json)
+    @schema = schema
+    @json = json
+  end
+
+  def valid?
+    formatted_validation_errors.blank?
+  end
+
+  def failure_message
+    <<~ERROR
+      Expected the JSON structure to be valid against the provided schema:
+
+      #{formatted_item}
+
+      But I got these validation errors:
+
+      #{formatted_validation_errors}
+
+    ERROR
+  end
+
+private
+
+  def formatted_validation_errors
+    errors = JSON::Validator.fully_validate(schema, json)
+    errors.map { |message| "- #{humanized_error(message)}" }.join("\n")
+  end
+
+  def formatted_item
+    return json if json.is_a?(String)
+
+    JSON.pretty_generate(json)
+  end
+
+  def humanized_error(message)
+    message.gsub("The property '#/'", "The (root) property '#/'")
+  end
+end


### PR DESCRIPTION
### Changes proposed in this pull request

- update the JSON schema for events sent to BigQuery
- add JSON schema validation
- add setting for BigQuery table name

### Guidance to review

Changes tested locally. Also this feature hasn't been enabled in any environments so zero impact to this particular changeset.
 
### Trello card

As the BigQuery event logging hasn't been enabled yet, I've decided to re-use the old Trello ticket number (3512) even though that ticket has been considered "Done".

https://trello.com/c/Fx0UPepe/3512-%F0%9F%8F%88-find-send-page-request-events-to-bigquery

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
