### PR TITLE
Cache subject API calls

### DIFF
--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -1,4 +1,12 @@
 class Subject < Base
+  TTAPI_CALLS_EXPIRY = 1.hour
+
+  connection do |conn|
+    conn.faraday.response(:caching, write_options: { expires_in: TTAPI_CALLS_EXPIRY }) do
+      Rails.cache
+    end
+  end
+
   has_many :course_subjects
   has_many :courses, through: :course_subjects
   belongs_to :subject_area, foreign_key: :type, inverse_of: :subjects, shallow_path: true

--- a/app/models/subject_area.rb
+++ b/app/models/subject_area.rb
@@ -1,4 +1,12 @@
 class SubjectArea < Base
+  TTAPI_CALLS_EXPIRY = 1.hour
+
+  connection do |conn|
+    conn.faraday.response(:caching, write_options: { expires_in: TTAPI_CALLS_EXPIRY }) do
+      Rails.cache
+    end
+  end
+
   has_many :subjects, foreign_key: :type, inverse_of: :subject_area
   self.primary_key = :typename
 end


### PR DESCRIPTION


### Context
We want to speed up Find.

Subjects and subject areas don't change very often, but are requested often from TTAPI during a typical workflow through Find. We can cache these calls.

### Changes proposed in this pull request
Cache the API calls for Subject and SubjectArea for an hour.

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
