### PR TITLE
[2261] Set Sidekiq log level to WARN

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -4,6 +4,7 @@ Sidekiq.configure_server do |config|
   config.redis = {
     url: RedisService.redis_url,
   }
+  config.logger.level = Logger::WARN
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
### Context
We removed logs from inside the BigQuery job but Sidekiq itself logs start and stop events.

### Changes proposed in this pull request
Set Sidekiq log level to WARN

### Guidance to review
Check sidekiq logs

### Trello card
https://trello.com/c/7uDtQqB3/2261-stop-logging-bigquery

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
