### PR TITLE
Use existing redis connection for checking SiteSettings

### DIFF
--- a/app/lib/redis.rb
+++ b/app/lib/redis.rb
@@ -1,5 +1,9 @@
 require 'redis'
 class RedisService
+  def self.current
+    @current ||= Redis.new(url: RedisService.redis_url)
+  end
+
   def self.new
     Redis.new(url: RedisService.redis_url)
   end

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -2,10 +2,10 @@ require './app/lib/redis'
 
 class SiteSetting < Base
   def self.cycle_schedule
-    RedisService.new.get('cycle_schedule')&.to_sym || :real
+    RedisService.current.get('cycle_schedule')&.to_sym || :real
   end
 
   def self.set(name:, value:)
-    RedisService.new.set(name, value)
+    RedisService.current.set(name, value)
   end
 end


### PR DESCRIPTION
### Context

Redis.new was being used to get/set SiteSettings

### Changes proposed in this pull request

use Redis.current instead

### Guidance to review

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
