### PR TITLE
Don’t use SemanticLogger in local dev

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,6 @@ gem 'draper'
 # http client
 gem 'httparty'
 
-# Semantic Logger makes logs pretty
-gem 'rails_semantic_logger'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.1.4'
 
@@ -87,6 +84,11 @@ gem 'govuk-components', '~> 2.0.1'
 
 # Data integration with BigQuery
 gem 'google-cloud-bigquery'
+
+# Semantic Logger makes production logs consumable by logit
+group :production do
+  gem 'rails_semantic_logger'
+end
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/config/initializers/big_query.rb
+++ b/config/initializers/big_query.rb
@@ -2,7 +2,13 @@ require 'google/cloud/bigquery'
 
 BIG_QUERY_API_JSON_KEY = ENV['BIG_QUERY_API_JSON_KEY']
 
-if FeatureFlag.active?(:send_web_requests_to_big_query)
+# https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-when-the-application-boots
+big_query_enabled = false
+Rails.application.reloader.to_prepare do
+  big_query_enabled = FeatureFlag.active?(:send_web_requests_to_big_query)
+end
+
+if big_query_enabled
   # Validate that the JSON key exists and that it is parseable.
   raise 'BigQuery JSON key missing. Disable feature if not sending events to BigQuery.' if BIG_QUERY_API_JSON_KEY.blank?
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,6 @@
-Rails.application.config.semantic_logger.application = Settings.application_name
-Rails.application.config.rails_semantic_logger.format = :json
-SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
-Rails.application.config.logger.info('Application logging to STDOUT')
+if defined?(SemanticLogger)
+  Rails.application.config.semantic_logger.application = Settings.application_name
+  Rails.application.config.rails_semantic_logger.format = :json
+  SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
+  Rails.application.config.logger.info('Application logging to STDOUT')
+end


### PR DESCRIPTION
### Context

JSON logs are for computers, not people.

#### Before

<img width="1249" alt="Screenshot 2021-09-28 at 21 06 12" src="https://user-images.githubusercontent.com/642279/135158175-95c6bf7a-27d8-48e1-8abd-1c27f2809cda.png">


#### After

<img width="1246" alt="Screenshot 2021-09-28 at 21 06 04" src="https://user-images.githubusercontent.com/642279/135158183-8a0a599a-25e7-4d87-9386-454be478ee1f.png">

### Changes proposed in this pull request

Only run SemanticLogger in the `production` bundle.
Fix a deprecation warning. (We should move ourselves off the Rails `5.2` defaults (!) at some point)