### PR TITLE
Add an EOC timetable to Find

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -1,0 +1,100 @@
+class CycleTimetable
+  CYCLE_DATES = {
+    2021 => {
+      find_opens: DateTime.new(2020, 10, 6, 9),
+      apply_opens: DateTime.new(2020, 10, 13, 9),
+      first_deadline_banner: DateTime.new(2021, 7, 12, 9),
+      apply_1_deadline: DateTime.new(2021, 8, 24, 18),
+      apply_2_deadline: DateTime.new(2021, 9, 20, 18),
+      find_closes: DateTime.new(2021, 10, 3),
+    },
+    2022 => {
+      find_opens: DateTime.new(2021, 10, 5, 9),
+      apply_opens: DateTime.new(2021, 10, 12, 9),
+      # the dates from below here are not the finalised but are required for
+      # the current implementation
+      first_deadline_banner: DateTime.new(2022, 7, 12, 9),
+      apply_1_deadline: DateTime.new(2022, 8, 24, 18),
+      apply_2_deadline: DateTime.new(2022, 9, 20, 18),
+      find_closes: DateTime.new(2022, 10, 3),
+    },
+  }.freeze
+
+  def self.current_year
+    now = DateTime.now
+
+    CYCLE_DATES.keys.detect do |year|
+      return year if last_recruitment_cycle_year?(year)
+
+      now.between?(CYCLE_DATES[year][:find_opens], CYCLE_DATES[year + 1][:find_opens])
+    end
+  end
+
+  def self.next_year
+    current_year + 1
+  end
+
+  def self.find_closes
+    date(:find_closes)
+  end
+
+  def self.first_deadline_banner
+    date(:first_deadline_banner)
+  end
+
+  def self.apply_1_deadline
+    date(:apply_1_deadline)
+  end
+
+  def self.apply_2_deadline
+    date(:apply_2_deadline)
+  end
+
+  def self.find_opens
+    date(:find_opens, current_year)
+  end
+
+  def self.find_reopens
+    date(:find_opens, next_year)
+  end
+
+  def self.apply_reopens
+    date(:apply_opens, next_year)
+  end
+
+  def self.preview_mode?
+    Time.zone.now.between?(apply_2_deadline, find_closes)
+  end
+
+  def self.find_down?
+    return false if Time.zone.now > find_opens && Time.zone.now < find_closes
+
+    true
+  end
+
+  def self.mid_cycle?
+    Time.zone.now.between?(find_opens, apply_2_deadline)
+  end
+
+  def self.show_apply_1_deadline_banner?
+    Time.zone.now.between?(first_deadline_banner, apply_1_deadline)
+  end
+
+  def self.show_apply_2_deadline_banner?
+    Time.zone.now.between?(apply_1_deadline, apply_2_deadline)
+  end
+
+  def self.show_cycle_closed_banner?
+    Time.zone.now.between?(apply_2_deadline, find_closes)
+  end
+
+  def self.date(name, year = current_year)
+    CYCLE_DATES[year].fetch(name)
+  end
+
+  def self.last_recruitment_cycle_year?(year)
+    year == CYCLE_DATES.keys.last
+  end
+
+  private_class_method :last_recruitment_cycle_year?
+end

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe CycleTimetable do
+  let(:one_hour_before_find_opens) { Time.zone.local(2020, 10, 6, 8, 0, 0) }
+  let(:one_hour_after_find_opens) { Time.zone.local(2020, 10, 6, 10, 0, 0) }
+  let(:one_hour_before_first_deadline_banner) { Time.zone.local(2021, 7, 12, 8, 0, 0) }
+  let(:one_hour_before_apply_1_deadline) { Time.zone.local(2021, 8, 24, 17, 0, 0) }
+  let(:one_hour_after_apply_1_deadline) { Time.zone.local(2021, 8, 24, 19, 0, 0) }
+  let(:one_hour_before_apply_2_deadline) { Time.zone.local(2021, 9, 20, 17, 0, 0) }
+  let(:one_hour_after_apply_2_deadline) { Time.zone.local(2021, 9, 20, 19, 0, 0) }
+  let(:one_hour_after_find_closes) { Time.zone.local(2021, 10, 4, 1, 0, 0) }
+  let(:one_hour_after_find_reopens) { Time.zone.local(2021, 10, 5, 10, 0, 0) }
+
+  describe '.current_year' do
+    it 'is 2021 if we are in the middle of the 2021 cycle' do
+      Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
+        expect(CycleTimetable.current_year).to eq(2021)
+      end
+    end
+
+    it 'is 2022 if we are in the middle of the 2022 cycle' do
+      Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
+        expect(CycleTimetable.current_year).to eq(2022)
+      end
+    end
+  end
+
+  describe '.next_year' do
+    it 'is 2021 if we are in the middle of the 2021 cycle' do
+      Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
+        expect(CycleTimetable.next_year).to eq(2022)
+      end
+    end
+
+    it 'is 2022 if we are in the middle of the 2022 cycle' do
+      Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
+        expect(CycleTimetable.next_year).to eq(2023)
+      end
+    end
+  end
+
+  describe '.preview_mode?' do
+    it 'returns true when it is after the Apply 2 deadline but before Find closes' do
+      Timecop.travel(one_hour_after_apply_2_deadline) do
+        expect(CycleTimetable.preview_mode?).to be true
+      end
+    end
+
+    it 'returns false before the Apply 2 deadline' do
+      Timecop.travel(one_hour_before_apply_2_deadline) do
+        expect(CycleTimetable.preview_mode?).to be false
+      end
+    end
+
+    it 'returns false when Find has reopened' do
+      Timecop.travel(one_hour_after_find_reopens) do
+        expect(CycleTimetable.preview_mode?).to be false
+      end
+    end
+  end
+
+  describe '.find_down?' do
+    it 'returns true when it is after Find closes and before it reopens' do
+      Timecop.travel(one_hour_after_find_closes) do
+        expect(CycleTimetable.find_down?).to be true
+      end
+    end
+
+    it 'returns false before Find closes' do
+      Timecop.travel(one_hour_before_apply_2_deadline) do
+        expect(CycleTimetable.find_down?).to be false
+      end
+    end
+
+    it 'returns false when Find has reopened' do
+      Timecop.travel(one_hour_after_find_reopens) do
+        expect(CycleTimetable.find_down?).to be false
+      end
+    end
+  end
+
+  describe '.mid_cycle??' do
+    it 'returns true after Find has opened' do
+      Timecop.travel(one_hour_after_find_opens) do
+        expect(CycleTimetable.mid_cycle?).to be true
+      end
+    end
+
+    it 'returns false after the apply_2_deadline' do
+      Timecop.travel(one_hour_after_apply_2_deadline) do
+        expect(CycleTimetable.mid_cycle?).to be false
+      end
+    end
+  end
+
+  describe '.show_apply_1_deadline_banner?' do
+    it 'returns true when it is after the deadline_banner and before the apply_1_deadline' do
+      Timecop.travel(one_hour_before_apply_1_deadline) do
+        expect(CycleTimetable.show_apply_1_deadline_banner?).to be true
+      end
+    end
+
+    it 'returns false after the the apply_1_deadline' do
+      Timecop.travel(one_hour_after_apply_1_deadline) do
+        expect(CycleTimetable.show_apply_1_deadline_banner?).to be false
+      end
+    end
+
+    it 'returns false before the deadline_banner' do
+      Timecop.travel(one_hour_before_first_deadline_banner) do
+        expect(CycleTimetable.show_apply_1_deadline_banner?).to be false
+      end
+    end
+  end
+
+  describe '.show_apply_2_deadline_banner?' do
+    it 'returns true when it is after the apply_1_deadline and before the apply_2_deadline' do
+      Timecop.travel(one_hour_before_apply_2_deadline) do
+        expect(CycleTimetable.show_apply_2_deadline_banner?).to be true
+      end
+    end
+
+    it 'returns false before the after the apply_2_deadline' do
+      Timecop.travel(one_hour_after_apply_2_deadline) do
+        expect(CycleTimetable.show_apply_2_deadline_banner?).to be false
+      end
+    end
+
+    it 'returns false before the apply_1_deadline' do
+      Timecop.travel(one_hour_before_apply_1_deadline) do
+        expect(CycleTimetable.show_apply_2_deadline_banner?).to be false
+      end
+    end
+  end
+
+  describe '.show_cycle_closed_banner?' do
+    it 'returns true when it is after the apply_2_deadline and before Find closes' do
+      Timecop.travel(one_hour_after_apply_2_deadline) do
+        expect(CycleTimetable.show_cycle_closed_banner?).to be true
+      end
+    end
+
+    it 'returns false after Find closes' do
+      Timecop.travel(one_hour_after_find_closes) do
+        expect(CycleTimetable.show_cycle_closed_banner?).to be false
+      end
+    end
+
+    it 'returns false before the apply_2_deadline' do
+      Timecop.travel(one_hour_before_apply_2_deadline) do
+        expect(CycleTimetable.show_cycle_closed_banner?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

Going forward we want to use a CycleTimetable to control the changes in behaviour in discreet phases of the cycle on Find such as the banners, removing the apply button and restricting access to courses when Find is closed.

This PR adds the CycleTimetable.

Going forward this will be used to implement all 4 cards captured in this epic https://trello.com/c/SZRVll8g/2302-%F0%9F%94%81-eoc-dev-find-changes-required-following-design-review

### Changes proposed in this pull request

- Add the cycle timetable 

This needs the following values 

1. find opens
2. apply opens (for content on the banner)
3. deadline banner shows
4. apply 1 deadline 
5. apply 2 deadline
6. find_closes

### Guidance to review

Does this all make sense? I think you'd probs eed to have a look at the banner cards for context.

### Trello card

https://trello.com/c/3MhlVfCk/3591-%F0%9F%94%81-find-eoc-dev-phase-1-banners-on-find-to-notify-candidates-the-cycle-will-end

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
