### PR TITLE
Ignore unactionable error in Sentry

### DIFF
--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -13,6 +13,7 @@ Raven.configure do |config|
   config.excluded_exceptions += [
     'ActionController::BadRequest',
     'JsonApiClient::Errors::ConnectionError',
+    'URI::InvalidURIError',
     'Mime::Type::InvalidMimeType',
   ]
 end


### PR DESCRIPTION
This error makes noise in the Slack channel. We can’t do anything about it, and the client correctly sees a 404 anyway. 