### PR TITLE
Update subject params to use rails subject codes

### DIFF
--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -16,7 +16,7 @@ module ResultFilters
     end
 
     def create
-      if params[:rails_subjects].blank? && (params[:senCourses].blank? || params[:senCourses] == 'false')
+      if params[:subject_codes].blank? && (params[:senCourses].blank? || params[:senCourses] == 'false')
         flash[:error] = [I18n.t('subject_filter.errors.no_option')]
 
         if flash[:start_wizard]
@@ -25,14 +25,16 @@ module ResultFilters
           redirect_to subject_path(filter_params)
         end
       else
-        redirect_to results_path(filter_params.merge(rails_subjects: params[:rails_subjects]))
+        redirect_to results_path(filter_params.merge(subject_codes: params[:subject_codes]))
       end
     end
 
   private
 
     def convert_csharp_params_to_rails
-      params['rails_subjects'] = convert_csharp_subject_id_params_to_subject_code if convert_csharp_subject_id_params_to_subject_code.present?
+      if params['subject_codes'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
+        request.query_parameters['subject_codes'] = convert_csharp_subject_id_params_to_subject_code
+      end
     end
 
     def build_subject_areas

--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -16,7 +16,7 @@ module ResultFilters
     end
 
     def create
-      if params[:subjects].blank? && (params[:senCourses].blank? || params[:senCourses] == 'false')
+      if params[:rails_subjects].blank? && (params[:senCourses].blank? || params[:senCourses] == 'false')
         flash[:error] = [I18n.t('subject_filter.errors.no_option')]
 
         if flash[:start_wizard]
@@ -25,14 +25,14 @@ module ResultFilters
           redirect_to subject_path(filter_params)
         end
       else
-        redirect_to results_path(filter_params.merge(subjects: convert_subject_code_params_to_csharp))
+        redirect_to results_path(filter_params.merge(rails_subjects: params[:rails_subjects]))
       end
     end
 
   private
 
     def convert_csharp_params_to_rails
-      params['subjects'] = convert_csharp_subject_id_params_to_subject_code if convert_csharp_subject_id_params_to_subject_code.present?
+      params['rails_subjects'] = convert_csharp_subject_id_params_to_subject_code if convert_csharp_subject_id_params_to_subject_code.present?
     end
 
     def build_subject_areas

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -25,8 +25,8 @@ class ResultsController < ApplicationController
 private
 
   def convert_csharp_params_to_rails
-    if params['rails_subjects'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
-      request.query_parameters['rails_subjects'] = convert_csharp_subject_id_params_to_subject_code
+    if params['subject_codes'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
+      request.query_parameters['subject_codes'] = convert_csharp_subject_id_params_to_subject_code
     end
   end
 end

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -22,7 +22,7 @@ class ResultsController < ApplicationController
     end
   end
 
-  private
+private
 
   def convert_csharp_params_to_rails
     if params['rails_subjects'].blank? && convert_csharp_subject_id_params_to_subject_code.present?

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,5 +1,7 @@
 class ResultsController < ApplicationController
-  before_action :render_feedback_component
+  include CsharpRailsSubjectConversionHelper
+
+  before_action :render_feedback_component, :convert_csharp_params_to_rails
 
   def index
     service = DeprecatedParametersService.new(parameters: request.query_parameters)
@@ -17,6 +19,14 @@ class ResultsController < ApplicationController
       expires_in 10.minutes
     rescue JsonApiClient::Errors::ClientError
       render template: 'errors/unprocessable_entity', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def convert_csharp_params_to_rails
+    if params['rails_subjects'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
+      request.query_parameters['rails_subjects'] = convert_csharp_subject_id_params_to_subject_code
     end
   end
 end

--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -1,4 +1,4 @@
-# These functions are barely tested and temporary, they should be removed when the results page is filtering in Rails
+# These functions are being used to map bookmarked requests. This module should be deleted at the end of 2021
 module CsharpRailsSubjectConversionHelper
   def convert_csharp_subject_id_params_to_subject_code
     subjects = if params['subjects'].is_a?(String)

--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -4,17 +4,17 @@ module ResultFilters
     include CsharpRailsSubjectConversionHelper
 
     def subject_is_selected?(subject_code:)
-      if !params['rails_subjects']&.length.nil?
-        subject_code.in?(params['rails_subjects'])
+      if !params['subject_codes']&.length.nil?
+        subject_code.in?(params['subject_codes'])
       else
         false
       end
     end
 
     def subject_area_is_selected?(subject_area:)
-      return false if params['rails_subjects'].nil?
+      return false if params['subject_codes'].nil?
 
-      (params['rails_subjects'] & subject_area.subjects.map(&:subject_code)).any?
+      (params['subject_codes'] & subject_area.subjects.map(&:subject_code)).any?
     end
 
     def no_subject_selected_error?

--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -4,17 +4,17 @@ module ResultFilters
     include CsharpRailsSubjectConversionHelper
 
     def subject_is_selected?(subject_code:)
-      if !params['subjects']&.length.nil?
-        subject_code.in?(params['subjects'])
+      if !params['rails_subjects']&.length.nil?
+        subject_code.in?(params['rails_subjects'])
       else
         false
       end
     end
 
     def subject_area_is_selected?(subject_area:)
-      return false if params['subjects'].nil?
+      return false if params['rails_subjects'].nil?
 
-      (params['subjects'] & subject_area.subjects.map(&:subject_code)).any?
+      (params['rails_subjects'] & subject_area.subjects.map(&:subject_code)).any?
     end
 
     def no_subject_selected_error?

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -373,15 +373,15 @@ private
   end
 
   def subject_parameters
-    query_parameters['subjects'].present? ? { 'subjects' => query_parameters['subjects'].presence } : {}
+    query_parameters['rails_subjects'].present? ? { 'rails_subjects' => query_parameters['rails_subjects'].presence } : {}
   end
 
   def subject_parameters_array
-    query_parameters['subjects'] || []
+    query_parameters['rails_subjects'] || []
   end
 
   def subject_codes
-    csharp_array_to_subject_codes(subject_parameters_array)
+    query_parameters['rails_subjects'] || []
   end
 
   def latitude

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -373,15 +373,15 @@ private
   end
 
   def subject_parameters
-    query_parameters['rails_subjects'].present? ? { 'rails_subjects' => query_parameters['rails_subjects'].presence } : {}
+    query_parameters['subject_codes'].present? ? { 'subject_codes' => query_parameters['subject_codes'].presence } : {}
   end
 
   def subject_parameters_array
-    query_parameters['rails_subjects'] || []
+    query_parameters['subject_codes'] || []
   end
 
   def subject_codes
-    query_parameters['rails_subjects'] || []
+    query_parameters['subject_codes'] || []
   end
 
   def latitude

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'shared/error_message', locals: { error_anchor_id: 'subject00' } %>
 
     <%= form_with(url: subject_path, method: :post, data: { 'ga-event-form' => 'Subject' }) do |f| %>
-      <%= render 'shared/hidden_fields', exclude_keys: %w[rails_subjects senCourses], form: f %>
+      <%= render 'shared/hidden_fields', exclude_keys: %w[subject_codes senCourses], form: f %>
       <h1 class="govuk-heading-l" data-qa="heading"><%= I18n.t('page_titles.subjects_filter') %></h1>
 
       <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
@@ -32,8 +32,8 @@
                   <%# C# doesn't have a distinct modern languages subject %>
                   <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
                     <div class="govuk-checkboxes__item" data-qa="subject">
-                      <%= f.check_box(:rails_subjects, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
-                      <%= f.label(:rails_subjects, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
+                      <%= f.check_box(:subject_codes, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
+                      <%= f.label(:subject_codes, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
                         <span class="govuk-checkboxes__label-text" data-qa="subject__name">
                           <%= subject.subject_name %>
                           <% if subject.subject_name == "Design and technology" %>
@@ -79,7 +79,7 @@
           <div class="govuk-checkboxes" id="send-content">
             <div class="govuk-checkboxes__item" data-qa="subject">
               <%= f.check_box(:senCourses, { checked: params[:senCourses] == 'true', data: { qa: 'subject__checkbox' }, id: 'subject_send', class: 'govuk-checkboxes__input' }, 'true', nil) %>
-              <%= f.label(:rails_subjects, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
+              <%= f.label(:subject_codes, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
                 <span class="govuk-checkboxes__label-text">
                   Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
                 </span>

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -5,7 +5,7 @@
     <%= render partial: 'shared/error_message', locals: { error_anchor_id: 'subject00' } %>
 
     <%= form_with(url: subject_path, method: :post, data: { 'ga-event-form' => 'Subject' }) do |f| %>
-      <%= render 'shared/hidden_fields', exclude_keys: %w[subjects senCourses], form: f %>
+      <%= render 'shared/hidden_fields', exclude_keys: %w[rails_subjects senCourses], form: f %>
       <h1 class="govuk-heading-l" data-qa="heading"><%= I18n.t('page_titles.subjects_filter') %></h1>
 
       <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
@@ -32,8 +32,8 @@
                   <%# C# doesn't have a distinct modern languages subject %>
                   <% unless subject.subject_name == "Modern Languages" || subject.subject_name == "Philosophy" %>
                     <div class="govuk-checkboxes__item" data-qa="subject">
-                      <%= f.check_box(:subjects, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
-                      <%= f.label(:subjects, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
+                      <%= f.check_box(:rails_subjects, { multiple: true, checked: subject_is_selected?(subject_code: subject.subject_code), data: { qa: 'subject__checkbox' }, id: "subject#{subject.subject_code}", class: 'govuk-checkboxes__input' }, subject.subject_code, nil) %>
+                      <%= f.label(:rails_subjects, { for: "subject#{subject.subject_code}" }, class: 'govuk-label govuk-checkboxes__label') do %>
                         <span class="govuk-checkboxes__label-text" data-qa="subject__name">
                           <%= subject.subject_name %>
                           <% if subject.subject_name == "Design and technology" %>
@@ -79,7 +79,7 @@
           <div class="govuk-checkboxes" id="send-content">
             <div class="govuk-checkboxes__item" data-qa="subject">
               <%= f.check_box(:senCourses, { checked: params[:senCourses] == 'true', data: { qa: 'subject__checkbox' }, id: 'subject_send', class: 'govuk-checkboxes__input' }, 'true', nil) %>
-              <%= f.label(:subjects, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
+              <%= f.label(:rails_subjects, { for: 'subject_send', data: { qa: 'subject__name' } }, class: 'govuk-label govuk-checkboxes__label') do %>
                 <span class="govuk-checkboxes__label-text">
                   Show only courses with a <abbr title="Special educational needs and disability">SEND</abbr> specialism
                 </span>

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Results page new area and provider filter' do
           expected_query_params: {
             'l' => '3',
             'query' => 'ACME SCITT 0',
-            'rails_subjects' => %w[00],
+            'subject_codes' => %w[00],
           },
         )
       end

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature 'Results page new area and provider filter' do
           expected_query_params: {
             'l' => '3',
             'query' => 'ACME SCITT 0',
-            'subjects' => %w[31],
+            'rails_subjects' => %w[00],
           },
         )
       end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Results page new subject filter' do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            'rails_subjects' => %w[00 01 F1 Q8 P3],
+            'subject_codes' => %w[00 01 F1 Q8 P3],
           },
         )
       end
@@ -78,7 +78,7 @@ RSpec.feature 'Results page new subject filter' do
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          'rails_subjects' => %w[00 01 F1],
+          'subject_codes' => %w[00 01 F1],
           'senCourses' => 'true',
         },
       )
@@ -231,7 +231,7 @@ RSpec.feature 'Results page new subject filter' do
 
   context 'with previously selected subjects' do
     it 'automatically selects the given checkboxes' do
-      visit subject_path(rails_subjects: %w[00], senCourses: 'true')
+      visit subject_path(subject_codes: %w[00], senCourses: 'true')
       expect(filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
       expect(filter_page.send_area.subjects.first.checkbox).to be_checked
     end
@@ -247,7 +247,7 @@ RSpec.feature 'Results page new subject filter' do
         course_count: 10,
       )
 
-      visit subject_path(rails_subjects: %w[00], senCourses: 'true')
+      visit subject_path(subject_codes: %w[00], senCourses: 'true')
       filter_page.subject_areas.first.subjects[0].checkbox.click
       filter_page.subject_areas.first.subjects[1].checkbox.click
       filter_page.send_area.subjects.first.checkbox.click
@@ -267,12 +267,12 @@ RSpec.feature 'Results page new subject filter' do
     end
 
     it 'only changes the subjects params' do
-      visit subject_path(rails_subjects: %w[00 01], other_param: 'param_value')
+      visit subject_path(subject_codes: %w[00 01], other_param: 'param_value')
       filter_page.continue.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          'rails_subjects' => %w[00 01],
+          'subject_codes' => %w[00 01],
           'other_param' => 'param_value',
         },
       )

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature 'Results page new subject filter' do
         expect_page_to_be_displayed_with_query(
           page: results_page,
           expected_query_params: {
-            'subjects' => %w[31 32 3 5 47],
+            'rails_subjects' => %w[00 01 F1 Q8 P3],
           },
         )
       end
@@ -78,7 +78,7 @@ RSpec.feature 'Results page new subject filter' do
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          'subjects' => %w[31 32 3],
+          'rails_subjects' => %w[00 01 F1],
           'senCourses' => 'true',
         },
       )
@@ -231,7 +231,7 @@ RSpec.feature 'Results page new subject filter' do
 
   context 'with previously selected subjects' do
     it 'automatically selects the given checkboxes' do
-      visit subject_path(subjects: %w[31], senCourses: 'true')
+      visit subject_path(rails_subjects: %w[00], senCourses: 'true')
       expect(filter_page.subject_areas.first.subjects.first.checkbox).to be_checked
       expect(filter_page.send_area.subjects.first.checkbox).to be_checked
     end
@@ -247,10 +247,11 @@ RSpec.feature 'Results page new subject filter' do
         course_count: 10,
       )
 
-      visit subject_path(subjects: %w[31], senCourses: 'true')
+      visit subject_path(rails_subjects: %w[00], senCourses: 'true')
       filter_page.subject_areas.first.subjects[0].checkbox.click
       filter_page.subject_areas.first.subjects[1].checkbox.click
       filter_page.send_area.subjects.first.checkbox.click
+
       filter_page.continue.click
 
       expect(results_page.text).to include('Primary with English')
@@ -266,12 +267,12 @@ RSpec.feature 'Results page new subject filter' do
     end
 
     it 'only changes the subjects params' do
-      visit subject_path(subjects: %w[32 31], other_param: 'param_value')
+      visit subject_path(rails_subjects: %w[00 01], other_param: 'param_value')
       filter_page.continue.click
       expect_page_to_be_displayed_with_query(
         page: results_page,
         expected_query_params: {
-          'subjects' => %w[31 32],
+          'rails_subjects' => %w[00 01],
           'other_param' => 'param_value',
         },
       )

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -133,7 +133,7 @@ describe 'results', type: :feature do
     end
   end
 
-  context 'with C# parameters' do
+  context 'with depracated C# parameters' do
     let(:base_parameters) { results_page_parameters('sort' => sort, 'filter[subjects]' => 'C1,08,F1') }
 
     let(:params) do

--- a/spec/helpers/result_filters/subject_helper_spec.rb
+++ b/spec/helpers/result_filters/subject_helper_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'ResultFilters::SubjectHelper', type: :helper do
   describe '#subject_is_selected?' do
     it 'indicates that the subject is selected' do
-      controller.params[:rails_subjects] = '00,01,02'
+      controller.params[:subject_codes] = '00,01,02'
       expect(helper.subject_is_selected?(subject_code: '02')).to eq(true)
     end
 

--- a/spec/helpers/result_filters/subject_helper_spec.rb
+++ b/spec/helpers/result_filters/subject_helper_spec.rb
@@ -3,13 +3,13 @@ require 'rails_helper'
 describe 'ResultFilters::SubjectHelper', type: :helper do
   describe '#subject_is_selected?' do
     it 'indicates that the subject is selected' do
-      controller.params[:subjects] = '1,2,3'
-      expect(helper.subject_is_selected?(subject_code: '2')).to eq(true)
+      controller.params[:rails_subjects] = '00,01,02'
+      expect(helper.subject_is_selected?(subject_code: '02')).to eq(true)
     end
 
     it 'indicates that the subject is not selected' do
-      controller.params[:subjects] = '1,2,3'
-      expect(helper.subject_is_selected?(subject_code: '4')).to eq(false)
+      controller.params[:subjects] = '00,01,02'
+      expect(helper.subject_is_selected?(subject_code: '04')).to eq(false)
     end
   end
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -225,7 +225,7 @@ describe ResultsView do
     end
 
     context 'more than NUMBER_OF_SUBJECTS_DISPLAYED subjects are selected' do
-      let(:parameter_hash) { { 'rails_subjects' => %w[00 01 F1 Q8 P3] } }
+      let(:parameter_hash) { { 'subject_codes' => %w[00 01 F1 Q8 P3] } }
 
       it 'returns the number of the extra subjects' do
         expect(results_view.number_of_extra_subjects).to eq(5)
@@ -460,7 +460,7 @@ describe ResultsView do
       context 'when subject parameters are passed' do
         let(:results_view) do
           described_class.new(query_parameters: {
-            'rails_subjects' => [
+            'subject_codes' => [
               french_subject_code,
               russian_subject_code,
               primary_subject_code,

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -225,7 +225,7 @@ describe ResultsView do
     end
 
     context 'more than NUMBER_OF_SUBJECTS_DISPLAYED subjects are selected' do
-      let(:parameter_hash) { { 'subjects' => %w[1 2 3 4 5] } }
+      let(:parameter_hash) { { 'rails_subjects' => %w[00 01 F1 Q8 P3] } }
 
       it 'returns the number of the extra subjects' do
         expect(results_view.number_of_extra_subjects).to eq(5)
@@ -460,21 +460,21 @@ describe ResultsView do
       context 'when subject parameters are passed' do
         let(:results_view) do
           described_class.new(query_parameters: {
-            'subjects' => [
-              french_csharp_id,
-              russian_csharp_id,
-              primary_csharp_id,
-              spanish_csharp_id,
-              mathematics_csharp_id,
+            'rails_subjects' => [
+              french_subject_code,
+              russian_subject_code,
+              primary_subject_code,
+              spanish_subject_code,
+              mathematics_subject_code,
             ],
           })
         end
 
-        let(:french_csharp_id) { '13' }
-        let(:primary_csharp_id) { '31' }
-        let(:spanish_csharp_id) { '44' }
-        let(:mathematics_csharp_id) { '24' }
-        let(:russian_csharp_id) { '41' }
+        let(:french_subject_code) { '15' }
+        let(:primary_subject_code) { '00' }
+        let(:spanish_subject_code) { '22' }
+        let(:mathematics_subject_code) { 'G1' }
+        let(:russian_subject_code) { '21' }
 
         it 'returns the subjects in alphabetical order' do
           expect(results_view.subjects.map(&:subject_name)).to eq(


### PR DESCRIPTION
### Context

The subject filters in Find populate the query string with subject codes. These subject codes are the so-called Csharp subject codes, dating from when Find was a C# app before it was rewritten in Rails.

We would like to remove the Csharp codes and replace them with so-called Rails (ie TTAPI-standard) codes so that every service is using the same codes. Apart from being the right thing to do, this also simplifies our reporting and simplifies Find itself.

**However**, we do need to continue to support the old subject codes, because we want to continue to support users who have bookmarked search result pages. (A quick investigation with @misaka found a few hundred requests lacking `Referer`s a month).

### Changes proposed in this pull request

- Change Find subject filters to use the same subject codes as TTAPI does (it doesn't rn)
- Continue to support legacy codes using the `CsharpRailsSubjectConversionHelper`

### Guidance to review

Have i missed anything?

### Trello card

https://trello.com/c/MxJ6HtX4/3952-remove-the-csharp-to-rails-subject-conversion-logic-in-the-subject-filters

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
