### PR TITLE
Add temporary caching of course API requests

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -15,8 +15,6 @@ class ResultsController < ApplicationController
     begin
       @courses = @results_view.courses.all
       @number_of_courses_string = @results_view.number_of_courses_string
-
-      expires_in 10.minutes
     rescue JsonApiClient::Errors::ClientError
       render template: 'errors/unprocessable_entity', status: :unprocessable_entity
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,4 +1,16 @@
 class Course < Base
+  TTAPI_CALLS_EXPIRY = 10.minutes
+
+  connection do |conn|
+    conn.faraday.response(:caching, write_options: { expires_in: TTAPI_CALLS_EXPIRY }) do
+      if Settings.feature_flags.cache_courses
+        Rails.cache
+      else
+        ActiveSupport::Cache::NullStore.new
+      end
+    end
+  end
+
   belongs_to :recruitment_cycle, through: :provider, param: :recruitment_cycle_year
   belongs_to :provider, param: :provider_code, shallow_path: true
   has_many :site_statuses

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -20,6 +20,9 @@ Rails.application.configure do
     'Cache-Control' => 'public, max-age=3600',
   }
 
+  # Ensure that our tests are accounting for caching behaviour
+  config.cache_store = :memory_store
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,4 @@ feature_flags:
   new_filters: false
   maintenance_mode: false
   maintenance_banner: false
+  cache_courses: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -6,3 +6,4 @@ log_level: debug
 redis_url: redis://localhost:6379/0
 feature_flags:
   degree_required_filter: false
+  cache_courses: true

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -9,3 +9,4 @@ valid_referers:
 feature_flags:
   send_web_requests_to_big_query: true
   new_filters: true
+  cache_courses: true

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -9,3 +9,4 @@ google:
 redis_url: redis://localhost:6379/9
 feature_flags:
   new_filters: true
+  cache_courses: true

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -65,4 +65,20 @@ describe 'Search results', type: :feature do
       expect(stub_courses_request).to have_been_requested
     end
   end
+
+  context 'with courses API caching' do
+    it 'shows the same search results until the cache expires' do
+      expect(results_page.courses.count).to eq(10)
+      stub_courses(query: base_parameters, course_count: 4)
+
+      not_yet_expired = Course::TTAPI_CALLS_EXPIRY - 1.minute
+      Timecop.travel(Time.zone.now + not_yet_expired)
+      results_page.load
+      expect(results_page.courses.count).to eq(10)
+
+      Timecop.travel(Time.zone.now + 1.minute)
+      results_page.load
+      expect(results_page.courses.count).to eq(4)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,7 @@ RSpec.configure do |config|
   #   Kernel.srand config.seed
 
   config.before { RedisService.new.flushdb }
+  config.before { Rails.cache.clear }
 
   require 'webmock/rspec'
   require 'factory_bot'


### PR DESCRIPTION
### Context
We can't cache course details for any significant length of time in
Find, because there's a requirement for Providers to be able to quickly
update course details and issue corrections. However, we probably should
cache these API calls anyway during the opening week of the cycle, to
help the service handle the expected level of load.


### Changes proposed in this pull request
Do this via the following:

- Add a feature flag for this caching behaviour
- Use Faraday middleware to write to a cache when making requests in the
  Course resource
- Give cache entries written here a 10 minute expiry
- Make the Course connection use a valid cache object if the feature
  flag is on, otherwise use a null cache

This will serve requests for the same url, within the expiry, from the
cache.

Alongside these changes, we configure as follows:

- Clear the cache between tests
- Switch caching on in development, test, and qa
- Switch caching off in production (for now)
- ~Set production explicitly to a null store for now, changing this to a
  Redis store once an instance is configured.~

### Guidance to review
- This is enabled in development, and can be tested locally by navigating to search results and course pages. After the first visit, subsequent visits should skip the API call to TTAPI (visible in rack mini profiler). Change the value of `Course::TTAPI_CALLS_EXPIRY` to something lower (eg—10.seconds) to test the expiration.
- Note that both search queries and individual course detail pages have their TTAPI response data cached.
- What do we think of the overall approach here, namely switching this on temporarily before the spike?

### Trello card
https://trello.com/c/i4k7rJpC
### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
