### PR TITLE
Update the content on the cycle has ended page

### DIFF
--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -8,16 +8,16 @@
 <% elsif CycleTimetable.show_apply_2_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
     <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.strftime('%B %Y')}") %>
-    <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}" %> academic year.</p>
-    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= "#{CycleTimetable.next_year} to #{CycleTimetable.next_year + 1}" %> academic year.</p>
+    <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= CycleTimetable.cycle_year_range %> academic year.</p>
+    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
     <p class="govuk-body">You can submit an application from 9am on <%= apply_reopens %>.</p>
     <p class="govuk-notification-banner__heading">If your application did not lead to a place and you’re applying again</p>
-    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= "#{CycleTimetable.current_year} to #{CycleTimetable.next_year}" %> academic year until 6pm on <%= apply_2_deadline %>.</p>
+    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until 6pm on <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
     <%= notification_banner.slot(:heading, text: "It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year") %>
-    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= "#{CycleTimetable.next_year} to #{CycleTimetable.next_year + 1}" %> academic year, as there’s no guarantee that the courses currently shown on this website will be on offer next year.</p>
+    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range %> academic year, as there’s no guarantee that the courses currently shown on this website will be on offer next year.</p>
     <p class="govuk-body">You can submit an application from 9am on <%= apply_reopens %>.</p>
   <% end %>
 <% end %>

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -96,5 +96,9 @@ class CycleTimetable
     year == CYCLE_DATES.keys.last
   end
 
+  def self.cycle_year_range(year = current_year)
+    "#{year} to #{year + 1}"
+  end
+
   private_class_method :last_recruitment_cycle_year?
 end

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -6,10 +6,10 @@
       <h1 class="govuk-heading-l">Find postgraduate teacher training</h1>
 
       <h2 class="govuk-heading-m">Applications closed</h2>
-      <p class="govuk-body">Applications for this academic year (2020 to 2021) are now closed.</p>
+      <p class="govuk-body">Applications for the <%= CycleTimetable.cycle_year_range %> academic year are now closed.</p>
 
-      <h2 class="govuk-heading-m">Find courses starting next academic year (2021 to 2022)</h2>
-      <p class="govuk-body">You can find courses from 6 October 2020 and apply from 13 October 2020.</p>
+      <h2 class="govuk-heading-m">Find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year</h2>
+      <p class="govuk-body">You can find courses from 9am on <%= CycleTimetable.find_reopens.strftime('%e %B %Y') %> and apply from 9am on <%= CycleTimetable.apply_reopens.strftime('%e %B %Y') %>.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Context

As part of the changes we're making to Find for EOC, we need to update the content on the cycle has ended page.

This should be done using the CycleTimetable so it is future proof and does not need to be hardcoded.

### Changes proposed in this pull request

Update the content on the cycle has ended page
 
![image](https://user-images.githubusercontent.com/42515961/125266561-d69abb00-e2fd-11eb-8243-ff109591e1d2.png)

### Trello card

https://trello.com/c/mloDU6fr/3593-%F0%9F%94%81-find-eoc-phase-4-find-is-closed-page-including-content-changes-from-last-year

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
