### PR TITLE
Use sidekiq for async jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,9 @@ gem 'govuk-components'
 # Data integration with BigQuery
 gem 'google-cloud-bigquery'
 
+# Async job queue
+gem 'sidekiq'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
     config (3.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.2.5)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -406,6 +407,10 @@ GEM
     semantic_range (3.0.0)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
+    sidekiq (6.2.1)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     signet (0.15.0)
       addressable (~> 2.3)
       faraday (>= 0.17.3, < 2.0)
@@ -519,6 +524,7 @@ DEPENDENCIES
   rubypants
   scss_lint-govuk
   sentry-raven
+  sidekiq
   simplecov (< 0.18)
   site_prism
   skylight

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -p $PORT
+worker: bundle exec sidekiq -c 5 -C config/sidekiq.yml

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,8 +33,6 @@ module FindTeacherTraining
 
     config.skylight.environments = Settings.skylight_enable ? [Rails.env] : []
 
-    # Configure ActiveJobs to use on-server thread pool. This is acceptable for
-    # BigQuery event sending for now, can be changed to Sidekiq in the future.
-    config.active_job.queue_adapter = :async
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+---
+:queues:
+  - default


### PR DESCRIPTION
### Context

We use in-memory queues for async jobs at the moment, which are ephemeral. Sidekiq uses Redis, which is permanent and therefore more reliable.

### Changes proposed in this pull request

Install Sidekiq and use it as the default queue adapter.