### PR TITLE
Avoid HTML entities for apostrophe character

### DIFF
--- a/app/views/courses/qualification/_pgce.html.erb
+++ b/app/views/courses/qualification/_pgce.html.erb
@@ -3,7 +3,7 @@
     A postgraduate certificate in education (PGCE) is an academic qualification in education.
   </p>
   <p class="govuk-body">
-    It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
   <p class="govuk-body">
     This course does not lead to qualified teacher status (QTS).

--- a/app/views/courses/qualification/_pgce_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgce_with_qts.html.erb
@@ -3,9 +3,9 @@
     A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>
   <p class="govuk-body">
-    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
   <p class="govuk-body">
-    Many PGCE courses include credits that count toward a Master&rsquo;s degree.
+    Many PGCE courses include credits that count toward a Master’s degree.
   </p>
 <% end %>

--- a/app/views/courses/qualification/_pgde.html.erb
+++ b/app/views/courses/qualification/_pgde.html.erb
@@ -3,7 +3,7 @@
     A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).
   </p>
   <p class="govuk-body">
-    It&rsquo;s recognised internationally, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
   <p class="govuk-body">
     This course does not lead to qualified teacher status (QTS).

--- a/app/views/courses/qualification/_pgde_with_qts.html.erb
+++ b/app/views/courses/qualification/_pgde_with_qts.html.erb
@@ -3,9 +3,9 @@
     A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.
   </p>
   <p class="govuk-body">
-    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
   <p class="govuk-body">
-    Many PGDE courses include credits towards a Master&rsquo;s degree.
+    Many PGDE courses include credits towards a Master’s degree.
   </p>
 <% end %>

--- a/app/views/courses/qualification/_qts.html.erb
+++ b/app/views/courses/qualification/_qts.html.erb
@@ -6,6 +6,6 @@
     It may also allow you to teach in <%= govuk_link_to 'the EU and EEA', 'https://www.gov.uk/eu-eea' %>, though this could change after 2020.
   </p>
   <p class="govuk-body">
-    If you&rsquo;re planning to teach overseas, you should always check what qualifications are needed in the country you&rsquo;d like to teach in.
+    If you’re planning to teach overseas, you should always check what qualifications are needed in the country you’d like to teach in.
   </p>
 <% end %>


### PR DESCRIPTION
There's no need to use `&rquo;` when we can encode the `’` character directly, which also makes the source code easier to read.