### PR TITLE
Configure assets domain for serving static assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,8 +27,10 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
-  # Enable serving of images, styles, and JavaScripts from an asset server.
-  # config.action_controller.asset_host = 'http://assets.example.com'
+  if Settings.assets_url.present?
+    # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+    config.action_controller.asset_host = Settings.assets_url
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/assets_cache_headers.rb
+++ b/config/initializers/assets_cache_headers.rb
@@ -5,4 +5,5 @@ Rails.application.config.static_cache_control = 'public, max-age=31536000'
 Rails.application.config.public_file_server.headers = {
   'Cache-Control' => 'public, max-age=31536000',
   'Expires' => 1.year.from_now.to_formatted_s(:rfc822),
+  'Access-Control-Allow-Origin' => Settings.base_url,
 }

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,5 @@
 base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+assets_url: https://assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://www.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,4 +1,5 @@
 base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+assets_url: https://qa-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://qa.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,4 +1,5 @@
 base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+assets_url: https://sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://sandbox.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,4 +1,5 @@
 base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+assets_url: https://staging-assets.find-postgraduate-teacher-training.service.gov.uk
 apply_base_url: https://staging.apply-for-teacher-training.service.gov.uk
 teacher_training_api:
   base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -76,6 +76,12 @@ resource cloudfoundry_route web_app_service_gov_uk_route {
   hostname = each.value
 }
 
+resource "cloudfoundry_route" "web_app_assets_service_gov_uk_route" {
+  domain   = data.cloudfoundry_domain.find_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = local.assets_host_names[var.app_environment_config]
+}
+
 resource cloudfoundry_user_provided_service logging {
   name             = local.logging_service_name
   space            = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -47,6 +47,14 @@ locals {
     prod    = ["www", "www2"]
     review  = [local.app_name_suffix]
   }
+  assets_host_names = {
+    qa        = "qa-assets"
+    staging   = "staging-assets"
+    sandbox   = "sandbox-assets"
+    prod      = "assets"
+    review    = "${local.app_name_suffix}-assets"
+  }
   web_app_service_gov_uk_route_ids = [for r in cloudfoundry_route.web_app_service_gov_uk_route : r.id]
-  web_app_routes                   = concat(local.web_app_service_gov_uk_route_ids, [cloudfoundry_route.web_app_cloudapps_digital_route.id])
+  web_app_routes = concat(local.web_app_service_gov_uk_route_ids,
+  [cloudfoundry_route.web_app_cloudapps_digital_route.id, cloudfoundry_route.web_app_assets_service_gov_uk_route.id])
 }


### PR DESCRIPTION
### Context

At present the static assets are being served directly from the rails app server.
We can reduce the number of requests served by the app by serving assets from a different cdn-route instance.

### Changes proposed in this pull request

Set RAILS_ASSETS_HOST for different envs in KeyVault secrets
Terraform config for binding assets domain to web app
Set `asset_host` rails property to the assets domain

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
