### PR TITLE
Default Time to London and update the timetable to use Time.zone.local

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -1,27 +1,27 @@
 class CycleTimetable
   CYCLE_DATES = {
     2021 => {
-      find_opens: DateTime.new(2020, 10, 6, 9),
-      apply_opens: DateTime.new(2020, 10, 13, 9),
-      first_deadline_banner: DateTime.new(2021, 7, 12, 9),
-      apply_1_deadline: DateTime.new(2021, 9, 7, 18),
-      apply_2_deadline: DateTime.new(2021, 9, 20, 18),
-      find_closes: DateTime.new(2021, 10, 3),
+      find_opens: Time.zone.local(2020, 10, 6, 9),
+      apply_opens: Time.zone.local(2020, 10, 13, 9),
+      first_deadline_banner: Time.zone.local(2021, 7, 12, 9),
+      apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
+      apply_2_deadline: Time.zone.local(2021, 9, 20, 18),
+      find_closes: Time.zone.local(2021, 10, 3),
     },
     2022 => {
-      find_opens: DateTime.new(2021, 10, 5, 9),
-      apply_opens: DateTime.new(2021, 10, 12, 9),
+      find_opens: Time.zone.local(2021, 10, 5, 9),
+      apply_opens: Time.zone.local(2021, 10, 12, 9),
       # the dates from below here are not the finalised but are required for
       # the current implementation
-      first_deadline_banner: DateTime.new(2022, 7, 12, 9),
-      apply_1_deadline: DateTime.new(2021, 9, 7, 18),
-      apply_2_deadline: DateTime.new(2022, 9, 20, 18),
-      find_closes: DateTime.new(2022, 10, 3),
+      first_deadline_banner: Time.zone.local(2022, 7, 12, 9),
+      apply_1_deadline: Time.zone.local(2022, 9, 7, 18),
+      apply_2_deadline: Time.zone.local(2022, 9, 20, 18),
+      find_closes: Time.zone.local(2022, 10, 3),
     },
   }.freeze
 
   def self.current_year
-    now = DateTime.now
+    now = Time.zone.now
 
     CYCLE_DATES.keys.detect do |year|
       return year if last_recruitment_cycle_year?(year)

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,6 +26,8 @@ module FindTeacherTraining
 
     config.exceptions_app = routes
 
+    config.time_zone = 'London'
+
     # https://thoughtbot.com/blog/content-compression-with-rack-deflater
     config.middleware.use Rack::Deflater
 

--- a/spec/features/events/send_web_request_to_big_query_spec.rb
+++ b/spec/features/events/send_web_request_to_big_query_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'viewing the root page' do
           [{
             'environment' => 'test',
             'event_type' => 'web_request',
-            'occurred_at' => Time.now.utc.iso8601,
+            'occurred_at' => Time.zone.now.iso8601,
             'request_method' => 'GET',
             'request_path' => '/',
             'request_user_agent' => 'test agent',

--- a/spec/lib/events/web_request_spec.rb
+++ b/spec/lib/events/web_request_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Events::WebRequest do
     end
 
     it 'sets the occurred_at to now' do
-      Timecop.freeze('2021-06-16 12:00:00') do
+      Timecop.freeze(Time.zone.local(2021, 6, 16, 12)) do
         web_request = Events::WebRequest.new
 
-        expect(web_request.as_json['occurred_at']).to eq '2021-06-16T12:00:00Z'
+        expect(web_request.as_json['occurred_at']).to eq '2021-06-16T12:00:00+01:00'
       end
     end
 


### PR DESCRIPTION
### Context

At the moment, the CycleTimetable is an hour out of date as the zone has not been set to London.

### Changes proposed in this pull request

This PR sets Time.zone to London in the application file and sets the timetable to use Time.zone.local

### Guidance to review

Does this approach seem reasonable?

### Trello card

https://trello.com/c/IxL0GXY0/3634-find-cycletimetable-times-are-an-hour-out-due-to-time-zone

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
