### PR TITLE
Cache location suggestions

### DIFF
--- a/app/webpacker/scripts/autocomplete.js
+++ b/app/webpacker/scripts/autocomplete.js
@@ -1,5 +1,5 @@
 import accessibleAutocomplete from "accessible-autocomplete";
-import throttle from 'lodash.throttle'
+import debounce from 'lodash.debounce'
 
 export const getPath = (endpoint,query) => {
   return `${endpoint}?query=${query}`;
@@ -48,7 +48,7 @@ const initAutocomplete = ({element, input, path, selectNameAndCode}) => {
         name: $input.name,
         defaultValue: $input.value,
         minLength: 3,
-        source: throttle(request(path), 2000),
+        source: debounce(request(path), 900),
         templates: {
           inputValue: selectNameAndCode ? suggestionTemplate : inputValueTemplate,
           suggestion: suggestionTemplate

--- a/spec/services/location_suggestion_spec.rb
+++ b/spec/services/location_suggestion_spec.rb
@@ -23,24 +23,21 @@ describe LocationSuggestion do
       }.to_query
     end
     let(:url) { "#{Settings.google.places_api_host}#{Settings.google.places_api_path}?#{params}" }
-
-    let(:location_suggestions) do
-      suggest!
-    end
-
-    let(:query_stub) do
-      stub_query(predictions: predictions)
-    end
+    let(:location_suggestions) { suggest! }
+    let(:query_stub) { stub_query(predictions: predictions) }
 
     def suggest!
       LocationSuggestion.suggest(query)
     end
 
-    def stub_query(status: 200, predictions: {}, error_message: nil)
+    def stub_query(status: 200, predictions: [], error_message: nil)
+      body = { predictions: predictions }
+      body[:error_message] = error_message if error_message.present?
+
       stub_request(:get, url)
         .to_return(
           status: status,
-          body: { error_message: error_message, predictions: predictions }.to_json,
+          body: body.to_json,
           headers: { 'Content-Type': 'application/json' },
         )
     end
@@ -66,9 +63,7 @@ describe LocationSuggestion do
     end
 
     context 'caching' do
-      before do
-        query_stub
-      end
+      before { query_stub }
 
       it 'caches suggestions for a period of time' do
         result = suggest!
@@ -85,6 +80,30 @@ describe LocationSuggestion do
           expect(query_stub).to have_been_requested.twice
         end
       end
+
+      it 'caches nothing when the API returns an empty result' do
+        stub_query(predictions: [])
+        result = suggest!
+
+        expect(result).to be_nil
+        expect(Rails.cache.instance_variable_get(:@data)).to eq({})
+      end
+
+      it 'caches nothing when the API returns a bad HTTP status' do
+        stub_query(status: 500)
+        result = suggest!
+
+        expect(result).to be_nil
+        expect(Rails.cache.instance_variable_get(:@data)).to eq({})
+      end
+
+      it 'caches nothing when the API returns an error' do
+        stub_query(error_message: 'Something went wrong')
+        result = suggest!
+
+        expect(result).to be_nil
+        expect(Rails.cache.instance_variable_get(:@data)).to eq({})
+      end
     end
 
     context 'with an error message in the body' do
@@ -92,13 +111,30 @@ describe LocationSuggestion do
 
       before do
         allow(Sentry).to receive(:capture_message)
+        stub_query(error_message: error_message)
       end
 
       it 'sends a sentry error with the received error_message' do
-        stub_query(error_message: error_message)
-        location_suggestions
+        suggest!
 
-        expect(Sentry).to have_received(:capture_message).with(message: error_message)
+        expect(Sentry).to have_received(:capture_message).with(
+          "Google Places API error - status: 200, body: {\"predictions\"=>[], \"error_message\"=>\"#{error_message}\"}",
+        )
+      end
+    end
+
+    context 'unsuccessful request' do
+      before do
+        allow(Sentry).to receive(:capture_message)
+        stub_query(status: 500)
+      end
+
+      it 'sends a sentry error' do
+        suggest!
+
+        expect(Sentry).to have_received(:capture_message).with(
+          'Google Places API error - status: 500, body: {"predictions"=>[]}',
+        )
       end
     end
 
@@ -117,16 +153,6 @@ describe LocationSuggestion do
 
       it 'returns a maximum of 5 suggestions' do
         expect(location_suggestions.count).to eq(5)
-      end
-    end
-
-    context 'unsuccessful request' do
-      before do
-        stub_query(status: 500)
-      end
-
-      it 'returns nothing' do
-        expect(location_suggestions).to be_nil
       end
     end
   end


### PR DESCRIPTION
### Context
The [location suggestions endpoint](https://www.skylight.io/app/applications/fjR4NhKjEKlK/recent/6h/endpoints/LocationSuggestionsController%23index?responseType=json) gets hit at fairly high volumes as a user types a city, town or post code on the start page. Temporarily caching the results of the endpoint may help improve performance and avoid repeatedly sending the same input queries to the Google API in a short space of time.

### Changes proposed in this pull request
- Use debounce instead of throttle in the autocomplete, to improve the quality of search queries sent to the server
- Cache valid results with an expiry, ignoring errors from the Google API

### Guidance to review
Can be tested locally by navigating to the start page and searching by city, town or post code.

Edit -
Via @duncanjbrown, a demo of the difference between throttle and debounce http://demo.nimius.net/debounce_throttle/

### Trello card
https://trello.com/c/FtWwPETn

### Checklist

- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
