### PR TITLE
Disable cycle switcher on Find for the load test environment

### DIFF
--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -14,6 +14,8 @@ class SwitcherController < ApplicationController
 private
 
   def redirect_to_homepage_if_in_production
-    redirect_to root_path if Rails.env.production?
+    # rubocop:disable Rails/UnknownEnv
+    redirect_to root_path if Rails.env.production? || Rails.env.loadtest?
+    # rubocop:enable Rails/UnknownEnv
   end
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -124,7 +124,9 @@ class CycleTimetable
 
   def self.current_cycle_schedule
     # Make sure this setting only has effect on non-production environments
-    return :real if HostingEnvironment.production?
+    # rubocop:disable Rails/UnknownEnv
+    return :real if HostingEnvironment.production? || Rails.env.loadtest?
+    # rubocop:enable Rails/UnknownEnv
 
     SiteSetting.cycle_schedule
   end


### PR DESCRIPTION
### Context

This is disabled for Prod so it should also be for our load testing env.

### Changes proposed in this pull request

- Disable the cycle switcher in the load testing env

### Trello card

https://trello.com/c/YW5sKe0d/4002-dont-use-redis-on-prod-load-testing-in-find

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
