### PR TITLE
Update degree require radio labels

### DIFF
--- a/app/views/result_filters/_degree_required_filter.html.erb
+++ b/app/views/result_filters/_degree_required_filter.html.erb
@@ -1,29 +1,28 @@
 <fieldset class="govuk-fieldset app-filter__group" data-qa="filters__degree_required">
-  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Degree required</legend>
+  <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Degree grade accepted</legend>
 
   <div class="govuk-radios govuk-radios--small">
     <%= form.govuk_radio_button :degree_required,
       'show_all_courses',
-      label: { text: 'Show all courses' },
+      label: { text: '2:1 or First' },
       data: { qa: 'show_all_courses' },
       checked: @filters_view.all_courses_radio_chosen? || @filters_view.default_all_courses_radio_to_true
     %>
-    <div class='govuk-radios__divider'>or</div>
     <%= form.govuk_radio_button :degree_required,
       'two_two',
-      label: { text: 'Only show courses that accept a 2:2 degree' },
+      label: { text: '2:2' },
       data: { qa: 'two_two' },
       checked: @filters_view.two_two_radio_chosen?
     %>
     <%= form.govuk_radio_button :degree_required,
       'third_class',
-      label: { text: 'Only show courses that accept a Third class degree' },
+      label: { text: 'Third' },
       data: { qa: 'third_class' },
       checked: @filters_view.third_class_radio_chosen?
     %>
     <%= form.govuk_radio_button :degree_required,
       'not_required',
-      label: { text: 'Only show courses that accept any degree grade' },
+      label: { text: 'Pass (Ordinary degree)' },
       data: { qa: 'not_required' },
       checked: @filters_view.any_degree_grade_radio_chosen?
     %>

--- a/spec/features/result_filters/required_degree_spec.rb
+++ b/spec/features/result_filters/required_degree_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature 'Results page required degree filter' do
     it 'shows all courses' do
       results_page.load
 
-      expect(results_page.degree_required_filter.legend.text).to eq('Degree required')
+      expect(results_page.degree_required_filter.legend.text).to eq('Degree grade accepted')
       expect(results_page.degree_required_filter.show_all_courses_radio.checked?).to be(true)
     end
   end
@@ -38,7 +38,7 @@ RSpec.feature 'Results page required degree filter' do
       end
 
       it 'list the filtered courses' do
-        expect(results_page.degree_required_filter.legend.text).to eq('Degree required')
+        expect(results_page.degree_required_filter.legend.text).to eq('Degree grade accepted')
         expect(results_page.degree_required_filter.two_two_radio.checked?).to be(true)
       end
 
@@ -72,7 +72,7 @@ RSpec.feature 'Results page required degree filter' do
       end
 
       it 'list the filtered courses' do
-        expect(results_page.degree_required_filter.legend.text).to eq('Degree required')
+        expect(results_page.degree_required_filter.legend.text).to eq('Degree grade accepted')
         expect(results_page.degree_required_filter.third_class_radio.checked?).to be(true)
       end
 
@@ -106,7 +106,7 @@ RSpec.feature 'Results page required degree filter' do
       end
 
       it 'list the filtered courses' do
-        expect(results_page.degree_required_filter.legend.text).to eq('Degree required')
+        expect(results_page.degree_required_filter.legend.text).to eq('Degree grade accepted')
         expect(results_page.degree_required_filter.not_required_radio.checked?).to be(true)
       end
 


### PR DESCRIPTION
The previous labels caused confusion in research, with participants confused by the difference between "Show all courses" and "Only show courses that accept any degree grade"

So far the new, more succinct labelling has tested ok.

## Before

<img width="357" alt="Screenshot 2021-09-15 at 16 50 04" src="https://user-images.githubusercontent.com/30665/133466563-d8e7750f-3335-440d-823a-5b210d0b6568.png">

## After

<img width="362" alt="Screenshot 2021-09-15 at 16 49 49" src="https://user-images.githubusercontent.com/30665/133466602-49116abf-5a0e-4d9d-b72a-3ab17a46b623.png">
