### PR TITLE
Update content on the cycle has ended page

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -110,6 +110,10 @@ class CycleTimetable
     "#{year} to #{year + 1}"
   end
 
+  def self.next_cycle_year_range(year = current_year)
+    "#{year + 1} to #{year + 2}"
+  end
+
   def self.current_cycle_schedule
     # Make sure this setting only has effect on non-production environments
     return :real if HostingEnvironment.production?

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -5,11 +5,21 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Find postgraduate teacher training</h1>
 
-      <h2 class="govuk-heading-m">Applications closed</h2>
-      <p class="govuk-body">Applications for the <%= CycleTimetable.cycle_year_range %> academic year are now closed.</p>
+      <h2 class="govuk-heading-m">Courses are currently closed but you can get ready to apply</h2>
 
-      <h2 class="govuk-heading-m">Find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year</h2>
-      <p class="govuk-body">You can find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> and apply from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.</p>
+      <p class="govuk-body">Applications for the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
+
+      <p class="govuk-body">
+        You can <%= govuk_link_to('start or continue an application', Settings.apply_base_url) %>
+        for courses starting in the <%= CycleTimetable.next_cycle_year_range %>
+        academic year.
+      </p>
+
+      <p class="govuk-body">You'll be able to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>find courses from <%= l(CycleTimetable.find_opens.to_time, format: :hour_and_median) %> on <%= l(CycleTimetable.find_opens.to_date) %></li>
+        <li>submit your application from <%= l(CycleTimetable.apply_reopens.to_time, format: :hour_and_median) %> on <%= l(CycleTimetable.apply_reopens.to_date) %></li>
+      </ul>
     </div>
   </div>
 </div>

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -3,11 +3,9 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Find postgraduate teacher training</h1>
+      <h1 class="govuk-heading-l">Applications are currently closed but you can get ready to apply</h2>
 
-      <h2 class="govuk-heading-m">Courses are currently closed but you can get ready to apply</h2>
-
-      <p class="govuk-body">Applications for the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
+      <p class="govuk-body">Applications for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
 
       <p class="govuk-body">
         You can <%= govuk_link_to('start or continue an application', Settings.apply_base_url) %>
@@ -17,8 +15,8 @@
 
       <p class="govuk-body">You'll be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>find courses from <%= l(CycleTimetable.find_opens.to_time, format: :hour_and_median) %> on <%= l(CycleTimetable.find_opens.to_date) %></li>
-        <li>submit your application from <%= l(CycleTimetable.apply_reopens.to_time, format: :hour_and_median) %> on <%= l(CycleTimetable.apply_reopens.to_date) %></li>
+        <li>find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %></li>
+        <li>submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %></li>
       </ul>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
     formats:
       default: "%-d %B %Y"
       short: "%B %Y"
+  time:
+    formats:
+      hour_and_median: "%l%P"
   qualifications:
     qts: "QTS"
     pgce: "PGCE"

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     click_button 'Update point in recruitment cycle'
     visit root_path
 
-    expect(page).to have_content('Courses are currently closed but you can get ready to apply')
+    expect(page).to have_content('Applications are currently closed but you can get ready to apply')
   end
 
   it 'opens Find' do

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     click_button 'Update point in recruitment cycle'
     visit root_path
 
-    expect(page).to have_text('Applications closed')
+    expect(page).to have_content('Courses are currently closed but you can get ready to apply')
   end
 
   it 'opens Find' do

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -159,4 +159,20 @@ RSpec.describe CycleTimetable do
       end
     end
   end
+
+  describe '.cycle_year_range' do
+    it 'returns the correctly formatted value' do
+      Timecop.travel(one_hour_before_apply_1_deadline) do
+        expect(CycleTimetable.cycle_year_range).to eq('2021 to 2022')
+      end
+    end
+  end
+
+  describe '.next_cycle_year_range' do
+    it 'returns the correctly formatted value' do
+      Timecop.travel(one_hour_before_apply_1_deadline) do
+        expect(CycleTimetable.next_cycle_year_range).to eq('2022 to 2023')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

This PR introduces a content change on the 'cycle has ended' page to encourage people to start an application despite Find being unavailable. 

### Changes proposed in this pull request

Change content on the cycle has ended page to:

<img width="1059" alt="image" src="https://user-images.githubusercontent.com/450843/129869232-0c7b10d0-ba48-4413-8cae-2a347df2b2ac.png">

### Guidance to review

- Is the content and link correct?
- Are the dates correct?

### Trello card

https://trello.com/c/FgUEV9Nv/3852-eoc-con-dev-users-can-start-applying-when-find-is-closed

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
