### PR TITLE
Update content on the course show page

### DIFF
--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -138,7 +138,21 @@
         <% else %>
           <div data-qa="course__end_of_cycle_notice">
             <h1 class="govuk-heading-l">Apply</h1>
-            <p class="govuk-body">Courses are currently closed. Come back from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> to find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year. You can submit an application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.</p>
+            <p class="govuk-body">
+              Courses are currently closed but you can still
+              <%= govuk_link_to('start or continue an application', Settings.apply_base_url) %>
+              anyway.
+            </p>
+
+            <p class="govuk-body">You'll be able to:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+              <li>
+                find courses starting in the <%= CycleTimetable.next_cycle_year_range %>
+                academic year from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %>
+              </li>
+              <li>submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %></li>
+            </ul>
           </div>
         <% end %>
       </div>


### PR DESCRIPTION
### Context

New content encourages candidates to begin preparing to apply even while Find is closed

### Changes proposed in this pull request

- [x] Update content on the course show page as follows:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/450843/129931500-88c68442-acd6-45b6-9d2e-41ac6fa0701b.png">

### Guidance to review

### Trello card
https://trello.com/c/Nrv8otUv/3846-eoc-con-dev-users-can-still-start-applying-when-applications-are-closed

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
