### PR TITLE
Apply fix for banner not rendering due to start wizard

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -120,8 +120,8 @@
             <%= notification_banner.slot(:heading, text: flash[:success]) %>
           <% end %>
         <% end %>
-        
-        <%= render DeadlineBannerComponent.new(flash_empty: flash.empty?) unless request.url.include?('/results/filter/subject')%>
+
+        <%= render DeadlineBannerComponent.new(flash_empty: flash.reject { |flash| flash[0] == "start_wizard" }.empty?) unless request.url.include?('/results/filter/subject')%>
 
         <%= yield %>
       </main>

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -234,6 +234,16 @@ RSpec.feature 'Results page new area and provider filter' do
           end
         end
       end
+
+      context 'nearing end of cycle' do
+        it 'displays the deadline banner' do
+          Timecop.travel(Time.zone.local(2021, 9, 20, 19, 0, 0)) do
+            start_page.load
+
+            expect(start_page).to have_content('there’s no guarantee that the courses currently shown on this website will be on offer next year.')
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
### Context

When a candidate arrives on find, a start wizard is passed into the flash. This is used to retain state on whether a candidate is moving through the initial flow, or whether they are editing a previous selection. 

We need to fix this, but it will take a while so for now, i've remove the start_wizard from the flash before passing it into the deadline banner component. 

### Changes proposed in this pull request

- Render the deadline banner if the only flash is the start_wizard

### Guidance to review

As i've said above, this is a temporary fix. We should rework the way the wizard works. Unfortunately it's not as easy as just passing the params in as they views are completely shared. We can definitely take logic out the partials etc. but it's going to take a bit of time.

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
