### PR TITLE
Add visa sponsorship filter to results page

### DIFF
--- a/app/view_objects/result_filters/filters_view.rb
+++ b/app/view_objects/result_filters/filters_view.rb
@@ -46,6 +46,10 @@ module ResultFilters
       params[:senCourses] == 'true'
     end
 
+    def visa_checked?
+      params[:can_sponsor_visa] == 'true'
+    end
+
     def has_vacancies_checked?
       params[:hasvacancies] == 'true'
     end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -79,6 +79,10 @@ class ResultsView
     query_parameters['senCourses'].present? && query_parameters['senCourses'].downcase == 'true'
   end
 
+  def visa_courses?
+    query_parameters['can_sponsor_visa'].present? && query_parameters['can_sponsor_visa'].downcase == 'true'
+  end
+
   def number_of_extra_subjects
     return 37 if number_of_subjects_selected == MAXIMUM_NUMBER_OF_SUBJECTS
 
@@ -428,6 +432,7 @@ private
     base_query = base_query.where(has_vacancies: true) if hasvacancies?
     base_query = base_query.where(study_type: study_type) if study_type.present?
     base_query = base_query.where(degree_grade: degree_grade_types) if degree_required?
+    base_query = base_query.where(can_sponsor_visa: true) if visa_courses?
 
     base_query = base_query.where(qualification: qualification.join(',')) unless all_qualifications?
     base_query = base_query.where(subjects: subject_codes.join(',')) if subject_codes.any?

--- a/app/views/result_filters/_all.html.erb
+++ b/app/views/result_filters/_all.html.erb
@@ -8,8 +8,9 @@
     <%= render 'result_filters/vacancy_filter', form: form %>
     <%= render 'result_filters/study_type_filter', form: form %>
     <%= render 'result_filters/qualifications_filter', form: form %>
-    <% if FeatureFlag.active?(:degree_required_filter) %>
+    <% if FeatureFlag.active?(:new_filters) %>
       <%= render 'result_filters/degree_required_filter', form: form %>
+      <%= render 'result_filters/visa_filter', form: form %>
     <% end %>
     <%= render 'result_filters/salary_filter', form: form %>
     <%= render 'result_filters/hidden_fields', form: form %>

--- a/app/views/result_filters/_visa_filter.html.erb
+++ b/app/views/result_filters/_visa_filter.html.erb
@@ -1,0 +1,17 @@
+<fieldset class="govuk-fieldset app-filter__group" data-qa="filters__visa">
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Visa sponsorship</legend>
+  <div class="govuk-checkboxes govuk-checkboxes--small">
+    <div class="govuk-checkboxes__item">
+      <%= form.check_box(
+            :can_sponsor_visa,
+            { checked: @filters_view.visa_checked?, class: 'govuk-checkboxes__input' },
+            'true',
+            nil,
+          ) %>
+      <%= form.label(:can_sponsor_visa, class: 'govuk-label govuk-checkboxes__label') do %>
+        Show only courses with visa sponsorship
+      <% end %>
+    </div>
+  </div>
+</fieldset>
+

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,4 +21,4 @@ skylight_enable: true
 
 feature_flags:
   send_web_requests_to_big_query: false
-  degree_required_filter: false
+  new_filters: false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -7,4 +7,4 @@ valid_referers:
 
 feature_flags:
   send_web_requests_to_big_query: true
-  degree_required_filter: true
+  new_filters: true

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,3 +1,5 @@
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+feature_flags:
+  new_filters: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -8,4 +8,4 @@ google:
     dataset: bat-find-test-events
 redis_url: redis://localhost:6379/9
 feature_flags:
-  degree_required_filter: true
+  new_filters: true

--- a/spec/features/result_filters/visa_spec.rb
+++ b/spec/features/result_filters/visa_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.feature 'Results page visa filter' do
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  let(:results_page) { PageObjects::Page::Results.new }
+  let(:base_parameters) { results_page_parameters }
+
+  before do
+    stub_subjects
+    stub_courses(query: base_parameters, course_count: 10)
+  end
+
+  describe 'viewing results without explicitly selecting a filter' do
+    it 'show courses with or without Visa sponsorship' do
+      results_page.load
+
+      expect(results_page.visa_filter.legend.text).to eq('Visa sponsorship')
+      expect(results_page.visa_filter.checkbox.checked?).to be(false)
+    end
+  end
+
+  describe 'applying the filter' do
+    before do
+      stub_courses(
+        query: base_parameters.merge(
+          'filter[can_sponsor_visa]' => 'true',
+          'filter[study_type]' => 'full_time,part_time',
+        ),
+        course_count: 10,
+      )
+
+      results_page.load
+      results_page.visa_filter.checkbox.check
+      results_page.apply_filters_button.click
+    end
+
+    context 'selecting courses with visa sponsorship' do
+      it 'list the filtered courses' do
+        expect(results_page.visa_filter.legend.text).to eq('Visa sponsorship')
+        expect(results_page.visa_filter.checkbox.checked?).to be(true)
+      end
+
+      it 'retains the query parameters' do
+        expect_page_to_be_displayed_with_query(
+          page: results_page,
+          expected_query_params: {
+            'fulltime' => 'true',
+            'parttime' => 'true',
+            'hasvacancies' => 'true',
+            'degree_required' => 'show_all_courses',
+            'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
+            'can_sponsor_visa' => 'true',
+          },
+        )
+      end
+    end
+  end
+end

--- a/spec/site_prism/page_objects/page/results.rb
+++ b/spec/site_prism/page_objects/page/results.rb
@@ -65,6 +65,11 @@ module PageObjects
         element :not_required_radio, '[data-qa="not_required"]'
       end
 
+      class VisaSection < SitePrism::Section
+        element :legend, 'legend'
+        element :checkbox, 'input[name="can_sponsor_visa"]'
+      end
+
       class FundingSection < SitePrism::Section
         element :legend, 'legend'
         element :checkbox, 'input[name="funding"]'
@@ -92,9 +97,9 @@ module PageObjects
       section :funding_filter, FundingSection, '[data-qa="filters__funding"]'
       section :provider_filter, ProviderSection, '[data-qa="filters__provider"]'
       section :degree_required_filter, RequiredDegreeSection, '[data-qa="filters__degree_required"]'
-
-      section :area_and_provider_filter, LocationAndProviderSection, '[data-qa="filters__area_and_provider"]'
       section :send_filter, SendSection, '[data-qa="filters__send"]'
+      section :visa_filter, VisaSection, '[data-qa="filters__visa"]'
+      section :area_and_provider_filter, LocationAndProviderSection, '[data-qa="filters__area_and_provider"]'
 
       element :heading, '[data-qa="heading"]'
       element :next_button, '[data-qa="next_button"]'

--- a/spec/view_objects/result_filters/filters_view_spec.rb
+++ b/spec/view_objects/result_filters/filters_view_spec.rb
@@ -188,6 +188,22 @@ module ResultFilters
       end
     end
 
+    describe '#visa_checked?' do
+      subject { described_class.new(params: params).visa_checked? }
+
+      context 'when parameter is present' do
+        let(:params) { { can_sponsor_visa: 'true' } }
+
+        it { is_expected.to eq(true) }
+      end
+
+      context 'when parameter is not present' do
+        let(:params) { {} }
+
+        it { is_expected.to eq(false) }
+      end
+    end
+
     describe '#has_vacancies_checked?' do
       subject { described_class.new(params: params).has_vacancies_checked? }
 


### PR DESCRIPTION
### Context

```
As an... international user of Find
I need to... find courses that can sponsor my visa
So that... I don’t end up making an unsuccessful application
```

### Changes proposed in this pull request

- Add 'visa sponsorship' filter to results page, hidden behind feature flag

<img width="660" alt="visa_sponsorship_filter" src="https://user-images.githubusercontent.com/5256922/132026655-4330e4d1-d35b-4c80-afd3-f0f21e25cb20.png">

### Guidance to review

- [ In the review app](https://find-pr-935.london.cloudapps.digital/results?l=2&subjects%5B%5D=31&subjects%5B%5D=32&subjects%5B%5D=55&subjects%5B%5D=35&subjects%5B%5D=36&subjects%5B%5D=37&subjects%5B%5D=38), update the CycleSwitcher `/cycles` to 'find has reopened' - this will enable you to view 2022 cycle courses
- run a standard search but make sure you choose lots of subjects otherwise you may not get any results once you filter by 'visa sponsorship'

### Trello card
https://trello.com/c/r6Bwj28v/3794-%F0%9F%93%90-dev-find-add-visa-sponsorship-search-filter

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
