### PR TITLE
Update apply 2 deadline banner for EOC

### DIFF
--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -17,8 +17,9 @@
   <% end %>
 <% elsif CycleTimetable.show_cycle_closed_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.cycle_year_range} academic year") %>
-    <p class="govuk-body">Come back from <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range %> academic year, as there’s no guarantee that the courses currently shown on this website will be on offer next year.</p>
-    <p class="govuk-body">You can submit an application from <%= apply_reopens %>.</p>
+    <%= notification_banner.slot(:heading, text: "Courses are currently closed but you can get your application ready") %>
+    <p class="govuk-body">Courses starting in the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
+    <p class="govuk-body">You can <%= govuk_link_to('start or continue your application', Settings.apply_base_url) %> to get it ready for courses starting in the <%= CycleTimetable.next_cycle_year_range %> academic year.</p>
+    <p class="govuk-body">You’ll be able to find courses from <%= CycleTimetable.find_reopens.to_s(:govuk_date_and_time) %> and submit your application from <%= CycleTimetable.apply_reopens.to_s(:govuk_date_and_time) %>.</p>
   <% end %>
 <% end %>

--- a/spec/components/deadline_banner_component_spec.rb
+++ b/spec/components/deadline_banner_component_spec.rb
@@ -40,7 +40,7 @@ describe DeadlineBannerComponent, type: :component do
       Timecop.travel(CycleTimetable.apply_2_deadline + 1.hour) do
         result = render_inline(described_class.new(flash_empty: true))
 
-        expect(result.text).to include('as there’s no guarantee that the courses currently shown on this website will be on offer next year.')
+        expect(result.text).to include("Courses starting in the #{CycleTimetable.cycle_year_range} academic year are closed")
         expect(result.text).not_to include('Courses can fill up at any time, so you should apply as soon as you can.')
         expect(result.text).not_to include("If your application did not lead to a place and you’re applying again, apply no later than 6pm on #{CycleTimetable.apply_2_deadline.strftime('%e %B %Y')}.")
       end

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -297,7 +297,7 @@ describe 'Course show', type: :feature do
       end
 
       it 'renders the deadline banner' do
-        expect(page).to have_content "It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.current_year} to #{CycleTimetable.next_year} academic year"
+        expect(page).to have_content 'Courses are currently closed but you can get your application ready'
       end
     end
   end

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe 'Cycle switcher', type: :feature do
     click_button 'Update point in recruitment cycle'
     visit root_path
 
-    expect(page).to have_text("It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.cycle_year_range} academic year")
+    expect(page).to have_text('Courses are currently closed but you can get your application ready')
+    expect(page).to have_text("Courses starting in the #{CycleTimetable.cycle_year_range} academic year are closed")
   end
 
   it "redirects to the 'cycle has ended' page" do

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -240,7 +240,7 @@ RSpec.feature 'Results page new area and provider filter' do
           Timecop.travel(CycleTimetable.apply_2_deadline + 1.hour) do
             start_page.load
 
-            expect(start_page).to have_content('there’s no guarantee that the courses currently shown on this website will be on offer next year.')
+            expect(start_page).to have_content('Courses are currently closed but you can get your application ready')
           end
         end
       end


### PR DESCRIPTION
### Context

Change content of the apply 2 deadline banner to encourage candidates to begin their application before
find and apply reopen.

### Changes proposed in this pull request

- [x] Change content as follows:
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/450843/130242789-366a1600-5576-4690-8767-41749dce6575.png">

### Guidance to review

- Is the copy correct?
- Do the spec changes make sense?

### Trello card

https://trello.com/c/x0NPUz9I/3858-dev-edit-eoc-banner-the-one-when-apply-2-has-passed-to-include-link-to-sign-in

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
