### PR TITLE
Update Apply 2 Deadline Banner

### DIFF
--- a/app/components/deadline_banner_component.html.erb
+++ b/app/components/deadline_banner_component.html.erb
@@ -7,10 +7,11 @@
   <% end %>
 <% elsif CycleTimetable.show_apply_2_deadline_banner? %>
   <%= govuk_notification_banner(title: "Important") do |notification_banner| %>
-    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_s(:month_and_year)}") %>
+    <%= notification_banner.slot(:heading, text: "If you’re applying for the first time since applications opened in #{find_opens}") %>
     <p class="govuk-body">It’s no longer possible to apply for teacher training starting in the <%= CycleTimetable.cycle_year_range %> academic year.</p>
-    <p class="govuk-body">Come back from <%= find_reopens %> to find courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
-    <p class="govuk-body">You can submit an application from <%= apply_reopens %>.</p>
+    <p class="govuk-body">You can <%= govuk_link_to('start or continue your application', Settings.apply_base_url) %> to get it ready for courses starting in the <%= CycleTimetable.cycle_year_range(CycleTimetable.next_year) %> academic year.</p>
+    <p class="govuk-body">You’ll be able to find courses from <%= find_reopens %> and submit your application from <%= apply_reopens %>.</p>
+
     <p class="govuk-notification-banner__heading">If your application did not lead to a place and you’re applying again</p>
     <p class="govuk-body">You can continue to view and apply for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year until <%= apply_2_deadline %>.</p>
   <% end %>

--- a/app/components/deadline_banner_component.rb
+++ b/app/components/deadline_banner_component.rb
@@ -19,6 +19,10 @@ private
     CycleTimetable.apply_2_deadline.to_s(:govuk_date_and_time)
   end
 
+  def find_opens
+    CycleTimetable.find_opens.to_s(:month_and_year)
+  end
+
   def find_reopens
     CycleTimetable.find_reopens.to_s(:govuk_date_and_time)
   end

--- a/app/views/pages/cycle_has_ended.html.erb
+++ b/app/views/pages/cycle_has_ended.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-l">Applications are currently closed but you can get ready to apply</h2>
+      <h1 class="govuk-heading-l">Applications are currently closed but you can get ready to apply</h1>
 
       <p class="govuk-body">Applications for courses starting in the <%= CycleTimetable.cycle_year_range %> academic year are closed.</p>
 

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     expect(page).to have_text('Current point in the recruitment cycle')
   end
 
-  it 'show the deadline banner' do
+  it "show the 'apply 1 deadline' banner" do
     visit switch_cycle_schedule_path
     page.choose 'Mid cycle and deadlines should be displayed'
     click_button 'Update point in recruitment cycle'
@@ -18,7 +18,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     expect(page).to have_text("Apply now to get on a course starting in the #{CycleTimetable.cycle_year_range} academic year")
   end
 
-  it 'shows the Apply 1 has closed banner' do
+  it "shows the 'apply 2 deadline' banner" do
     visit switch_cycle_schedule_path
     page.choose 'Apply 1 deadline has passed'
     click_button 'Update point in recruitment cycle'
@@ -27,7 +27,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     expect(page).to have_text("If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_s(:month_and_year)}")
   end
 
-  it 'shows the Apply 2 has closed banner' do
+  it "shows the 'cycle has closed' banner" do
     visit switch_cycle_schedule_path
     page.choose 'Apply 2 deadline has passed'
     click_button 'Update point in recruitment cycle'
@@ -36,21 +36,23 @@ RSpec.describe 'Cycle switcher', type: :feature do
     expect(page).to have_text("It’s no longer possible to apply for teacher training starting in the #{CycleTimetable.cycle_year_range} academic year")
   end
 
-  it 'closes Find' do
+  it "redirects to the 'cycle has ended' page" do
     visit switch_cycle_schedule_path
     page.choose 'Find has closed'
     click_button 'Update point in recruitment cycle'
     visit root_path
 
     expect(page).to have_content('Applications are currently closed but you can get ready to apply')
+    expect(page).to have_current_path(cycle_has_ended_path)
   end
 
-  it 'opens Find' do
+  it 'redirects to the start wizard' do
     visit switch_cycle_schedule_path
     page.choose 'Find has reopened'
     click_button 'Update point in recruitment cycle'
     visit root_path
 
     expect(page).to have_text('Find courses by location or by training provider')
+    expect(page).to have_current_path(root_path)
   end
 end


### PR DESCRIPTION
### Context

[Reinstating earlier changes](https://github.com/DFE-Digital/find-teacher-training/pull/890) but this time editing the correct banner 😄 

Have also updated specs for clarity 

### Changes proposed in this pull request

Apply 2 deadline now appears as follows

<img width="1082" alt="apply_2_deadline_banner" src="https://user-images.githubusercontent.com/5256922/130089800-baa8d095-d26d-4a32-a330-f6481f4f27cc.png">

### Trello card
https://trello.com/c/16nEVOp9/3857-dev-edit-eoc-banner-the-one-when-apply-1-has-passed-to-give-link-to-apply-sign

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
