### PR TITLE
Send subject_code to BigQuery once it's been mapped from C#

### DIFF
--- a/app/controllers/result_filters/subject_controller.rb
+++ b/app/controllers/result_filters/subject_controller.rb
@@ -1,10 +1,8 @@
 module ResultFilters
   class SubjectController < ApplicationController
     include FilterParameters
-    include CsharpRailsSubjectConversionHelper
 
     before_action :build_results_filter_query_parameters
-    before_action :convert_csharp_params_to_rails, except: [:create]
     before_action :build_subject_areas, except: [:create]
 
     before_action { params['senCourses'].downcase! if params['senCourses'].present? }
@@ -30,12 +28,6 @@ module ResultFilters
     end
 
   private
-
-    def convert_csharp_params_to_rails
-      if params['subject_codes'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
-        request.query_parameters['subject_codes'] = convert_csharp_subject_id_params_to_subject_code
-      end
-    end
 
     def build_subject_areas
       @subject_areas = SubjectArea.includes(:subjects).all

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,8 +1,4 @@
 class ResultsController < ApplicationController
-  include CsharpRailsSubjectConversionHelper
-
-  before_action :render_feedback_component, :convert_csharp_params_to_rails
-
   def index
     service = DeprecatedParametersService.new(parameters: request.query_parameters)
     if service.deprecated?
@@ -17,14 +13,6 @@ class ResultsController < ApplicationController
       @number_of_courses_string = @results_view.number_of_courses_string
     rescue JsonApiClient::Errors::ClientError
       render template: 'errors/unprocessable_entity', status: :unprocessable_entity
-    end
-  end
-
-private
-
-  def convert_csharp_params_to_rails
-    if params['subject_codes'].blank? && convert_csharp_subject_id_params_to_subject_code.present?
-      request.query_parameters['subject_codes'] = convert_csharp_subject_id_params_to_subject_code
     end
   end
 end

--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -1,10 +1,10 @@
 # These functions are being used to map bookmarked requests. This module should be deleted at the end of 2021
 module CsharpRailsSubjectConversionHelper
-  def convert_csharp_subject_id_params_to_subject_code
-    subjects = if params['subjects'].is_a?(String)
-                 params['subjects'].split(',')
+  def convert_csharp_subject_id_params_to_subject_code(csharp_subjects)
+    subjects = if csharp_subjects.is_a?(String)
+                 csharp_subjects.split(',')
                else
-                 params['subjects']
+                 csharp_subjects
                end
 
     subjects&.map do |subject|

--- a/app/helpers/csharp_rails_subject_conversion_helper.rb
+++ b/app/helpers/csharp_rails_subject_conversion_helper.rb
@@ -12,18 +12,8 @@ module CsharpRailsSubjectConversionHelper
     end
   end
 
-  def convert_subject_code_params_to_csharp
-    params['subjects']&.map do |subject|
-      subject_code_to_csharp_subject_id(subject_id: subject)
-    end
-  end
-
-  def csharp_array_to_subject_codes(csharp_id_array)
-    csharp_id_array&.map { |csharp_id| csharp_to_subject_code(csharp_id: csharp_id) }
-  end
-
   def csharp_to_subject_code(csharp_id:)
-    rails_data = CsharpRailsSubjectConversionHelper.subject_codes.find do |entry|
+    rails_data = subject_codes.find do |entry|
       entry[:csharp_id] == csharp_id
     end
 
@@ -38,17 +28,7 @@ module CsharpRailsSubjectConversionHelper
     rails_data[:subject_code]
   end
 
-  def subject_code_to_csharp_subject_id(subject_id:)
-    csharp_data = CsharpRailsSubjectConversionHelper.subject_codes.find do |entry|
-      entry[:subject_code] == subject_id
-    end
-
-    return '[non-existent subject id]' if csharp_data.nil?
-
-    csharp_data[:csharp_id]
-  end
-
-  def self.subject_codes
+  def subject_codes
     @subject_codes ||= Rails.application.config_for(:subject_codes)['subject_codes'].map(&:symbolize_keys)
   end
 end

--- a/app/helpers/result_filters/subject_helper.rb
+++ b/app/helpers/result_filters/subject_helper.rb
@@ -1,7 +1,6 @@
 module ResultFilters
   module SubjectHelper
     include FilterParameters
-    include CsharpRailsSubjectConversionHelper
 
     def subject_is_selected?(subject_code:)
       if !params['subject_codes']&.length.nil?
@@ -21,18 +20,6 @@ module ResultFilters
       return false if flash[:error].nil?
 
       flash[:error].include?(I18n.t('subject_filter.errors.no_option'))
-    end
-
-    def filtered_subject_names
-      request.params['subjects']
-             .map { |csharp_id|
-               csharp_data = CsharpRailsSubjectConversionHelper.subject_codes.find do |entry|
-                 entry[:csharp_id] == csharp_id
-               end
-               csharp_data[:name]
-             }
-             .sort
-             .join(', ')
     end
   end
 end

--- a/app/middleware/csharp_subject_conversion_middleware.rb
+++ b/app/middleware/csharp_subject_conversion_middleware.rb
@@ -19,6 +19,12 @@ class CsharpSubjectConversionMiddleware
     if request.params['subject_codes'].blank? && converted_params.present?
       request.update_param('subject_codes', converted_params)
       request.delete_param('subjects')
+
+      # we must update the query string because this is what BigQuery looks at
+      # when it sends the request params, and we care about the mapped subjects there
+      query_vars = Rack::Utils.parse_query(request.query_string)
+      query_vars['subject_codes[]'] = converted_params
+      request.set_header(Rack::QUERY_STRING, Rack::Utils.build_query(query_vars))
     end
 
     @status, @headers, @response = @app.call(env)

--- a/app/middleware/csharp_subject_conversion_middleware.rb
+++ b/app/middleware/csharp_subject_conversion_middleware.rb
@@ -1,0 +1,27 @@
+require './app/helpers/csharp_rails_subject_conversion_helper'
+
+class CsharpSubjectConversionMiddleware
+  include CsharpRailsSubjectConversionHelper
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    dup._call(env)
+  end
+
+  def _call(env)
+    request = Rack::Request.new(env)
+
+    converted_params = convert_csharp_subject_id_params_to_subject_code(request.params['subjects'])
+
+    if request.params['subject_codes'].blank? && converted_params.present?
+      request.update_param('subject_codes', converted_params)
+      request.delete_param('subjects')
+    end
+
+    @status, @headers, @response = @app.call(env)
+    [@status, @headers, @response]
+  end
+end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -1,7 +1,6 @@
 require 'geokit'
 
 class ResultsView
-  include CsharpRailsSubjectConversionHelper
   include ActionView::Helpers::NumberHelper
 
   MAXIMUM_NUMBER_OF_SUBJECTS = 43

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,6 +9,7 @@ require 'active_job/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'view_component/engine'
+require './app/middleware/csharp_subject_conversion_middleware'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -30,6 +31,7 @@ module FindTeacherTraining
 
     # https://thoughtbot.com/blog/content-compression-with-rack-deflater
     config.middleware.use Rack::Deflater
+    config.middleware.use CsharpSubjectConversionMiddleware
 
     config.skylight.environments = Settings.skylight_enable ? [Rails.env] : []
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,6 @@ Rails.application.configure do
 
   # Only log warnings and above in test environment.
   config.log_level = :warn
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -259,14 +259,12 @@ RSpec.feature 'Results page new subject filter' do
   end
 
   context 'with existing parameters' do
-    before do
+    it 'only changes the subjects params' do
       stub_courses(
         query: base_parameters.merge('filter[subjects]' => '00,01'),
         course_count: 10,
       )
-    end
 
-    it 'only changes the subjects params' do
       visit subject_path(subject_codes: %w[00 01], other_param: 'param_value')
       filter_page.continue.click
       expect_page_to_be_displayed_with_query(
@@ -276,6 +274,18 @@ RSpec.feature 'Results page new subject filter' do
           'other_param' => 'param_value',
         },
       )
+    end
+
+    it 'translates CSharp subjects to Rails' do
+      api_request = stub_courses(
+        query: base_parameters.merge('filter[subjects]' => '24'),
+        course_count: 10,
+      )
+
+      visit subject_path(subjects: %w[49], other_param: 'param_value')
+      filter_page.continue.click
+
+      expect(api_request).to have_been_made
     end
   end
 


### PR DESCRIPTION
### Context

When we mapped `subjects[]` to `subject_codes[]` we didn't go on to send the new `subject_codes[]` to BigQuery. This meant that we lost the canonical subject codes for these requests. 

We also did the mapping in two places, in the Results and Subjects controllers, and the mapping in the Subjects controller didn't work.

### Changes proposed in this pull request

Map once and finally in middleware so all controllers can benefit, and make sure the query string is updated so we send the `subject_codes[]` on to BigQuery. Remove some unused methods.