### PR TITLE
Do not show maintenance banner on maintenance page

### DIFF
--- a/app/components/maintenance_banner_component.rb
+++ b/app/components/maintenance_banner_component.rb
@@ -1,6 +1,6 @@
 class MaintenanceBannerComponent < ViewComponent::Base
   include ViewHelper
   def render?
-    FeatureFlag.active?(:maintenance_banner)
+    FeatureFlag.active?(:maintenance_banner) && !FeatureFlag.active?(:maintenance_mode)
   end
 end

--- a/spec/features/maintainance_page_spec.rb
+++ b/spec/features/maintainance_page_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe 'Maintenance mode', type: :feature do
   context 'given the maintenance_mode feature flag is active and i arrive at the site' do
     it 'sends me to the maintenance page' do
       activate_feature(:maintenance_mode)
+      activate_feature(:maintenance_banner)
 
       visit '/'
 
       expect(page).to have_current_path maintainance_path
+      expect(page).not_to have_content 'This service will be unavailable on'
     end
   end
 


### PR DESCRIPTION
### Context

Ensure maintenance banner does not render on the maintenance page

### Changes proposed in this pull request

- Do not render the maintenance banner if the maintenance_mode feature flag is on. 

