### PR TITLE
Add date format initialiser

### DIFF
--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -1,23 +1,23 @@
 <% if CycleTimetable.show_apply_1_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "Apply now to get on a course starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year") %>
+    <%= notification_banner.slot(:heading, text: "Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year") %>
     <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
-    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= CycleTimetable.find_opens.strftime('%B %Y') %>, apply no later than 6pm on <%= apply_1_deadline %>.</p>
-    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than 6pm on <%= apply_2_deadline %>.</p>
+    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= CycleTimetable.find_opens.to_s(:month_and_year) %>, apply no later than <%= apply_1_deadline %>.</p>
+    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_apply_2_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.strftime('%B %Y')}") %>
+    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_s(:month_and_year)}") %>
     <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= CycleTimetable.cycle_year_range %> academic year.</p>
-    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
-    <p class="govuk-body">You can submit an application from 9am on <%= apply_reopens %>.</p>
+    <p class="govuk-body">Come back from <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
+    <p class="govuk-body">You can submit an application from <%= apply_reopens %>.</p>
     <p class="govuk-notification-banner__heading">If your application did not lead to a place and you’re applying again</p>
-    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until 6pm on <%= apply_2_deadline %>.</p>
+    <p class="govuk-body">You can continue to view and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until <%= apply_2_deadline %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year") %>
-    <p class="govuk-body">Come back from 9am on <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range %> academic year, as there’s no guarantee that the courses currently shown on this website will be on offer next year.</p>
-    <p class="govuk-body">You can submit an application from 9am on <%= apply_reopens %>.</p>
+    <%= notification_banner.slot(:heading, text: "It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.cycle_year_range} academic year") %>
+    <p class="govuk-body">Come back from <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range %> academic year, as there’s no guarantee that the courses currently shown on this website will be on offer next year.</p>
+    <p class="govuk-body">You can submit an application from <%= apply_reopens %>.</p>
   <% end %>
 <% end %>

--- a/app/components/deadline_banner_component.rb
+++ b/app/components/deadline_banner_component.rb
@@ -12,18 +12,18 @@ class DeadlineBannerComponent < ViewComponent::Base
 private
 
   def apply_1_deadline
-    CycleTimetable.apply_1_deadline.strftime('%e %B %Y')
+    CycleTimetable.apply_1_deadline.to_s(:govuk_date_and_time)
   end
 
   def apply_2_deadline
-    CycleTimetable.apply_2_deadline.strftime('%e %B %Y')
+    CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time)
   end
 
   def find_reopens
-    CycleTimetable.find_reopens.strftime('%e %B %Y')
+    CycleTimetable.find_reopens.to_s(:govuk_date_and_time)
   end
 
   def apply_reopens
-    CycleTimetable.apply_reopens.strftime('%e %B %Y')
+    CycleTimetable.apply_reopens.to_s(:govuk_date_and_time)
   end
 end

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -9,7 +9,7 @@
       <p class="govuk-body">Applications for the <%= CycleTimetable.cycle_year_range %> academic year are now closed.</p>
 
       <h2 class="govuk-heading-m">Find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year</h2>
-      <p class="govuk-body">You can find courses from 9am on <%= CycleTimetable.find_reopens.strftime('%e %B %Y') %> and apply from 9am on <%= CycleTimetable.apply_reopens.strftime('%e %B %Y') %>.</p>
+      <p class="govuk-body">You can find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> and apply from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.</p>
     </div>
   </div>
 </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,32 @@
+Time::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
+Time::DATE_FORMATS[:govuk_date_short_month] = '%-d %b %Y'
+Date::DATE_FORMATS[:govuk_date] = '%-d %B %Y'
+
+Time::DATE_FORMATS[:month_and_year] = '%B %Y'
+Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+
+Time::DATE_FORMATS[:short_month_and_year] = '%b %Y'
+Date::DATE_FORMATS[:short_month_and_year] = '%b %Y'
+
+Time::DATE_FORMATS[:day_and_month] = '%d %B'
+Date::DATE_FORMATS[:day_and_month] = '%d %B'
+
+Time::DATE_FORMATS[:govuk_date_and_time] = lambda do |time|
+  format = if time.min.zero?
+             '%l%P on %e %B %Y'
+           else
+             '%l:%M%P on %e %B %Y'
+           end
+
+  time.strftime(format).squish
+end
+
+Time::DATE_FORMATS[:govuk_time] = lambda do |time|
+  format = if time.min.zero?
+             '%l%P'
+           else
+             '%l:%M%P'
+           end
+
+  time.strftime(format).squish
+end


### PR DESCRIPTION
### Context

We're using quite a bit of strftime throughout the deadline banner component and EOC related views. It would be much nicer to use something similar to apply which allows us to create custom time/date formats based around need.

### Changes proposed in this pull request

- Implement a similar date format intialiser to apply
- use it where appropriate 

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
