### PR TITLE
Move root redirect before action into a private method

### DIFF
--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -1,6 +1,6 @@
 class SwitcherController < ApplicationController
   skip_before_action :redirect_to_cycle_has_ended_if_find_is_down
-  before_action redirect_to root_path if Rails.env.production?
+  before_action :redirect_to_homepage_if_in_production
 
   def cycles; end
 
@@ -9,5 +9,11 @@ class SwitcherController < ApplicationController
     SiteSetting.set(name: 'cycle_schedule', value: new_cycle)
     flash[:success] = 'Cycle schedule updated'
     redirect_to cycles_path
+  end
+
+private
+
+  def redirect_to_homepage_if_in_production
+    redirect_to root_path if Rails.env.production?
   end
 end


### PR DESCRIPTION
### Context

Original cycle switcher PR [#866](https://github.com/DFE-Digital/find-teacher-training/pull/866) is currently unable to deploy to production due to:
```
2021-08-16T12:46:47.90+0100 [APP/PROC/WEB/0] ERR /app/app/controllers/switcher_controller.rb:3:in `<class:SwitcherController>': undefined local variable or method `root_path' for SwitcherController:Class (NameError)
```

### Changes proposed in this pull request

`root_path` is used elsewhere in the codebase but is normally within a private method, this PR will follow that pattern to see if it resolves the issue.

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
