### PR TITLE
update link to TT in Wales

### DIFF
--- a/app/views/results/_no_results.html.erb
+++ b/app/views/results/_no_results.html.erb
@@ -9,7 +9,7 @@
   </p>
 <% when "Wales" %>
   <p class="govuk-body">
-    <%= govuk_link_to 'Learn more about teacher training in Wales', 'https://www.discoverteaching.wales/routes-into-teaching/' %>
+    <%= govuk_link_to 'Learn more about teacher training in Wales', 'https://educators.wales/teachers' %>
   </p>
 <% when "Northern Ireland" %>
   <p class="govuk-body">

--- a/spec/views/results/no_results_spec.rb
+++ b/spec/views/results/no_results_spec.rb
@@ -20,7 +20,7 @@ describe 'results/no_results.html.erb', type: :view do
     it 'renders Welsh teacher training website' do
       expect(html).to match('This service is for courses in England')
       expect(html).to have_link('Learn more about teacher training in Wales',
-                                href: 'https://www.discoverteaching.wales/routes-into-teaching/')
+                                href: 'https://educators.wales/teachers')
     end
   end
 


### PR DESCRIPTION
### Context

The links on Find that refer to teaching training are linking to the wrong site.

Correct link is: https://educators.wales/teachers

### Changes proposed in this pull request

### Guidance to review

per slack discussion: https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1630399478078300

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
