### PR TITLE
Feature flag provider autocomplete

### DIFF
--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -101,12 +101,15 @@
                   </span>
                   <% end %>
                 <% end %>
-                <%= form.text_field :query,
-                                    id: 'provider',
-                                    value: params[:query],
-                                    class: 'govuk-input',
-                                    data: { qa: 'provider-search' } %>
-                <div id="provider-autocomplete" class="govuk-body"></div>
+                <%= form.text_field(
+                  :query,
+                  id: 'provider',
+                  value: params[:query],
+                  class: 'govuk-input',
+                  data: { qa: 'provider-search' } ) %>
+                <% if FeatureFlag.active?(:provider_autocomplete) %>
+                  <div id="provider-autocomplete" class="govuk-body"></div>
+                <% end %>
               </div>
             </div>
           </div>

--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -35,6 +35,8 @@ export const request = endpoint => {
 const initAutocomplete = ({element, input, path, selectNameAndCode}) => {
   const $input = document.getElementById(input);
   const $el = document.getElementById(element);
+  if (!$el) return;
+
   const inputValueTemplate = result => (typeof result === "string" ? result : result && result.name);
   const suggestionTemplate = result =>
     typeof result === "string" ? result : result && `${result.name} (${result.code})`;

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -25,3 +25,4 @@ feature_flags:
   maintenance_mode: false
   maintenance_banner: false
   cache_courses: false
+  provider_autocomplete: true

--- a/spec/requests/start_spec.rb
+++ b/spec/requests/start_spec.rb
@@ -6,4 +6,22 @@ describe '/start', type: :request do
 
     expect(response).to redirect_to('/')
   end
+
+  describe 'provider autocomplete' do
+    let(:container_div) { '<div id="provider-autocomplete" class="govuk-body"></div>' }
+
+    it 'is present when provider_autocomplete feature flag is active' do
+      activate_feature(:provider_autocomplete)
+      get '/'
+
+      expect(response.body).to include(container_div)
+    end
+
+    it 'is not present when provider_autocomplete feature flag is inactive' do
+      deactivate_feature(:provider_autocomplete)
+      get '/'
+
+      expect(response.body).not_to include(container_div)
+    end
+  end
 end


### PR DESCRIPTION




### Context
The provider autocomplete on the start page sends requests to TTAPI as
the user types. This gets a bit heavy-going when traffic spikes at start
of cycle.

We're planning on reimplementing it so it uses a locally-stored
providers list for its suggestions. Until that's done, we want to be
able to switch the autocomplete off during peak load.

### Changes proposed in this pull request
Wrap the container div for the autocomplete in a feature flag check
Return early from the autocomplete js if this div isn't found on the page

### Guidance to review
- Can be tested locally by toggling the value of the feature flag and typing a provider name into the third input on the start page

### Trello card
https://trello.com/c/B3FlzE6Z
### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
