### PR TITLE
Migrate to sentry-ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,10 @@ gem 'geokit'
 # Render nice markdown
 gem 'redcarpet'
 
+# Error tracking
+gem 'sentry-rails'
+gem 'sentry-sidekiq'
+
 # Render smart quotes
 gem 'rubypants'
 

--- a/Gemfile
+++ b/Gemfile
@@ -68,9 +68,6 @@ gem 'sidekiq'
 # Calculate distance between two locations
 gem 'geokit'
 
-# Error tracking
-gem 'sentry-raven'
-
 # Render nice markdown
 gem 'redcarpet'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,8 +407,6 @@ GEM
     semantic_logger (4.8.2)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
     sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -526,7 +524,6 @@ DEPENDENCIES
   rubocop-rspec
   rubypants
   scss_lint-govuk
-  sentry-raven
   sidekiq
   simplecov (< 0.18)
   site_prism

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -407,6 +407,15 @@ GEM
     semantic_logger (4.8.2)
       concurrent-ruby (~> 1.0)
     semantic_range (3.0.0)
+    sentry-rails (4.7.2)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.7.0)
+    sentry-ruby-core (4.7.2)
+      concurrent-ruby
+      faraday
+    sentry-sidekiq (4.7.2)
+      sentry-ruby-core (~> 4.7.0)
+      sidekiq (>= 3.0)
     sidekiq (6.2.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -524,6 +533,8 @@ DEPENDENCIES
   rubocop-rspec
   rubypants
   scss_lint-govuk
+  sentry-rails
+  sentry-sidekiq
   sidekiq
   simplecov (< 0.18)
   site_prism

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   end
 
   def assign_sentry_contexts
-    Raven.tags_context(request_id: RequestStore.store[:request_id])
+    Sentry.set_tags(request_id: RequestStore.store[:request_id])
   end
 
   def append_info_to_payload(payload)

--- a/app/services/location_suggestion.rb
+++ b/app/services/location_suggestion.rb
@@ -14,7 +14,7 @@ class LocationSuggestion
           .map(&format_prediction)
           .take(5)
       elsif response['error_message'].present?
-        Raven.send_event(error_message: response['error_message'])
+        Sentry.capture_message(message: response['error_message'])
       end
     end
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,6 +1,7 @@
 # https://docs.sentry.io/clients/ruby/config
-Raven.configure do |config|
-  config.silence_ready = true
+Sentry.init do |config|
+  config.environment = Rails.env
+  config.release = ENV['SHA']
 
   # > Inspect an incoming exception's causes when determining whether or not that
   # exception should be excluded

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -19,10 +19,10 @@ describe ApplicationController, type: :controller do
 
   describe '#assign_sentry_contexts' do
     it 'assigns a request id to Sentry tags' do
-      allow(Raven).to receive(:tags_context).and_return({})
+      allow(Sentry).to receive(:set_tags).and_return({})
       controller.__send__(:store_request_id)
       controller.__send__(:assign_sentry_contexts)
-      expect(Raven).to have_received(:tags_context).with(request_id: request_uuid)
+      expect(Sentry).to have_received(:set_tags).with(request_id: request_uuid)
     end
   end
 

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -65,14 +65,14 @@ describe LocationSuggestion do
       let(:error_message) { 'The provided API key is invalid.' }
 
       before do
-        allow(Raven).to receive(:send_event)
+        allow(Sentry).to receive(:capture_message)
       end
 
       it 'sends a sentry error with the received error_message' do
         stub_query(error_message: error_message)
         location_suggestions
 
-        expect(Raven).to have_received(:send_event).with(error_message: error_message)
+        expect(Sentry).to have_received(:capture_message).with(message: error_message)
       end
     end
 


### PR DESCRIPTION
### Context

The sentry-raven library is deprecated. We need to move to the new version, sentry-ruby.

### Changes proposed in this pull request

Replace Raven gem with Sentry
Replace raven methods with sentry methods
https://docs.sentry.io/platforms/ruby/migration/

### Guidance to review
Correct?

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
