### PR TITLE
Edit 'Apply 1' deadline banner

### DIFF
--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -1,9 +1,14 @@
 <% if CycleTimetable.show_apply_1_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year") %>
-    <p class="govuk-body">Courses can fill up at any time, so you should apply as soon as you can.</p>
-    <p class="govuk-body">If you’re applying for the first time since applications opened in <%= CycleTimetable.find_opens.to_s(:month_and_year) %>, apply no later than <%= apply_1_deadline %>.</p>
-    <p class="govuk-body">If your application did not lead to a place and you’re applying again, apply no later than <%= apply_2_deadline %>.</p>
+    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in October 2020") %>
+    <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= CycleTimetable.cycle_year_range %> academic year.</p>
+    <p class="govuk-body">You can <%= govuk_link_to('start or continue your application', Settings.apply_base_url) %> to get it ready for courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
+    <p class="govuk-body">
+      You’ll be able to find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> and submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.
+    </p>
+
+    <h2 class="govuk-heading-m">If your application did not lead to a place and you’re applying again</h2>
+    <p class="govuk-body">You can continue to search and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until <%= CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time) %>.</p>
   <% end %>
 <% elsif CycleTimetable.show_apply_2_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>

--- a/spec/components/deadline_banner_component_spec.rb
+++ b/spec/components/deadline_banner_component_spec.rb
@@ -16,9 +16,8 @@ describe DeadlineBannerComponent, type: :component do
       Timecop.travel(CycleTimetable.first_deadline_banner + 1.hour) do
         result = render_inline(described_class.new(flash_empty: true))
 
-        expect(result.text).to include('Courses can fill up at any time, so you should apply as soon as you can.')
-        expect(result.text).not_to include("You can continue to view and apply for courses until 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}")
-        expect(result.text).not_to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
+        expect(result.text).to include('If you’re applying for the first time since applications opened in October 2020')
+        expect(result.text).to include('If your application did not lead to a place and you’re applying again')
       end
     end
   end

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     click_button 'Update point in recruitment cycle'
     visit root_path
 
-    expect(page).to have_text("Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year")
+    expect(page).to have_text('If you’re applying for the first time since applications opened in October 2020')
   end
 
   it 'shows the Apply 1 has closed banner' do


### PR DESCRIPTION
### Context
We want to edit the content so that users are encouraged to create an account and start applying anyway once the apply deadline has closed.

### Changes proposed in this pull request

<img width="966" alt="deadline_banner" src="https://user-images.githubusercontent.com/5256922/129879481-fdfd2b32-50af-464f-ab74-99e4e029cdf9.png">


### Trello card
https://trello.com/c/16nEVOp9/3857-dev-edit-eoc-banner-the-one-when-apply-1-has-passed-to-give-link-to-apply-sign

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
