### PR TITLE
[3626] add anonymised user agent and ip to events

### DIFF
--- a/app/lib/events/web_request.rb
+++ b/app/lib/events/web_request.rb
@@ -47,8 +47,6 @@ module Events
     def anonymised_user_agent_and_ip(rack_request)
       if rack_request.remote_ip.present?
         anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s)
-      else
-        ''
       end
     end
 

--- a/app/lib/events/web_request.rb
+++ b/app/lib/events/web_request.rb
@@ -20,7 +20,7 @@ module Events
         request_user_agent: rack_request.user_agent,
         request_referer: rack_request.referer,
         request_query: query_to_kv_pairs(rack_request.query_string),
-        anonymised_user_agent_and_ip: anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s),
+        anonymised_user_agent_and_ip: anonymised_user_agent_and_ip(rack_request),
       )
 
       self
@@ -41,6 +41,14 @@ module Events
       vars = Rack::Utils.parse_query(query_string)
       vars.map do |(key, value)|
         { 'key' => key, 'value' => Array.wrap(value) }
+      end
+    end
+
+    def anonymised_user_agent_and_ip(rack_request)
+      if rack_request.remote_ip.present?
+        anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s)
+      else
+        ''
       end
     end
 

--- a/app/lib/events/web_request.rb
+++ b/app/lib/events/web_request.rb
@@ -20,6 +20,7 @@ module Events
         request_user_agent: rack_request.user_agent,
         request_referer: rack_request.referer,
         request_query: query_to_kv_pairs(rack_request.query_string),
+        anonymised_user_agent_and_ip: anonymise(rack_request.user_agent.to_s + rack_request.remote_ip.to_s),
       )
 
       self
@@ -41,6 +42,10 @@ module Events
       vars.map do |(key, value)|
         { 'key' => key, 'value' => Array.wrap(value) }
       end
+    end
+
+    def anonymise(text)
+      Digest::SHA2.hexdigest(text)
     end
   end
 end

--- a/config/event-schema.json
+++ b/config/event-schema.json
@@ -43,8 +43,12 @@
     },
     "response_status": {
       "type": "integer"
+    },
+    "anonymised_user_agent_and_ip": {
+      "type": "string"
     }
   },
+  "additionalProperties": false,
   "required": [
     "environment",
     "occurred_at",

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'viewing the root page' do
             'request_uuid' => request_uuid,
             'response_content_type' => 'text/html; charset=utf-8',
             'response_status' => 200,
-            'anonymised_user_agent_and_ip' => Digest::SHA2.hexdigest('test agent127.0.0.1'),
+            'anonymised_user_agent_and_ip' => '57c7c45d80c614903eae405563be150d66d0ea898da7b85570aa9c78175328b8',
           }],
         ),
       )

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'viewing the root page' do
             'request_uuid' => request_uuid,
             'response_content_type' => 'text/html; charset=utf-8',
             'response_status' => 200,
+            'anonymised_user_agent_and_ip' => Digest::SHA2.hexdigest('test agent127.0.0.1'),
           }],
         ),
       )

--- a/spec/lib/events/web_request_spec.rb
+++ b/spec/lib/events/web_request_spec.rb
@@ -83,10 +83,41 @@ RSpec.describe Events::WebRequest do
       )
     end
 
-    it 'sets the anonymised user identifier' do
-      expect(web_request.as_json['anonymised_user_agent_and_ip']).to(
-        eq(Digest::SHA2.hexdigest(user_agent + remote_ip))
-      )
+    describe 'anonymised_user_agent_and_ip' do
+      context 'when user agent and ip address both present' do
+        it 'is set to a hash of user agent and ip' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to(
+            eq(Digest::SHA2.hexdigest(user_agent + remote_ip)),
+          )
+        end
+      end
+
+      context 'when user agent is present but ip address is blank' do
+        let(:remote_ip) { nil }
+
+        it 'is blank' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_blank
+        end
+      end
+
+      context 'when user agent is blank but ip address is present' do
+        let(:user_agent) { nil }
+
+        it 'is set to a hash of the ip' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to(
+            eq(Digest::SHA2.hexdigest(remote_ip)),
+          )
+        end
+      end
+
+      context 'when user agent and ip address are both blank' do
+        let(:remote_ip) { nil }
+        let(:user_agent) { nil }
+
+        it 'is blank' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_blank
+        end
+      end
     end
 
     context 'query string with array' do

--- a/spec/lib/events/web_request_spec.rb
+++ b/spec/lib/events/web_request_spec.rb
@@ -95,8 +95,8 @@ RSpec.describe Events::WebRequest do
       context 'when user agent is present but ip address is blank' do
         let(:remote_ip) { nil }
 
-        it 'is blank' do
-          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_blank
+        it 'is nil' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_nil
         end
       end
 
@@ -114,8 +114,8 @@ RSpec.describe Events::WebRequest do
         let(:remote_ip) { nil }
         let(:user_agent) { nil }
 
-        it 'is blank' do
-          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_blank
+        it 'is nil' do
+          expect(web_request.as_json['anonymised_user_agent_and_ip']).to be_nil
         end
       end
     end

--- a/spec/lib/events/web_request_spec.rb
+++ b/spec/lib/events/web_request_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Events::WebRequest do
       context 'when user agent and ip address both present' do
         it 'is set to a hash of user agent and ip' do
           expect(web_request.as_json['anonymised_user_agent_and_ip']).to(
-            eq(Digest::SHA2.hexdigest(user_agent + remote_ip)),
+            eq('611cc7906e5a7781acc6747562057dcaf132ce10afcb3f9b59897d75b3994645'),
           )
         end
       end
@@ -105,7 +105,7 @@ RSpec.describe Events::WebRequest do
 
         it 'is set to a hash of the ip' do
           expect(web_request.as_json['anonymised_user_agent_and_ip']).to(
-            eq(Digest::SHA2.hexdigest(remote_ip)),
+            eq('f5047344122f0dee9974ba6761e61c6b8649e1f3968d13a635ebbf7be53a3a0d'),
           )
         end
       end


### PR DESCRIPTION
### Context

We want to have a general sense of the number of unique users in BigQuery events.

### Changes proposed in this pull request

Generate `anonymised_user_agent_and_ip` and send to BigQuery.

### Guidance to review

See Trello cards for further info.

### Trello card

https://trello.com/c/hBfnkeMI/3626-add-user-anonymous-identifier-field-to-event-being-sent-to-bq

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
