### PR TITLE
Return next cycle's courses when changing CycleSwitcher to 'find_reopens'

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -9,7 +9,7 @@ class CoursesController < ApplicationController
       .includes(site_statuses: [:site])
       .includes(provider: [:sites])
       .includes(:accrediting_provider)
-      .where(recruitment_cycle_year: Settings.current_cycle)
+      .where(recruitment_cycle_year: SiteSetting.recruitment_cycle_year)
       .where(provider_code: params[:provider_code])
       .find(params[:course_code])
       .first
@@ -20,7 +20,7 @@ class CoursesController < ApplicationController
   def apply
     course = Course
       .includes(:provider)
-      .where(recruitment_cycle_year: Settings.current_cycle)
+      .where(recruitment_cycle_year: SiteSetting.recruitment_cycle_year)
       .where(provider_code: params[:provider_code])
       .find(params[:course_code])
       .first

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -15,7 +15,7 @@ module ResultFilters
 
       @provider_suggestions = Provider
         .select(:provider_code, :provider_name)
-        .where(recruitment_cycle_year: Settings.current_cycle)
+        .where(recruitment_cycle_year: SiteSetting.recruitment_cycle_year)
         .with_params(search: params[:query])
         .all
 

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,7 +1,7 @@
 class SitemapsController < ApplicationController
   def show
     @courses = Course
-      .where(recruitment_cycle_year: Settings.current_cycle)
+      .where(recruitment_cycle_year: SiteSetting.recruitment_cycle_year)
       .select('course_code', 'provider_code', 'changed_at')
       .page(1)
       .per(20_000)

--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -7,6 +7,13 @@ class SwitcherController < ApplicationController
   def update
     new_cycle = params[:change_cycle_form][:cycle_schedule_name]
     SiteSetting.set(name: 'cycle_schedule', value: new_cycle)
+
+    if new_cycle == 'today_is_after_find_opens'
+      SiteSetting.set(name: 'recruitment_cycle_year', value: CycleTimetable.next_year)
+    else
+      SiteSetting.set(name: 'recruitment_cycle_year', value: CycleTimetable.current_year)
+    end
+
     flash[:success] = 'Cycle schedule updated'
     redirect_to cycles_path
   end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -6,7 +6,7 @@ class RecruitmentCycle < Base
   self.primary_key = :year
 
   def self.current
-    RecruitmentCycle.includes(:providers).find(Settings.current_cycle).first
+    RecruitmentCycle.includes(:providers).find(CycleTimetable.current_year).first
   end
 
   def self.current_year

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -5,6 +5,10 @@ class SiteSetting < Base
     RedisService.new.get('cycle_schedule')&.to_sym || :real
   end
 
+  def self.recruitment_cycle_year
+    RedisService.new.get('recruitment_cycle_year') || CycleTimetable.current_year
+  end
+
   def self.set(name:, value:)
     RedisService.new.set(name, value)
   end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -422,7 +422,7 @@ private
       .includes(site_statuses: [:site])
       .includes(:provider)
       .includes(:subjects)
-      .where(recruitment_cycle_year: Settings.current_cycle)
+      .where(recruitment_cycle_year: SiteSetting.recruitment_cycle_year)
 
     base_query = base_query.where(funding: 'salary') if include_salary && with_salaries?
     base_query = base_query.where(has_vacancies: true) if hasvacancies?

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -9,14 +9,14 @@
       "file": "app/controllers/courses_controller.rb",
       "line": 30,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(\"#{Settings.apply_base_url}/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
+      "code": "redirect_to(\"#{Settings.apply_base_url}/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => SiteSetting.recruitment_cycle_year).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "CoursesController",
         "method": "apply"
       },
-      "user_input": "Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code",
+      "user_input": "Course.includes(:provider).where(:recruitment_cycle_year => SiteSetting.recruitment_cycle_year).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code",
       "confidence": "High",
       "note": ""
     }

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "f0b3eb7d8280ec2b850565fa0b992affb215b084c89d46868aea46ba826b9ff3",
+      "fingerprint": "27875778fbcfb0dc96458e8be610ff3fb0b452c8a45c3c17c960b5a3b72f36be",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/courses_controller.rb",
       "line": 30,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(\"#{Settings.apply_base_url}/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => SiteSetting.recruitment_cycle_year).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => Settings.current_cycle).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
+      "code": "redirect_to(\"#{Settings.apply_base_url}/candidate/apply?providerCode=#{Course.includes(:provider).where(:recruitment_cycle_year => SiteSetting.recruitment_cycle_year).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.provider.provider_code}&courseCode=#{Course.includes(:provider).where(:recruitment_cycle_year => SiteSetting.recruitment_cycle_year).where(:provider_code => params[:provider_code]).find(params[:course_code]).first.course_code}\")",
       "render_path": null,
       "location": {
         "type": "method",
@@ -21,6 +21,6 @@
       "note": ""
     }
   ],
-  "updated": "2021-05-25 10:00:00 +0100",
-  "brakeman_version": "5.0.1"
+  "updated": "2021-09-02 16:17:22 +0100",
+  "brakeman_version": "5.1.1"
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,4 +98,4 @@ en:
       description: Candidates can no longer browse courses on Find
     today_is_after_find_opens:
       name: Find has reopened
-      description: Candidates can browse courses on Find
+      description: Candidates can browse courses on Find. Courses returned from the Teacher Traininig API will be from next year's recruitment cycle

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,6 @@ apply_base_url: https://www.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   # URL of the API app (teacher-training-api)
   base_url: http://localhost:3001
-current_cycle: 2021
 expand_university: false # When true HEI institutions have search radii increased. See https://bat-design-history.netlify.app/find-teacher-training/search-results-locations/
 google:
   maps_api_key: replace_me

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe CoursesController do
         stub_api_v3_resource(
           type: Course,
           params: {
-            recruitment_cycle_year: Settings.current_cycle,
+            recruitment_cycle_year: CycleTimetable.current_year,
             provider_code: course.provider_code,
             course_code: course.course_code,
           },
@@ -40,7 +40,7 @@ RSpec.describe CoursesController do
       before do
         stub_request(
           :get,
-          "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers/#{course.provider_code}/courses/#{course.course_code}?include=provider",
+          "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{CycleTimetable.current_year}/providers/#{course.provider_code}/courses/#{course.course_code}?include=provider",
         ).to_raise(JsonApiClient::Errors::NotFound)
       end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -392,7 +392,7 @@ describe CourseDecorator do
 
   describe '#year_range' do
     it 'returns correct year range' do
-      expect(decorated_course.year_range).to eq("#{Settings.current_cycle} to #{Settings.current_cycle + 1}")
+      expect(decorated_course.year_range).to eq("#{CycleTimetable.current_year} to #{CycleTimetable.next_year}")
     end
   end
 

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :recruitment_cycle do
     sequence(:id)
-    year { Settings.current_cycle }
+    year { CycleTimetable.current_year }
     application_start_date { '2018-10-09' }
 
     trait :next_cycle do
-      year { Settings.current_cycle + 1 }
+      year { CycleTimetable.next_year }
     end
 
     trait :previous_cycle do
-      year { Settings.current_cycle - 1 }
+      year { CycleTimetable.previous_year }
     end
   end
 end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     latitude { nil }
     longitude { nil }
     london_borough { nil }
-    recruitment_cycle_year { Settings.current_cycle }
+    recruitment_cycle_year { CycleTimetable.current_year }
 
     after :build do |course, evaluator|
       course.recruitment_cycle = evaluator.recruitment_cycle

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -86,7 +86,7 @@ describe 'Course show', type: :feature do
     stub_api_v3_resource(
       type: RecruitmentCycle,
       params: {
-        recruitment_cycle_year: Settings.current_cycle,
+        recruitment_cycle_year: CycleTimetable.current_year,
       },
       resources: current_recruitment_cycle,
     )
@@ -94,7 +94,7 @@ describe 'Course show', type: :feature do
     stub_api_v3_resource(
       type: Course,
       params: {
-        recruitment_cycle_year: Settings.current_cycle,
+        recruitment_cycle_year: CycleTimetable.current_year,
         provider_code: course.provider_code,
         provider_type: course.provider_type,
         course_code: course.course_code,
@@ -317,7 +317,7 @@ describe 'Course show', type: :feature do
 
     it 'only displays uk fees' do
       expect(course_page).to have_content(
-        "The course fees for UK students in #{Settings.current_cycle} to #{Settings.current_cycle + 1} are £9,250",
+        "The course fees for UK students in #{CycleTimetable.current_year} to #{CycleTimetable.next_year} are £9,250",
       )
 
       expect(course_page).not_to have_international_fees

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -324,7 +324,7 @@ RSpec.feature 'Results page new area and provider filter' do
         type: Provider,
         resources: providers,
         fields: { providers: %i[provider_code provider_name] },
-        params: { recruitment_cycle_year: Settings.current_cycle },
+        params: { recruitment_cycle_year: CycleTimetable.current_year },
         search: 'ACME',
       )
 
@@ -347,7 +347,7 @@ RSpec.feature 'Results page new area and provider filter' do
           type: Provider,
           resources: providers,
           fields: { providers: %i[provider_code provider_name] },
-          params: { recruitment_cycle_year: Settings.current_cycle },
+          params: { recruitment_cycle_year: CycleTimetable.current_year },
           search: 'ACME',
         )
 

--- a/spec/requests/cycles_spec.rb
+++ b/spec/requests/cycles_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe '/cycles', type: :request do
+  context "when cycle selected is 'today_is_after_find_opens'" do
+    it "sets recruitment cycle year to #{CycleTimetable.next_year}" do
+      post '/cycles', params: { change_cycle_form: { cycle_schedule_name: 'today_is_after_find_opens' } }
+
+      expect(SiteSetting.recruitment_cycle_year).to eq(CycleTimetable.next_year.to_s)
+    end
+  end
+
+  context "when cycle selected is anything other than 'today_is_after_find_opens'" do
+    it "sets recruitment cycle year to #{CycleTimetable.current_year}" do
+      post '/cycles', params: { change_cycle_form: { cycle_schedule_name: 'today_is_mid_cycle' } }
+
+      expect(SiteSetting.recruitment_cycle_year).to eq(CycleTimetable.current_year.to_s)
+    end
+  end
+end

--- a/spec/requests/sitemaps_spec.rb
+++ b/spec/requests/sitemaps_spec.rb
@@ -19,7 +19,7 @@ describe '/sitemap.xml', type: :request do
     stub_api_v3_resource(
       type: RecruitmentCycle,
       params: {
-        recruitment_cycle_year: Settings.current_cycle,
+        recruitment_cycle_year: CycleTimetable.current_year,
       },
       resources: current_recruitment_cycle,
     )
@@ -27,7 +27,7 @@ describe '/sitemap.xml', type: :request do
     stub_api_v3_resource(
       type: Course,
       params: {
-        recruitment_cycle_year: Settings.current_cycle,
+        recruitment_cycle_year: CycleTimetable.current_year,
       },
       pagination: {
         page: 1,

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -23,7 +23,7 @@ module Helpers
     # This is needed because we check the provider count on all pages
     # TODO: Move this to be returned with the user.
     stub_api_v2_request(
-      "/recruitment_cycles/#{Settings.current_cycle}/providers",
+      "/recruitment_cycles/#{CycleTimetable.current_year}/providers",
       resource_to_jsonapi(provider),
     )
     Rails.application.env_config['omniauth.auth'] = OmniAuth.config.mock_auth[:dfe]

--- a/spec/support/stubbed_requests/courses.rb
+++ b/spec/support/stubbed_requests/courses.rb
@@ -26,7 +26,7 @@ module StubbedRequests
     end
 
     def courses_url
-      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/courses"
+      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{CycleTimetable.current_year}/courses"
     end
   end
 end

--- a/spec/support/stubbed_requests/providers.rb
+++ b/spec/support/stubbed_requests/providers.rb
@@ -28,7 +28,7 @@ module StubbedRequests
     end
 
     def providers_url
-      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{Settings.current_cycle}/providers"
+      "#{Settings.teacher_training_api.base_url}/api/v3/recruitment_cycles/#{CycleTimetable.current_year}/providers"
     end
   end
 end


### PR DESCRIPTION
### Context

We have been adding new search filters to Find but these rely on data that is only available in courses from the next recruitment cycle.

### Changes proposed in this pull request

- When the CycleSwitcher is updated to `find_reopens` the TTAPI now returns courses from the next recruitment cycle.
- Update codebase to obtain the 'current_year' from the CycleTimetable class, rather than Settings

### Guidance to review
- Go to `/cycles` and switch to `find_has_reopened`
- Run a search - you should now see courses from the next recruitment cycle

### Trello card
https://trello.com/c/PmNodHKW/3911-cycleswitcher-add-ability-to-query-next-years-recruitment-cycle-data

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
