### PR TITLE
Add client side caching to search results

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -13,6 +13,8 @@ class ResultsController < ApplicationController
     begin
       @courses = @results_view.courses.all
       @number_of_courses_string = @results_view.number_of_courses_string
+
+      expires_in 10.minutes
     rescue JsonApiClient::Errors::ClientError
       render template: 'errors/unprocessable_entity', status: :unprocessable_entity
     end


### PR DESCRIPTION
### Context
The search results page on Find is slow, high traffic, and changes infrequently. A typical workflow probably involves a lot of back and forth between the results page and individual courses. 

### Changes proposed in this pull request
Add client side caching to reduce the number of server calls to Find (and TTAPI), while still providing reasonably up to date information.

<img width="1406" alt="firefox_cache" src="https://user-images.githubusercontent.com/5256922/133103525-4602403e-1f59-4fb8-9981-ec026b9ba166.png">


### Guidance to review

- Note that this only appears to work on Firefox. Safari and Chrome appear to ignore the returned cache header and will only cache sub resources, not the main resource. See https://stackoverflow.com/questions/11245767/is-chrome-ignoring-cache-control-max-age
- To test locally, start Firefox, disable the Rack mini profiler (via the initialiser) and run a search e.g. `http://localhost:3002/results?l=2&subjects[]=31&subjects[]=32&subjects[]=55` a few times. 
- You should see that the main resource (the search results) is cached by the browser

### Trello card
https://trello.com/c/xYXkGTRj/3914-add-client-side-caching-to-find-search-results

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
