### PR TITLE
Cache API request made when rendering CoursesController#show 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
   config.rails_semantic_logger.add_file_appender = false
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :null_store
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,9 @@ Rails.application.configure do
     'Cache-Control' => 'public, max-age=3600',
   }
 
+  # Ensure that our tests are accounting for caching behaviour
+  config.cache_store = :memory_store
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
   #   Kernel.srand config.seed
 
   config.before { RedisService.new.flushdb }
+  config.before { Rails.cache.clear }
 
   require 'webmock/rspec'
   require 'factory_bot'


### PR DESCRIPTION
### Context
Skylight has flagged this as a relatively popular endpoint that could
potentially be made faster. Most of the time in this action is spent
making the API call to TTAPI. 
### Changes proposed in this pull request
By setting an expiring cache entry for
each course, we increase the likelihood that popular course data is
served from the cache rather than the API.
### Guidance to review
- We have rack mini profiler on Find now, so viewing a course page on this branch locally should show the API request happening only on the first page load.

### Trello card
https://trello.com/c/qqZRrmQg

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
