### PR TITLE
Update 'Find closes' calendar event

### DIFF
--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -6,7 +6,7 @@ class CycleTimetable
       first_deadline_banner: Time.zone.local(2021, 7, 12, 9),
       apply_1_deadline: Time.zone.local(2021, 9, 7, 18),
       apply_2_deadline: Time.zone.local(2021, 9, 21, 18),
-      find_closes: Time.zone.local(2021, 10, 3),
+      find_closes: Time.zone.local(2021, 10, 4, 23, 59, 59),
     },
     2022 => {
       find_opens: Time.zone.local(2021, 10, 5, 9),
@@ -16,7 +16,7 @@ class CycleTimetable
       first_deadline_banner: Time.zone.local(2022, 7, 12, 9),
       apply_1_deadline: Time.zone.local(2022, 9, 7, 18),
       apply_2_deadline: Time.zone.local(2022, 9, 21, 18),
-      find_closes: Time.zone.local(2022, 10, 3),
+      find_closes: Time.zone.local(2022, 10, 4, 23, 59, 59),
     },
     2023 => {
       find_opens: Time.zone.local(2022, 10, 5, 9),

--- a/spec/requests/end_of_cycle_spec.rb
+++ b/spec/requests/end_of_cycle_spec.rb
@@ -11,7 +11,7 @@ describe '/cycle-has-ended', type: :request do
 
   context 'end of cycle' do
     before do
-      Timecop.freeze(2021, 10, 3, 1)
+      Timecop.freeze(CycleTimetable.find_closes)
       Rails.application.reload_routes!
     end
 

--- a/spec/services/cycle_timetable_spec.rb
+++ b/spec/services/cycle_timetable_spec.rb
@@ -1,38 +1,38 @@
 require 'rails_helper'
 
 RSpec.describe CycleTimetable do
-  let(:one_hour_before_find_opens) { Time.zone.local(2020, 10, 6, 8, 0, 0) }
-  let(:one_hour_after_find_opens) { Time.zone.local(2020, 10, 6, 10, 0, 0) }
-  let(:one_hour_before_first_deadline_banner) { Time.zone.local(2021, 7, 12, 8, 0, 0) }
-  let(:one_hour_before_apply_1_deadline) { Time.zone.local(2021, 8, 24, 17, 0, 0) }
-  let(:one_hour_after_apply_1_deadline) { Time.zone.local(2021, 9, 7, 19, 0, 0) }
-  let(:one_hour_before_apply_2_deadline) { Time.zone.local(2021, 9, 21, 17, 0, 0) }
-  let(:one_hour_after_apply_2_deadline) { Time.zone.local(2021, 9, 21, 19, 0, 0) }
-  let(:one_hour_after_find_closes) { Time.zone.local(2021, 10, 4, 1, 0, 0) }
-  let(:one_hour_after_find_reopens) { Time.zone.local(2021, 10, 5, 10, 0, 0) }
+  let(:one_hour_before_find_opens) { CycleTimetable.find_opens - 1.hour }
+  let(:one_hour_after_find_opens) { CycleTimetable.find_opens + 1.hour }
+  let(:one_hour_before_first_deadline_banner) { CycleTimetable.first_deadline_banner - 1.hour }
+  let(:one_hour_before_apply_1_deadline) { CycleTimetable.apply_1_deadline - 1.hour }
+  let(:one_hour_after_apply_1_deadline) { CycleTimetable.apply_1_deadline + 1.hour  }
+  let(:one_hour_before_apply_2_deadline) { CycleTimetable.apply_2_deadline - 1.hour }
+  let(:one_hour_after_apply_2_deadline) { CycleTimetable.apply_2_deadline + 1.hour }
+  let(:one_hour_after_find_closes) { CycleTimetable.find_closes + 1.hour }
+  let(:one_hour_after_find_reopens) { CycleTimetable.find_reopens + 1.hour }
 
   describe '.current_year' do
     it 'is 2021 if we are in the middle of the 2021 cycle' do
-      Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
+      Timecop.travel(one_hour_after_find_opens) do
         expect(CycleTimetable.current_year).to eq(2021)
       end
     end
 
     it 'is 2022 if we are in the middle of the 2022 cycle' do
-      Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
+      Timecop.travel(one_hour_after_find_reopens) do
         expect(CycleTimetable.current_year).to eq(2022)
       end
     end
   end
 
   describe '.next_year' do
-    it 'is 2021 if we are in the middle of the 2021 cycle' do
+    it 'is 2022 if we are in the middle of the 2021 cycle' do
       Timecop.travel(Time.zone.local(2021, 1, 1, 12, 0, 0)) do
         expect(CycleTimetable.next_year).to eq(2022)
       end
     end
 
-    it 'is 2022 if we are in the middle of the 2022 cycle' do
+    it 'is 2023 if we are in the middle of the 2022 cycle' do
       Timecop.travel(Time.zone.local(2021, 11, 1, 12, 0, 0)) do
         expect(CycleTimetable.next_year).to eq(2023)
       end


### PR DESCRIPTION
## Context

Find closes at the end of the day (11:59pm) on 4th October in the 2021 cycle

## Changes proposed in this pull request

Make it so.

## Guidance to review

It should just work ™️ 

## Link to Trello card

https://trello.com/c/y2CZ1eMw/3856-eoc-dev-update-find-closed-date-in-timeline-across-find-apply

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
