### PR TITLE
Add id to the new subject/provider filter line

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,10 +59,10 @@ gem 'json-schema'
 # Settings for the app
 gem 'config'
 
-#Redis for sidekiq & cache
+# Redis for sidekiq & cache
 gem 'redis'
 
-#Sidekiq for background jobs
+# Sidekiq for background jobs
 gem 'sidekiq'
 
 # Calculate distance between two locations

--- a/app/components/location_subject_filter_component.html.erb
+++ b/app/components/location_subject_filter_component.html.erb
@@ -1,4 +1,4 @@
-  <p class="govuk-body">
+  <p id="filter-line" class="govuk-body">
 		<%= subjects_line %>
 
 			<% if @results.location_filter? %>


### PR DESCRIPTION
### Context

Need to update smoke tests due to [#909](https://github.com/DFE-Digital/find-teacher-training/pull/909) but without an id in the new filter line it's hard to pinpoint due to the number of paragraph classes on the page.

### Changes proposed in this pull request

Added an id to the filter line

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
