### PR TITLE
Add a cycle switcher to Find

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem 'puma', '~> 5.4'
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker'
 
+# Use the GOV UK form builder
+gem 'govuk_design_system_formbuilder', '~> 2.7.2'
+
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,6 +213,11 @@ GEM
       activemodel (>= 6.0)
       railties (>= 6.0)
       view_component (~> 2.20)
+    govuk_design_system_formbuilder (2.7.2)
+      actionview (>= 6.0)
+      activemodel (>= 6.0)
+      activesupport (>= 6.0)
+      deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
     html_tokenizer (0.0.7)
     httparty (0.18.1)
@@ -487,6 +492,7 @@ DEPENDENCIES
   geokit
   google-cloud-bigquery
   govuk-components
+  govuk_design_system_formbuilder (~> 2.7.2)
   httparty
   json-schema
   json_api_client

--- a/app/components/summary_list_component.html.erb
+++ b/app/components/summary_list_component.html.erb
@@ -1,0 +1,11 @@
+<%= govuk_summary_list do |component| %>
+  <% rows.each do |row| %>
+    <%= component.slot(
+      :row,
+      key: row[:key],
+      value: value(row),
+      action: action(row),
+      html_attributes: html_attributes(row),
+    ) %>
+  <% end %>
+<% end %>

--- a/app/components/summary_list_component.rb
+++ b/app/components/summary_list_component.rb
@@ -1,0 +1,68 @@
+class SummaryListComponent < ViewComponent::Base
+  include ViewHelper
+
+  def initialize(rows:)
+    rows = transform_hash(rows) if rows.is_a?(Hash)
+    @rows = rows
+  end
+
+  def value(row)
+    if row[:value].is_a?(Array)
+      if row[:bulleted_format]
+        format_list_with_bullets(row[:value])
+      else
+        row[:value].map { |s| ERB::Util.html_escape(s) }.join('<br>').html_safe
+      end
+    elsif row[:value].html_safe?
+      row[:value]
+    else
+      simple_format(row[:value], class: 'govuk-body')
+    end
+  end
+
+  def action(row)
+    if row[:change_path]
+      govuk_link_to(row[:change_path], class: 'govuk-!-display-none-print') do
+        "Change<span class=\"govuk-visually-hidden\"> #{row[:action]}</span>".html_safe
+      end
+    elsif row[:action_path]
+      govuk_link_to(row[:action], row[:action_path], class: 'govuk-!-display-none-print')
+    elsif row[:actions]
+      links = row[:actions].map do |action|
+        govuk_link_to(action[:path], class: 'govuk-!-display-none-print') do
+          "#{action[:verb]}<span class=\"govuk-visually-hidden\"> #{action[:object]}</span>".html_safe
+        end
+      end
+      links.join('<br>').html_safe
+    end
+  end
+
+  def html_attributes(row)
+    if row[:data_qa]
+      { 'data-qa' => row[:data_qa] }
+    else
+      {}
+    end
+  end
+
+private
+
+  attr_reader :rows
+
+  def transform_hash(row_hash)
+    row_hash.map do |key, value|
+      {
+        key: key,
+        value: value,
+      }
+    end
+  end
+
+  def format_list_with_bullets(list)
+    markup = '<ul class="govuk-list govuk-list--bullet">'.html_safe
+    list.map do |list_item|
+      markup << '<li>'.html_safe << list_item << '</li>'.html_safe
+    end
+    markup + '</ul>'.html_safe
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_request_id
   before_action :assign_sentry_contexts
+  before_action :redirect_to_cycle_has_ended_if_find_is_down
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
@@ -24,5 +25,11 @@ class ApplicationController < ActionController::Base
 
   def render_feedback_component
     @render_feedback_component = true
+  end
+
+private
+
+  def redirect_to_cycle_has_ended_if_find_is_down
+    redirect_to cycle_has_ended_path if CycleTimetable.find_down?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,8 @@ class ApplicationController < ActionController::Base
   before_action :store_request_id
   before_action :assign_sentry_contexts
 
+  default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
+
   def store_request_id
     RequestStore.store[:request_id] = request.uuid
   end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
+  skip_before_action :redirect_to_cycle_has_ended_if_find_is_down, only: :cycle_has_ended
+  before_action :redirect_to_homepage_if_find_is_open, only: :cycle_has_ended
+
   def terms; end
 
   def privacy; end
@@ -8,4 +11,10 @@ class PagesController < ApplicationController
   def accessibilty; end
 
   def cycle_has_ended; end
+
+private
+
+  def redirect_to_homepage_if_find_is_open
+    redirect_to root_path unless CycleTimetable.find_down?
+  end
 end

--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -1,4 +1,5 @@
 class SwitcherController < ApplicationController
+  skip_before_action :redirect_to_cycle_has_ended_if_find_is_down
   before_action redirect_to root_path if Rails.env.production?
 
   def cycles; end
@@ -6,8 +7,6 @@ class SwitcherController < ApplicationController
   def update
     new_cycle = params[:change_cycle_form][:cycle_schedule_name]
     SiteSetting.set(name: 'cycle_schedule', value: new_cycle)
-    Rails.application.reload_routes!
-
     flash[:success] = 'Cycle schedule updated'
     redirect_to cycles_path
   end

--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -1,0 +1,14 @@
+class SwitcherController < ApplicationController
+  before_action redirect_to root_path if Rails.env.production?
+
+  def cycles; end
+
+  def update
+    new_cycle = params[:change_cycle_form][:cycle_schedule_name]
+    SiteSetting.set(name: 'cycle_schedule', value: new_cycle)
+    Rails.application.reload_routes!
+
+    flash[:success] = 'Cycle schedule updated'
+    redirect_to cycles_path
+  end
+end

--- a/app/forms/change_cycle_form.rb
+++ b/app/forms/change_cycle_form.rb
@@ -1,0 +1,7 @@
+class ChangeCycleForm
+  include ActiveModel::Model
+
+  def cycle_schedule_name
+    CycleTimetable.current_cycle_schedule
+  end
+end

--- a/app/lib/hosting_environment.rb
+++ b/app/lib/hosting_environment.rb
@@ -1,0 +1,5 @@
+module HostingEnvironment
+  def self.production?
+    Rails.env.production?
+  end
+end

--- a/app/lib/redis.rb
+++ b/app/lib/redis.rb
@@ -6,7 +6,7 @@ class RedisService
 
   def self.redis_url
     @redis_credentials ||= begin
-      redis_credentials = ENV['REDIS_URL']
+      redis_credentials = ENV['REDIS_URL'] || Settings.redis_url
       if ENV.key?('VCAP_SERVICES')
         service_config = JSON.parse(ENV['VCAP_SERVICES'])
         redis_config = service_config['redis'].first

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -8,4 +8,16 @@ class RecruitmentCycle < Base
   def self.current
     RecruitmentCycle.includes(:providers).find(Settings.current_cycle).first
   end
+
+  def self.current_year
+    CycleTimetable.current_year
+  end
+
+  def self.next_year
+    CycleTimetable.next_year
+  end
+
+  def self.previous_year
+    current_year - 1
+  end
 end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -1,0 +1,11 @@
+require './app/lib/redis'
+
+class SiteSetting < Base
+  def self.cycle_schedule
+    RedisService.new.get('cycle_schedule')&.to_sym || :real
+  end
+
+  def self.set(name:, value:)
+    RedisService.new.set(name, value)
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -18,6 +18,10 @@ class CycleTimetable
       apply_2_deadline: Time.zone.local(2022, 9, 21, 18),
       find_closes: Time.zone.local(2022, 10, 3),
     },
+    2023 => {
+      find_opens: Time.zone.local(2022, 10, 5, 9),
+      apply_opens: Time.zone.local(2022, 10, 12, 9),
+    },
   }.freeze
 
   def self.current_year
@@ -67,9 +71,7 @@ class CycleTimetable
   end
 
   def self.find_down?
-    return false if Time.zone.now > find_opens && Time.zone.now < find_closes
-
-    true
+    Time.zone.now.between?(find_closes, find_reopens)
   end
 
   def self.mid_cycle?
@@ -89,7 +91,13 @@ class CycleTimetable
   end
 
   def self.date(name, year = current_year)
-    CYCLE_DATES[year].fetch(name)
+    schedule = if current_cycle_schedule == :real
+                 real_schedule_for(year)
+               else
+                 fake_schedules.fetch(current_cycle_schedule).fetch(year)
+               end
+
+    schedule.fetch(name)
   end
 
   def self.last_recruitment_cycle_year?(year)
@@ -117,10 +125,38 @@ class CycleTimetable
         current_year => {
           find_opens: 7.days.ago,
           apply_opens: 6.days.ago,
-          show_deadline_banner: 1.day.ago,
+          first_deadline_banner: 1.day.ago,
           apply_1_deadline: 1.day.from_now,
           apply_2_deadline: 2.days.from_now,
           find_closes: 3.days.from_now,
+        },
+        next_year => {
+          find_opens: 6.days.from_now,
+          apply_opens: 7.days.from_now,
+        },
+      },
+      today_is_after_apply_1_deadline_passed: {
+        current_year => {
+          find_opens: 7.days.ago,
+          apply_opens: 6.days.ago,
+          first_deadline_banner: 3.days.ago,
+          apply_1_deadline: 1.day.ago,
+          apply_2_deadline: 2.days.from_now,
+          find_closes: 3.days.from_now,
+        },
+        next_year => {
+          find_opens: 6.days.from_now,
+          apply_opens: 7.days.from_now,
+        },
+      },
+      today_is_after_apply_2_deadline_passed: {
+        current_year => {
+          find_opens: 7.days.ago,
+          apply_opens: 6.days.ago,
+          first_deadline_banner: 4.days.ago,
+          apply_1_deadline: 3.days.ago,
+          apply_2_deadline: 1.day.ago,
+          find_closes: 1.day.from_now,
         },
         next_year => {
           find_opens: 6.days.from_now,
@@ -131,7 +167,7 @@ class CycleTimetable
         current_year => {
           find_opens: 7.days.ago,
           apply_opens: 6.days.ago,
-          show_deadline_banner: 5.days.ago,
+          first_deadline_banner: 5.days.ago,
           apply_1_deadline: 4.days.ago,
           apply_2_deadline: 2.days.ago,
           find_closes: 1.day.ago,
@@ -145,7 +181,7 @@ class CycleTimetable
         current_year => {
           find_opens: 9.days.ago,
           apply_opens: 8.days.from_now,
-          show_deadline_banner: 7.days.ago,
+          first_deadline_banner: 7.days.ago,
           apply_1_deadline: 6.days.ago,
           apply_2_deadline: 5.days.ago,
           find_closes: 4.days.ago,

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -100,5 +100,63 @@ class CycleTimetable
     "#{year} to #{year + 1}"
   end
 
+  def self.current_cycle_schedule
+    # Make sure this setting only has effect on non-production environments
+    return :real if HostingEnvironment.production?
+
+    SiteSetting.cycle_schedule
+  end
+
+  def self.real_schedule_for(year = current_year)
+    CYCLE_DATES[year]
+  end
+
+  def self.fake_schedules
+    {
+      today_is_mid_cycle: {
+        current_year => {
+          find_opens: 7.days.ago,
+          apply_opens: 6.days.ago,
+          show_deadline_banner: 1.day.ago,
+          apply_1_deadline: 1.day.from_now,
+          apply_2_deadline: 2.days.from_now,
+          find_closes: 3.days.from_now,
+        },
+        next_year => {
+          find_opens: 6.days.from_now,
+          apply_opens: 7.days.from_now,
+        },
+      },
+      today_is_after_find_closes: {
+        current_year => {
+          find_opens: 7.days.ago,
+          apply_opens: 6.days.ago,
+          show_deadline_banner: 5.days.ago,
+          apply_1_deadline: 4.days.ago,
+          apply_2_deadline: 2.days.ago,
+          find_closes: 1.day.ago,
+        },
+        next_year => {
+          find_opens: 6.days.from_now,
+          apply_opens: 7.days.from_now,
+        },
+      },
+      today_is_after_find_opens: {
+        current_year => {
+          find_opens: 9.days.ago,
+          apply_opens: 8.days.from_now,
+          show_deadline_banner: 7.days.ago,
+          apply_1_deadline: 6.days.ago,
+          apply_2_deadline: 5.days.ago,
+          find_closes: 4.days.ago,
+        },
+        next_year => {
+          find_opens: 1.day.ago,
+          apply_opens: 2.days.from_now,
+        },
+      },
+    }
+  end
+
   private_class_method :last_recruitment_cycle_year?
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -75,6 +75,8 @@ class CycleTimetable
   end
 
   def self.mid_cycle?
+    return true if current_cycle_schedule == :today_is_after_find_opens
+
     Time.zone.now.between?(find_opens, apply_2_deadline)
   end
 

--- a/app/views/switcher/cycles.html.erb
+++ b/app/views/switcher/cycles.html.erb
@@ -1,0 +1,42 @@
+<%= content_for :page_title, 'Recruitment cycles' %>
+
+<% unless HostingEnvironment.production? %>
+  <%= form_with model: ChangeCycleForm.new, url: switch_cycle_schedule_path, method: :post do |f| %>
+    <%= f.govuk_radio_buttons_fieldset :cycle_schedule_name,
+      legend: { text: 'Current point in the recruitment cycle' } do %>
+
+      <%= f.govuk_radio_button :cycle_schedule_name, 'real', label: { text: t('cycles.real.name') }, hint: { text: t('cycles.real.description') } %>
+
+      <%= f.govuk_radio_divider %>
+
+      <% (CycleTimetable.fake_schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
+        <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
+      <% end %>
+    <% end %>
+
+    <%= f.govuk_submit 'Update point in recruitment cycle' %>
+  <% end %>
+
+  <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<% end %>
+
+<h2 class="govuk-heading-m">Cycle years</h2>
+
+
+ <%= render SummaryListComponent.new(rows: {
+  'Previous cycle year' => RecruitmentCycle.previous_year,
+  'Current cycle year' => RecruitmentCycle.current_year,
+  'Next cycle year' => RecruitmentCycle.next_year,
+}) %>
+
+<h2 class="govuk-heading-m">Deadlines</h2>
+
+<p class="govuk-body">(Today is <%= Time.zone.today.to_s(:govuk_date) %>)</p>
+
+<%= render SummaryListComponent.new(rows: {
+  'Apply 1 deadline' => CycleTimetable.apply_1_deadline.to_s(:govuk_date),
+  'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_s(:govuk_date),
+  'Find closes on' => CycleTimetable.find_closes.to_s(:govuk_date),
+  'Find reopens on' => CycleTimetable.find_reopens.to_s(:govuk_date),
+}) %>
+

--- a/config/initializers/sanitise.rb
+++ b/config/initializers/sanitise.rb
@@ -1,0 +1,5 @@
+# Make `sanitize` strip all tags by default
+#
+# https://apidock.com/rails/ActionView/Helpers/SanitizeHelper/sanitize
+# Used by https://apidock.com/rails/ActionView/Helpers/TextHelper/simple_format
+ActionView::Base.sanitized_allowed_tags = %w[]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,3 +76,22 @@ en:
     opening_times: "Monday to Friday, 8.30am to 5pm"
     url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+  cycles:
+    real:
+      name: 'Same as production environment'
+      description: ''
+    today_is_mid_cycle:
+      name: Mid cycle and deadlines should be displayed
+      description: Candidates can see upcoming application deadlines
+    today_is_after_apply_1_deadline_passed:
+      name: Apply 1 deadline has passed
+      description: Candidates can no longer submit their initial application
+    today_is_after_apply_2_deadline_passed:
+      name: Apply 2 deadline has passed
+      description: Candidates can no longer submit any subsequent applications
+    today_is_after_find_closes:
+      name: Find has closed
+      description: Candidates can no longer browse courses on Find
+    today_is_after_find_opens:
+      name: Find has reopened
+      description: Candidates can browse courses on Find

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,10 @@ Rails.application.routes.draw do
   # legacy c# app so we're redirecting to root
   get '/start/location', to: redirect('/', status: '301')
 
+  get '/cycles', to: 'switcher#cycles', as: :cycles
+
+  post '/cycles', to: 'switcher#update', as: :switch_cycle_schedule
+
   scope module: 'result_filters' do
     root to: 'location#start'
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,15 +8,7 @@ Rails.application.routes.draw do
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat
 
-  if CycleTimetable.find_down?
-    get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'
-    get '/', to: redirect('/cycle-has-ended', status: 302)
-    get '/results', to: redirect('/cycle-has-ended', status: 302), as: 'results_redirect'
-    get '/course/*path', to: redirect('/cycle-has-ended', status: 302)
-    get '/start/*path', to: redirect('/cycle-has-ended', status: 302)
-  else
-    get '/cycle-has-ended', to: redirect('/', status: 301)
-  end
+  get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'
 
   get '/cycle-ending-soon', to: redirect('/', status: 301)
   # During the cycle there is no need for a separate path for

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -3,3 +3,4 @@ teacher_training_api:
 valid_referers:
   - http://localhost:5000
 log_level: debug
+redis_url: redis://localhost:6379/0

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,3 +6,4 @@ google:
   big_query:
     project_id: bat-find-test
     dataset: bat-find-test-events
+redis_url: redis://localhost:6379/9

--- a/spec/components/summary_list_component_spec.rb
+++ b/spec/components/summary_list_component_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+
+describe SummaryListComponent, type: :component do
+  it 'renders component with correct structure' do
+    rows = [
+      key: 'Name:',
+      value: 'Lando Calrissian',
+      action: 'Name',
+      change_path: '/some/url',
+    ]
+    result = render_inline(described_class.new(rows: rows))
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Name:')
+    expect(result.css('.govuk-summary-list__value').text).to include('Lando Calrissian')
+    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/some/url')
+    expect(result.css('.govuk-summary-list__actions').text).to include('Change Name')
+  end
+
+  describe 'array content' do
+    it 'renders array content when passed in' do
+      rows = [
+        key: 'Address:',
+        value: ['Whoa Drive', 'Wewvile', 'London'],
+        action: 'Name',
+        change_path: '/some/url',
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.css('.govuk-summary-list__value').to_html).to include('Whoa Drive<br>Wewvile<br>London')
+    end
+
+    it 'renders values as bullets if specified for the row' do
+      rows = [
+        key: 'Address:',
+        value: %w[A list of items],
+        bulleted_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <ul class="govuk-list govuk-list--bullet">
+        <li>A</li>
+        <li>list</li>
+        <li>of</li>
+        <li>items</li>
+        </ul>
+      HTML
+    end
+
+    it 'safely escapes markup when rendering values as bullets' do
+      rows = [
+        key: 'Address:',
+        value: ['<script></script>', '<br>'],
+        bulleted_format: true,
+      ]
+      result = render_inline(described_class.new(rows: rows))
+
+      expect(result.to_html).to include(<<~HTML)
+        <ul class="govuk-list govuk-list--bullet">
+        <li>&lt;script&gt;&lt;/script&gt;</li>
+        <li>&lt;br&gt;</li>
+        </ul>
+      HTML
+    end
+  end
+
+  it 'renders component with correct struture using action_path' do
+    rows = [
+      key: 'Please enter the sound a cat makes',
+      value: 'Meow',
+      action: 'Enter cat sounds',
+      action_path: '/cat/sounds',
+    ]
+    result = render_inline(described_class.new(rows: rows))
+
+    expect(result.css('.govuk-summary-list__key').text).to include('Please enter the sound a cat makes')
+    expect(result.css('.govuk-summary-list__value').text).to include('Meow')
+    expect(result.css('.govuk-summary-list__actions a').attr('href').value).to include('/cat/sounds')
+    expect(result.css('.govuk-summary-list__actions').text).to include('Enter cat sounds')
+  end
+
+  it 'renders HTML in values when safe' do
+    rows = [
+      key: 'Safe',
+      value: '<span class="safe-html">This is safe</span>'.html_safe,
+    ]
+
+    result = render_inline(described_class.new(rows: rows))
+    expect(result.css('.govuk-summary-list__value > .safe-html').text).to include('This is safe')
+  end
+
+  it 'uses simple_format to convert line breaks and strip HTML' do
+    rows = [
+      key: 'Unsafe',
+      value: '<span class="unsafe-html"><script>Unsafe</script></span>',
+    ]
+
+    result = render_inline(described_class.new(rows: rows))
+    expect(result.css('.govuk-summary-list__value p').to_html).to eq('<p class="govuk-body">Unsafe</p>')
+  end
+
+  it 'supports adding data_qa to rows' do
+    rows = [{ key: 'Job',
+              value: 'Ice cream man',
+              data_qa: 'ice-cream-man' }]
+
+    result = render_inline(described_class.new(rows: rows))
+
+    expect(result.css('[data-qa="ice-cream-man"]')).to be_present
+  end
+
+  it 'handles rows with multiple actions' do
+    rows = [
+      { key: 'Role',
+        value: 'Chef de partie',
+        actions: [
+          { verb: 'Change', object: 'role', path: '#change-role' },
+          { verb: 'Remove', object: 'this chef', path: '#remove' },
+        ] },
+    ]
+
+    result = render_inline(described_class.new(rows: rows))
+
+    links = result.css('.govuk-summary-list__actions a')
+
+    expect(links[0].text).to eq 'Change role'
+    expect(links[0].attr('href')).to eq '#change-role'
+
+    expect(links[1].text).to eq 'Remove this chef'
+    expect(links[1].attr('href')).to eq '#remove'
+  end
+end

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Cycle switcher', type: :feature do
+  it 'Navigates to the cycle switcher' do
+    visit switch_cycle_schedule_path
+
+    expect(page).to have_text('Current point in the recruitment cycle')
+  end
+
+  it 'show the deadline banner' do
+    visit switch_cycle_schedule_path
+    page.choose 'Mid cycle and deadlines should be displayed'
+    click_button 'Update point in recruitment cycle'
+    visit root_path
+
+    expect(page).to have_text("Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year")
+  end
+
+  it 'shows the Apply 1 has closed banner' do
+    visit switch_cycle_schedule_path
+    page.choose 'Apply 1 deadline has passed'
+    click_button 'Update point in recruitment cycle'
+    visit root_path
+
+    expect(page).to have_text("If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_s(:month_and_year)}")
+  end
+
+  it 'shows the Apply 2 has closed banner' do
+    visit switch_cycle_schedule_path
+    page.choose 'Apply 2 deadline has passed'
+    click_button 'Update point in recruitment cycle'
+    visit root_path
+
+    expect(page).to have_text("It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.cycle_year_range} academic year")
+  end
+
+  it 'closes Find' do
+    visit switch_cycle_schedule_path
+    page.choose 'Find has closed'
+    click_button 'Update point in recruitment cycle'
+    visit root_path
+
+    expect(page).to have_text('Applications closed')
+  end
+
+  it 'opens Find' do
+    visit switch_cycle_schedule_path
+    page.choose 'Find has reopened'
+    click_button 'Update point in recruitment cycle'
+    visit root_path
+
+    expect(page).to have_text('Find courses by location or by training provider')
+  end
+end

--- a/spec/requests/end_of_cycle_spec.rb
+++ b/spec/requests/end_of_cycle_spec.rb
@@ -22,9 +22,9 @@ describe '/cycle-has-ended', type: :request do
 
     [
       '/',
-      '/start/foo',
+      '/start/subject?l=2',
       '/results',
-      '/course/foo',
+      '/course/1N1/238T',
     ].each do |path|
       it "redirects #{path} to '/cycle-has-ended'" do
         get path

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -91,6 +91,13 @@ RSpec.describe CycleTimetable do
         expect(CycleTimetable.mid_cycle?).to be false
       end
     end
+
+    context 'when current_cycle_schedule returns `:today_is_after_find_opens`' do
+      it 'returns true' do
+        allow(CycleTimetable).to receive(:current_cycle_schedule).and_return(:today_is_after_find_opens)
+        expect(CycleTimetable.mid_cycle?).to be true
+      end
+    end
   end
 
   describe '.show_apply_1_deadline_banner?' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -87,6 +87,9 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+
+  config.before { RedisService.new.flushdb }
+
   require 'webmock/rspec'
   require 'factory_bot'
   config.include FactoryBot::Syntax::Methods

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'site_prism'
 require 'simplecov'
+require './app/lib/redis'
 
 SimpleCov.minimum_coverage 95
 SimpleCov.start 'rails' do


### PR DESCRIPTION
### Context

We're no longer using feature flags to move between phases of the cycle on Find to test EoC behaviour & content.

Apply has a switcher which allows you to move between the discreet phases of the cycle – this is to port the behaviour over to Find.

### Changes proposed in this pull request

Adds a cycle switcher under the `/cycles` endpoint:
![image](https://user-images.githubusercontent.com/47917431/128381005-c1ba6726-fea9-48d3-bb73-d576064ca0e6.png)

This will jump Find forward/back to different points in the cycle. It can only be used in a non-prod environment.

### Guidance to review

Similar to the logic on Apply

Using `http://localhost:3002/cycles` locally you can now switch between the different phases and then view the changes.

### Trello card

https://trello.com/c/K8cXWM7N

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
