### PR TITLE
Use net_http_persistent for better performance when making API calls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,8 @@ gem 'pkg-config', '~> 1.4.6'
 # Decorate logic to keep it of the views and helper methods
 gem 'draper'
 
-# Keep-Alive a http connection
+# HTTP client library
+gem 'faraday'
 gem 'net-http-persistent'
 
 # Semantic Logger makes logs pretty

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gem 'pkg-config', '~> 1.4.6'
 # Decorate logic to keep it of the views and helper methods
 gem 'draper'
 
-# http client
-gem 'httparty'
+# Keep-Alive a http connection
+gem 'net-http-persistent'
 
 # Semantic Logger makes logs pretty
 gem 'rails_semantic_logger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
     html_tokenizer (0.0.7)
-    httparty (0.19.0)
-      mime-types (~> 3.0)
-      multi_xml (>= 0.5.2)
     httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
@@ -267,16 +264,14 @@ GEM
     marcel (1.0.1)
     memoist (0.16.2)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2021.0901)
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     multi_json (1.15.0)
-    multi_xml (0.6.0)
     multipart-post (2.1.1)
+    net-http-persistent (4.0.1)
+      connection_pool (~> 2.2)
     nio4r (2.5.8)
     nokogiri (1.12.5)
       mini_portile2 (~> 2.6.1)
@@ -506,7 +501,6 @@ DEPENDENCIES
   google-cloud-bigquery
   govuk-components (~> 2.0.1)
   govuk_design_system_formbuilder (~> 2.7.4)
-  httparty
   json-schema
   json_api_client
   jsonapi-deserializable
@@ -515,6 +509,7 @@ DEPENDENCIES
   kaminari
   launchy
   listen (>= 3.0.5, < 3.8)
+  net-http-persistent
   pkg-config (~> 1.4.6)
   pry-byebug
   puma (~> 5.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -495,6 +495,7 @@ DEPENDENCIES
   erb_lint
   factory_bot_rails
   faker
+  faraday
   foreman
   geocoder
   geokit
@@ -536,7 +537,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   timecop
-  tzinfo-data
   view_component
   web-console (>= 3.3.0)
   webdrivers (~> 4.6)

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -21,7 +21,7 @@ class HeartbeatController < ActionController::API
 private
 
   def api_alive?
-    response = HTTParty.get("#{Settings.teacher_training_api.base_url}/healthcheck")
+    response = Faraday.get("#{Settings.teacher_training_api.base_url}/healthcheck")
     response.success?
   rescue StandardError
     false

--- a/app/models/base.rb
+++ b/app/models/base.rb
@@ -17,5 +17,6 @@ class Base < JsonApiClient::Resource
 
   self.site = "#{Settings.teacher_training_api.base_url}/api/v3/"
   self.paginator = JsonApiClient::Paginating::NestedParamPaginator
+  self.connection_options = { adapter: :net_http_persistent }
   self.connection_class = ConnectionWithRequestId
 end


### PR DESCRIPTION
### Context

Calls to the Google API are quite slow, according to mini profiler:

![image](https://user-images.githubusercontent.com/10269434/135299955-9b0c3f76-fc13-4160-9f26-fe196e2f8f3b.png)

We can improve this by using persistent HTTP connections: 

![image](https://user-images.githubusercontent.com/10269434/135299316-c67d08ad-1b4c-4d3c-991d-b5a52da0ad69.png)

### Changes proposed in this pull request

- Remove HTTParty gem
- Add persistent http gem
- Use Faraday for connecting to Google API, with net_http_persistent as the adaptor
- Use a simlar approach for making all API calls to TTAPI

### Guidance to review

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
