### PR TITLE
Increase the throttle on provider autocomplete

### DIFF
--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -48,7 +48,7 @@ const initAutocomplete = ({element, input, path, selectNameAndCode}) => {
         name: $input.name,
         defaultValue: $input.value,
         minLength: 3,
-        source: throttle(request(path), 500),
+        source: throttle(request(path), 2000),
         templates: {
           inputValue: selectNameAndCode ? suggestionTemplate : inputValueTemplate,
           suggestion: suggestionTemplate


### PR DESCRIPTION

### Context
The provider search autocomplete makes XHR requests as the user types.
Increasing the throttle wait value from 500 to 2000 results in fewer
requests without impacting usability.

### Changes proposed in this pull request
Increase wait value in `throttle` function from 500 to 2000ms.

### Guidance to review
Can be tested by running this branch locally and viewing network requests in your browser tools as you type in the autocomplete. Can be compared with current master or QA. Should be fewer requests at anything but the slowest of typing speeds.

### Trello card
https://trello.com/c/XecYnOwt
### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
