### PR TITLE
Update the content in the entry requirements section of the course page

### DIFF
--- a/app/components/courses/entry_requirements_component.html.erb
+++ b/app/components/courses/entry_requirements_component.html.erb
@@ -3,7 +3,7 @@
   <h3 class="govuk-heading-m">Qualifications needed</h3>
   <div data-qa="course__required_qualifications">
     <p class="govuk-body">
-      <%= degree_grade_content(course) %>.
+      <%= degree_grade_content(course) %>
     </p>
 
     <% if course.degree_subject_requirements.present? %>
@@ -13,15 +13,15 @@
     <% end %>
 
     <p class="govuk-body">
-      <%= required_gcse_content(course) %>.
+      <%= required_gcse_content(course) %>
     </p>
 
     <p class="govuk-body">
-      <%= pending_gcse_content(course) %>.
+      <%= pending_gcse_content(course) %>
     </p>
 
     <p class="govuk-body">
-      <%= gcse_equivalency_content(course) %>.
+      <%= gcse_equivalency_content(course) %>
     </p>
 
     <% if course.additional_gcse_equivalencies.present? %>

--- a/app/components/courses/entry_requirements_component.rb
+++ b/app/components/courses/entry_requirements_component.rb
@@ -13,38 +13,38 @@ module Courses
     def degree_grade_content(course)
       case course.degree_grade
       when 'two_one'
-        '2:1 or above, or equivalent'
+        'An undergraduate degree at class 2:1 or above, or equivalent.'
       when 'two_two'
-        '2:2 or above, or equivalent'
+        'An undergraduate degree at class 2:2 or above, or equivalent.'
       when 'third_class'
-        'Third class degree or above, or equivalent'
+        'An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.'
       when 'not_required'
-        'An undergraduate degree, or equivalent'
+        'An undergraduate degree, or equivalent.'
       end
     end
 
     def required_gcse_content(course)
       case course.level
       when 'primary'
-        "Grade #{course.gcse_grade_required} (C) or above in English, maths and science, or equivalent qualification"
+        "Grade #{course.gcse_grade_required} (C) or above in English, maths and science, or equivalent qualification."
       when 'secondary'
-        "Grade #{course.gcse_grade_required} (C) or above in English and maths, or equivalent qualification"
+        "Grade #{course.gcse_grade_required} (C) or above in English and maths, or equivalent qualification."
       end
     end
 
     def pending_gcse_content(course)
       if course.accept_pending_gcse
-        'Candidates with pending GCSEs will be considered'
+        'We will consider candidates with pending GCSEs.'
       else
-        'Candidates with pending GCSEs will not be considered'
+        'We will not consider candidates with pending GCSEs.'
       end
     end
 
     def gcse_equivalency_content(course)
       if course.accept_gcse_equivalency?
-        "Equivalency tests will be accepted in #{equivalencies}"
+        "We will accept equivalency tests in #{equivalencies}."
       else
-        'Equivalency tests will not be accepted'
+        'We do not accept equivalency tests.'
       end
     end
 

--- a/app/components/courses/entry_requirements_component.rb
+++ b/app/components/courses/entry_requirements_component.rb
@@ -34,7 +34,7 @@ module Courses
 
     def pending_gcse_content(course)
       if course.accept_pending_gcse
-        'We will consider candidates with pending GCSEs.'
+        'We’ll consider candidates with pending GCSEs.'
       else
         'We will not consider candidates with pending GCSEs.'
       end
@@ -42,9 +42,9 @@ module Courses
 
     def gcse_equivalency_content(course)
       if course.accept_gcse_equivalency?
-        "We will accept equivalency tests in #{equivalencies}."
+        "We’ll consider candidates who need to take a GCSE equivalency test in #{equivalencies}."
       else
-        'We do not accept equivalency tests.'
+        'We will not consider candidates who need to take a GCSE equivalency test.'
       end
     end
 
@@ -54,7 +54,7 @@ module Courses
       subjects << 'maths' if course.accept_maths_gcse_equivalency.present?
       subjects << 'science' if course.accept_science_gcse_equivalency.present?
 
-      subjects.to_sentence(last_word_connector: ' and ')
+      subjects.to_sentence(last_word_connector: ' or ', two_words_connector: ' or ')
     end
   end
 end

--- a/app/components/courses/international_students_component.html.erb
+++ b/app/components/courses/international_students_component.html.erb
@@ -2,7 +2,7 @@
   <h2 class="govuk-heading-l" id="section-international-students">International students</h2>
   <div data-qa="course__international_students">
     <p class="govuk-body"><%= visa_sponsorship_status %></p>
-    <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you are an Irish citizen.</p>
+    <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you’re an Irish citizen.</p>
     <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <%= govuk_link_to("UK ENIC statement", "https://www.enic.org.uk") %>.</p>
   </div>
 </div>

--- a/app/components/courses/international_students_component.rb
+++ b/app/components/courses/international_students_component.rb
@@ -18,7 +18,7 @@ module Courses
       elsif @course.salaried? && provider.can_sponsor_skilled_worker_visa
         "We can sponsor #{govuk_link_to('Skilled Worker visas', TRAIN_TO_TEACH_URL)}, but this is not guaranteed.".html_safe
       else
-        "We cannot sponsor visas. You will need to #{govuk_link_to('get the right visa or status to study in the UK', TRAIN_TO_TEACH_URL)}.".html_safe
+        "We cannot sponsor visas. You’ll need to #{govuk_link_to('get the right visa or status to study in the UK', TRAIN_TO_TEACH_URL)}.".html_safe
       end
     end
   end

--- a/spec/components/courses/entry_requirements_component_spec.rb
+++ b/spec/components/courses/entry_requirements_component_spec.rb
@@ -10,7 +10,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'Candidates with pending GCSEs will be considered',
+        'We will consider candidates with pending GCSEs.',
       )
     end
   end
@@ -24,7 +24,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'Candidates with pending GCSEs will not be considered',
+        'We will not consider candidates with pending GCSEs.',
       )
     end
   end
@@ -39,7 +39,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'Grade 4 (C) or above in English, maths and science, or equivalent qualification',
+        'Grade 4 (C) or above in English, maths and science, or equivalent qualification.',
       )
     end
   end
@@ -89,7 +89,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'Equivalency tests will not be accepted.',
+        'We do not accept equivalency tests.',
       )
     end
   end
@@ -106,7 +106,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'Equivalency tests will be accepted in maths and science.',
+        'We will accept equivalency tests in maths and science.',
       )
     end
   end

--- a/spec/components/courses/entry_requirements_component_spec.rb
+++ b/spec/components/courses/entry_requirements_component_spec.rb
@@ -10,7 +10,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'We will consider candidates with pending GCSEs.',
+        'We’ll consider candidates with pending GCSEs',
       )
     end
   end
@@ -89,7 +89,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'We do not accept equivalency tests.',
+        'We will not consider candidates who need to take a GCSE equivalency test.',
       )
     end
   end
@@ -106,7 +106,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
       result = render_inline(described_class.new(course: course))
 
       expect(result.text).to include(
-        'We will accept equivalency tests in maths and science.',
+        'We’ll consider candidates who need to take a GCSE equivalency test in maths or science',
       )
     end
   end

--- a/spec/components/courses/international_students_component_spec.rb
+++ b/spec/components/courses/international_students_component_spec.rb
@@ -15,7 +15,7 @@ describe Courses::InternationalStudentsComponent do
       )
       result = render_inline(described_class.new(course: CourseDecorator.new(course)))
 
-      expect(result.text).to include('We cannot sponsor visas. You will need to get the right visa or status to study in the UK')
+      expect(result.text).to include('We cannot sponsor visas. You’ll need to get the right visa or status to study in the UK')
       expect(result).to have_selector("a[href='#{described_class::TRAIN_TO_TEACH_URL}']")
     end
   end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -261,10 +261,10 @@ describe 'Course show', type: :feature do
           'Grade 4 (C) or above in English and maths, or equivalent qualification.',
         )
         expect(course_page.required_qualifications).to have_content(
-          'Candidates with pending GCSEs will be considered.',
+          'We will consider candidates with pending GCSEs.',
         )
         expect(course_page.required_qualifications).to have_content(
-          'Equivalency tests will be accepted in English.',
+          'We will accept equivalency tests in English.',
         )
         expect(course_page.required_qualifications).to have_content(
           'You need to work hard',

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -261,10 +261,10 @@ describe 'Course show', type: :feature do
           'Grade 4 (C) or above in English and maths, or equivalent qualification.',
         )
         expect(course_page.required_qualifications).to have_content(
-          'We will consider candidates with pending GCSEs.',
+          'We’ll consider candidates with pending GCSEs.',
         )
         expect(course_page.required_qualifications).to have_content(
-          'We will accept equivalency tests in English.',
+          'We’ll consider candidates who need to take a GCSE equivalency test in English.',
         )
         expect(course_page.required_qualifications).to have_content(
           'You need to work hard',


### PR DESCRIPTION
### Context

After product review, there are some required changes to the `International students` and `Entry requirements` sections of the course page.

### Changes proposed in this pull request

1. use positive contractions in the international students component 
2. add copy around the required degree grade i.e. `2:1 or above, or equivalent` => `An undergraduate degree at class 2:1 or above, or equivalent`
3. update copy for equivalencies and pending GCSEs

### Trello card

https://trello.com/c/eHkPZRRx/3787-update-content-on-find-publish-for-structured-quals

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
