### PR TITLE
Update QTS-only description to reflect UK leaving the EU

### DIFF
--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -3,6 +3,6 @@
     Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
   </p>
   <p class="govuk-body">
-    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
 <% end %>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -3,9 +3,6 @@
     Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.
   </p>
   <p class="govuk-body">
-    It may also allow you to teach in <%= govuk_link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea' %>, though this could change after 2020.
-  </p>
-  <p class="govuk-body">
-    If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
   </p>
 <% end %>


### PR DESCRIPTION
The QTS-only details component contained some content written pre-Brexit.

This brings it inline with the other qualification statuses in advising candidates to check qualification requirements for overseas teaching.

# Before

<img width="703" alt="Screenshot 2021-09-30 at 14 19 17" src="https://user-images.githubusercontent.com/30665/135462650-1cb0c0f8-d105-4c3a-bfd6-5b418d048b50.png">

# After

<img width="706" alt="Screenshot 2021-09-30 at 14 20 01" src="https://user-images.githubusercontent.com/30665/135462766-fffb0322-9102-4eaa-8557-cfaa2aef14ff.png">


