### PR TITLE
[2261] Stop logging Bigquery job

### DIFF
--- a/app/job/send_event_to_big_query_job.rb
+++ b/app/job/send_event_to_big_query_job.rb
@@ -1,4 +1,6 @@
 class SendEventToBigQueryJob < ApplicationJob
+  self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
+
   def perform(request_event_json)
     bq = Google::Cloud::Bigquery.new(project: Settings.google.big_query.project_id)
     dataset = bq.dataset(Settings.google.big_query.dataset, skip_lookup: true)


### PR DESCRIPTION
### Context
Logit is expensive and most of the logs are because of the BigQuery job. They don't add any value since we use BigQuery as an event log anyway.

### Changes proposed in this pull request
Turn off logging for the BigQuery job. Same as teaching vacancies: https://github.com/DFE-Digital/teaching-vacancies/pull/3986/files

### Guidance to review
Check the BigQuery job doesn't emit any log

### Trello card
https://trello.com/c/7uDtQqB3

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
