### PR TITLE
Add maintenance page and flag for when find is down

### DIFF
--- a/app/components/maintenance_banner_component.html.erb
+++ b/app/components/maintenance_banner_component.html.erb
@@ -1,0 +1,4 @@
+<%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
+  <% notification_banner.heading(text: 'This service will be unavailable on Thursday 23 September from 7.30am to 8am, while we carry out maintenance') %>
+  <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
+<% end %>

--- a/app/components/maintenance_banner_component.rb
+++ b/app/components/maintenance_banner_component.rb
@@ -1,0 +1,6 @@
+class MaintenanceBannerComponent < ViewComponent::Base
+  include ViewHelper
+  def render?
+    FeatureFlag.active?(:maintenance_banner)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_request_id
   before_action :assign_sentry_contexts
+  before_action :redirect_to_maintanance_page_if_flag_is_active
   before_action :redirect_to_cycle_has_ended_if_find_is_down
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
@@ -28,6 +29,10 @@ class ApplicationController < ActionController::Base
   end
 
 private
+
+  def redirect_to_maintanance_page_if_flag_is_active
+    redirect_to maintainance_path if FeatureFlag.active?(:maintenance_mode)
+  end
 
   def redirect_to_cycle_has_ended_if_find_is_down
     redirect_to cycle_has_ended_path if CycleTimetable.find_down?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :store_request_id
   before_action :assign_sentry_contexts
-  before_action :redirect_to_maintanance_page_if_flag_is_active
+  before_action :redirect_to_maintenance_page_if_flag_is_active
   before_action :redirect_to_cycle_has_ended_if_find_is_down
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
@@ -30,7 +30,7 @@ class ApplicationController < ActionController::Base
 
 private
 
-  def redirect_to_maintanance_page_if_flag_is_active
+  def redirect_to_maintenance_page_if_flag_is_active
     redirect_to maintainance_path if FeatureFlag.active?(:maintenance_mode)
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,7 @@
 
 class PagesController < ApplicationController
   skip_before_action :redirect_to_cycle_has_ended_if_find_is_down, only: :cycle_has_ended
-  skip_before_action :redirect_to_maintanance_page_if_flag_is_active, only: :maintainance
+  skip_before_action :redirect_to_maintenance_page_if_flag_is_active, only: :maintainance
   before_action :redirect_to_homepage_if_find_is_open, only: :cycle_has_ended
   before_action :redirect_to_homepage_unless_in_maintenance_mode, only: :maintainance
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,7 +2,9 @@
 
 class PagesController < ApplicationController
   skip_before_action :redirect_to_cycle_has_ended_if_find_is_down, only: :cycle_has_ended
+  skip_before_action :redirect_to_maintanance_page_if_flag_is_active, only: :maintainance
   before_action :redirect_to_homepage_if_find_is_open, only: :cycle_has_ended
+  before_action :redirect_to_homepage_unless_in_maintenance_mode, only: :maintainance
 
   def terms; end
 
@@ -12,9 +14,15 @@ class PagesController < ApplicationController
 
   def cycle_has_ended; end
 
+  def maintainance; end
+
 private
 
   def redirect_to_homepage_if_find_is_open
     redirect_to root_path unless CycleTimetable.find_down?
+  end
+
+  def redirect_to_homepage_unless_in_maintenance_mode
+    redirect_to root_path unless FeatureFlag.active?(:maintenance_mode)
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -116,6 +116,7 @@
           <% end %>
         <% end %>
 
+        <%= render MaintenanceBannerComponent.new %>
         <%= render DeadlineBannerComponent.new(flash_empty: flash.reject { |flash| flash[0] == "start_wizard" }.empty?) unless request.url.include?('/results/filter/subject')%>
 
         <%= yield %>

--- a/app/views/pages/maintainance.html.erb
+++ b/app/views/pages/maintainance.html.erb
@@ -1,0 +1,12 @@
+<%= content_for :page_title, 'Applications closed' %>
+
+<div class="govuk-width-container">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">This service is currently down for maintenance</h1>
+
+      <p class="govuk-body">The service will be available from 8am on 23 September.</p>
+      <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get :sha, controller: :heartbeat
 
   get '/cycle-has-ended', to: 'pages#cycle_has_ended', as: 'cycle_has_ended'
+  get '/maintainance', to: 'pages#maintainance', as: 'maintainance'
 
   get '/cycle-ending-soon', to: redirect('/', status: 301)
   # During the cycle there is no need for a separate path for

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,3 +23,4 @@ feature_flags:
   send_web_requests_to_big_query: false
   new_filters: false
   maintenance_mode: false
+  maintenance_banner: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,3 +22,4 @@ skylight_enable: true
 feature_flags:
   send_web_requests_to_big_query: false
   new_filters: false
+  maintenance_mode: false

--- a/spec/components/maintenance_banner_component_spec.rb
+++ b/spec/components/maintenance_banner_component_spec.rb
@@ -12,6 +12,8 @@ describe MaintenanceBannerComponent, type: :component do
 
   context 'when the `maintenance_mode` flag is deactive' do
     it 'does not render' do
+      deactivate_feature(:maintenance_banner)
+
       result = render_inline(described_class.new)
 
       expect(result.text).to be_blank

--- a/spec/components/maintenance_banner_component_spec.rb
+++ b/spec/components/maintenance_banner_component_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe MaintenanceBannerComponent, type: :component do
+  context 'when the `maintenance_mode` flag is active' do
+    it 'renders the correct content' do
+      activate_feature(:maintenance_banner)
+      result = render_inline(described_class.new)
+
+      expect(result.text).to have_content 'This service will be unavailable on'
+    end
+  end
+
+  context 'when the `maintenance_mode` flag is deactive' do
+    it 'does not render' do
+      result = render_inline(described_class.new)
+
+      expect(result.text).to be_blank
+    end
+  end
+end

--- a/spec/features/maintainance_page_spec.rb
+++ b/spec/features/maintainance_page_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Maintenance mode', type: :feature do
 
   context 'given the maintenance_mode feature flag is deactive and i visit the maintenance_path' do
     it 'sends me to the homepage' do
+      deactivate_feature(:maintenance_mode)
+
       visit maintainance_path
 
       expect(page).to have_current_path root_path

--- a/spec/features/maintainance_page_spec.rb
+++ b/spec/features/maintainance_page_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe 'View pages', type: :feature do
-  context 'given the maintainance_mode feature flag is active and i arrive at the site' do
+  context 'given the maintenance_mode feature flag is active and i arrive at the site' do
     it 'sends me to the maintainance page' do
-      activate_feature(:maintainance_mode)
+      activate_feature(:maintenance_mode)
 
       visit '/'
 
@@ -11,7 +11,7 @@ RSpec.describe 'View pages', type: :feature do
     end
   end
 
-  context 'given the maintainance_mode feature flag is deactive and i visit the maintainance_path' do
+  context 'given the maintenance_mode feature flag is deactive and i visit the maintainance_path' do
     it 'sends me to the homepage' do
       visit maintainance_path
 

--- a/spec/features/maintainance_page_spec.rb
+++ b/spec/features/maintainance_page_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe 'View pages', type: :feature do
+RSpec.describe 'Maintenance mode', type: :feature do
   context 'given the maintenance_mode feature flag is active and i arrive at the site' do
-    it 'sends me to the maintainance page' do
+    it 'sends me to the maintenance page' do
       activate_feature(:maintenance_mode)
 
       visit '/'
@@ -11,7 +11,7 @@ RSpec.describe 'View pages', type: :feature do
     end
   end
 
-  context 'given the maintenance_mode feature flag is deactive and i visit the maintainance_path' do
+  context 'given the maintenance_mode feature flag is deactive and i visit the maintenance_path' do
     it 'sends me to the homepage' do
       visit maintainance_path
 

--- a/spec/features/maintainance_page_spec.rb
+++ b/spec/features/maintainance_page_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'View pages', type: :feature do
+  context 'given the maintainance_mode feature flag is active and i arrive at the site' do
+    it 'sends me to the maintainance page' do
+      activate_feature(:maintainance_mode)
+
+      visit '/'
+
+      expect(page).to have_current_path maintainance_path
+    end
+  end
+
+  context 'given the maintainance_mode feature flag is deactive and i visit the maintainance_path' do
+    it 'sends me to the homepage' do
+      visit maintainance_path
+
+      expect(page).to have_current_path root_path
+    end
+  end
+end

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe 'Maintenance banner', type: :feature do
 
   context 'given the maintenance_banner feature flag is deactive and i visit the homepage' do
     it 'sends me to the homepage' do
+      deactivate_feature(:maintenance_banner)
+
       visit '/'
 
       expect(page).not_to have_content 'This service will be unavailable on'

--- a/spec/features/maintenance_banner_spec.rb
+++ b/spec/features/maintenance_banner_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Maintenance banner', type: :feature do
+  context 'given the maintenance_mode feature flag is active and i arrive at the site' do
+    it 'sends me to the maintenance page' do
+      activate_feature(:maintenance_banner)
+
+      visit '/'
+
+      expect(page).to have_content 'This service will be unavailable on'
+    end
+  end
+
+  context 'given the maintenance_banner feature flag is deactive and i visit the homepage' do
+    it 'sends me to the homepage' do
+      visit '/'
+
+      expect(page).not_to have_content 'This service will be unavailable on'
+    end
+  end
+end


### PR DESCRIPTION
### Context

We're going to have to bring Find down for a set period of time while we upgrade the TTAPI DB. There may well be a few minutes where we're unable to hit the TTAPI so we're going to pop the service into maintenance mode for 30 mins.

### Changes proposed in this pull request

- Add maintenance_mode feature flag
- Add a maintenance mode page 
- Redirect to the page when the flag is active


### Guidance to review

Does this seem about right time wise? Not sure how long the db upgrade will take. Could make it an hour to be safe?

This will have to be manually deployed before we swap the DBs. Is that an issue?

![image](https://user-images.githubusercontent.com/42515961/134184209-889de3f7-f7eb-4249-8cce-8d6d16c33458.png)

Add banner 

![image](https://user-image hubusercontent.com/42515961/134188206-23f7903c-6c53-4283-ab77-bae636000485.png)

🤢

### Trello card

https://trello.com/c/WPcZ8odw/3970-add-maintenance-page-for-find-for-when-the-ttapi-is-down

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
