### PR TITLE
Remove www2 sub-domain

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,4 @@
 Rails.application.routes.draw do
-  constraints(host: /^www2\.|\.education\./) do
-    match '/(*path)' => redirect { |_, req| "#{Settings.base_url}#{req.fullpath}" },
-          via: %i[get post put]
-  end
-
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
   get :sha, controller: :heartbeat

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -69,11 +69,9 @@ resource cloudfoundry_route web_app_cloudapps_digital_route {
 }
 
 resource cloudfoundry_route web_app_service_gov_uk_route {
-  for_each = toset(local.service_gov_uk_host_names[var.app_environment_config])
-
   domain   = data.cloudfoundry_domain.find_service_gov_uk.id
   space    = data.cloudfoundry_space.space.id
-  hostname = each.value
+  hostname = local.service_gov_uk_host_names[var.app_environment_config]
 }
 
 resource "cloudfoundry_route" "web_app_assets_service_gov_uk_route" {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -41,20 +41,22 @@ locals {
   logging_service_name     = "find-logit-${local.app_name_suffix}"
   redis_service_name       = "find-redis-${local.app_name_suffix}"
   service_gov_uk_host_names = {
-    qa      = ["qa"]
-    staging = ["staging"]
-    sandbox = ["sandbox"]
-    prod    = ["www", "www2"]
-    review  = [local.app_name_suffix]
+    qa      = "qa"
+    staging = "staging"
+    sandbox = "sandbox"
+    prod    = "www"
+    review  = local.app_name_suffix
   }
   assets_host_names = {
-    qa        = "qa-assets"
-    staging   = "staging-assets"
-    sandbox   = "sandbox-assets"
-    prod      = "assets"
-    review    = "${local.app_name_suffix}-assets"
+    qa      = "qa-assets"
+    staging = "staging-assets"
+    sandbox = "sandbox-assets"
+    prod    = "assets"
+    review  = "${local.app_name_suffix}-assets"
   }
-  web_app_service_gov_uk_route_ids = [for r in cloudfoundry_route.web_app_service_gov_uk_route : r.id]
-  web_app_routes = concat(local.web_app_service_gov_uk_route_ids,
-  [cloudfoundry_route.web_app_cloudapps_digital_route.id, cloudfoundry_route.web_app_assets_service_gov_uk_route.id])
+  web_app_routes = [
+    cloudfoundry_route.web_app_service_gov_uk_route.id,
+    cloudfoundry_route.web_app_cloudapps_digital_route.id,
+    cloudfoundry_route.web_app_assets_service_gov_uk_route.id
+  ]
 }


### PR DESCRIPTION
### Context

No longer required to support www2 sub-domain

### Changes proposed in this pull request

Remove www2 redirect

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
