### PR TITLE
Drop Windows timezone support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -155,6 +155,3 @@ group :test do
   # Control time
   gem 'timecop'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]


### PR DESCRIPTION
Find is neither developed (right now) nor deployed on Windows. Drop this gem, which is never installed.
