### PR TITLE
Add GiT link to the course page

### DIFF
--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -7,6 +7,10 @@
     speak to an adviser using their  <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>
     <%= t('get_into_teaching.opening_times') %> (except public holidays).</p>
 
+  <p class="govuk-body">Find out about the different
+  <%= govuk_link_to('ways to train', t('get_into_teaching.url_ways_to_train')) %>
+  if you do not have a degree, or are already an experienced teacher.</p>
+
   <h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
   <p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to('contact us by email', subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})") %>.</p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
     opening_times: "Monday to Friday, 8.30am to 5pm"
     url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
+    url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
   cycles:
     real:
       name: 'Same as production environment'


### PR DESCRIPTION
### Context

We need to add a new links to the Get into teaching site on the Find course page.

### Changes proposed in this pull request

- [x] Under the _Support and advice section we add an extra paragraph with the _ways to _train_ link.

<img width="714" alt="image" src="https://user-images.githubusercontent.com/450843/129356695-a1c8555c-eed3-4396-860a-4fe183e696ea.png">

### Guidance to review

- Is the copy correct and does the link work?

### Trello card

https://trello.com/c/EC0lo4u6/3728-add-git-links-to-apply-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
