### PR TITLE
Remove bursary and scholarship information and add placeholder guidance

### DIFF
--- a/app/components/courses/search_result_component.html.erb
+++ b/app/components/courses/search_result_component.html.erb
@@ -26,8 +26,10 @@
       <% end %>
     <% end %>
 
-    <dt class="app-description-list__label">Financial support</dt>
-    <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
+    <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
+      <dt class="app-description-list__label">Financial support</dt>
+      <dd data-qa="course__funding_options"><%= course.decorate.funding_option %></dd>
+    <% end %>
 
     <% if show_visa_sponsorship_and_degree_required? %>
       <dt class="app-description-list__label">Degree required</dt>

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -1,21 +1,23 @@
 <div data-qa="course__bursary_details">
-  <p class="govuk-body">
-    You’ll get a bursary of <%= number_to_currency(course.bursary_amount) %> if you have <%= course.bursary_first_line_ending %>
-  </p>
+  <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
+    <p class="govuk-body">
+      You’ll get a bursary of <%= number_to_currency(course.bursary_amount) %> if you have <%= course.bursary_first_line_ending %>
+    </p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <% if course.bursary_requirements.length > 1 %>
-      <% course.bursary_requirements.each do |requirement| %>
-        <li><%= requirement %></li>
+    <ul class="govuk-list govuk-list--bullet">
+      <% if course.bursary_requirements.length > 1 %>
+        <% course.bursary_requirements.each do |requirement| %>
+          <li><%= requirement %></li>
+        <% end %>
       <% end %>
-    <% end %>
-  </ul>
+    </ul>
 
-  <p class="govuk-body">
-    You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
-    Find out about <%= govuk_link_to 'eligibility', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %> and
-    <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
-  </p>
+    <p class="govuk-body">
+      You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
+      Find out about <%= govuk_link_to 'eligibility', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %> and
+      <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
+    </p>
+  <% end %>
 
   <p class="govuk-body">
     You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -1,34 +1,40 @@
 <div data-qa="course__scholarship_and_bursary_details">
-  <p class="govuk-body">
-    You could be eligible for either:
-  </p>
+  <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
+    <p class="govuk-body">
+      You could be eligible for either:
+    </p>
 
-  <ul class="govuk-list govuk-list--bullet">
-    <li data-qa="course__scholarship_amount">a scholarship of <%= number_to_currency(course.scholarship_amount) %></li>
-    <li data-qa="course__bursary_amount">a bursary of <%= number_to_currency(course.bursary_amount) %></li>
-  </ul>
+    <ul class="govuk-list govuk-list--bullet">
+      <li data-qa="course__scholarship_amount">a scholarship of <%= number_to_currency(course.scholarship_amount) %></li>
+      <li data-qa="course__bursary_amount">a bursary of <%= number_to_currency(course.bursary_amount) %></li>
+    </ul>
 
-  <% if course.has_early_career_payments? %>
-    <p class="govuk-body" data-qa="course__early_career_payment_details">
-      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= govuk_link_to 'some areas of England', 'https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools' %>).
+    <% if course.has_early_career_payments? %>
+      <p class="govuk-body" data-qa="course__early_career_payment_details">
+        With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= govuk_link_to 'some areas of England', 'https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools' %>).
+      </p>
+    <% end %>
+
+    <p class="govuk-body">
+      To qualify for a scholarship you’ll need a degree of 2:1 or above in <%= course.subject_name %> or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
+    </p>
+
+    <p class="govuk-body">
+      You cannot claim both a bursary and a scholarship - you can only claim one.
+    </p>
+
+    <p class="govuk-body">
+      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
+    </p>
+
+    <p class="govuk-body">
+      You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    </p>
+  <% else %>
+    <p class="govuk-body">
+      You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
     </p>
   <% end %>
-
-  <p class="govuk-body">
-    To qualify for a scholarship you’ll need a degree of 2:1 or above in <%= course.subject_name %> or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
-  </p>
-
-  <p class="govuk-body">
-    You cannot claim both a bursary and a scholarship - you can only claim one.
-  </p>
-
-  <p class="govuk-body">
-    Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
-  </p>
-
-  <p class="govuk-body">
-    You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
-  </p>
 
   <p class="govuk-body">
     Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://getintoteaching.education.gov.uk/guidance/financial-support-for-international-applicants' %>.

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -8,6 +8,8 @@
       <%= render 'shared/hidden_fields', exclude_keys: %w[subject_codes senCourses], form: f %>
       <h1 class="govuk-heading-l" data-qa="heading"><%= I18n.t('page_titles.subjects_filter') %></h1>
 
+      <p class="govuk-body">Some subjects may offer bursaries or scholarships. Funding will be announced later this autumn.</p>
+
       <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
         <% @subject_areas.each_with_index do |subject_area, counter| %>
           <%= accordion.section(
@@ -41,25 +43,28 @@
                           <% end %>
                         </span>
 
-                        <% if subject.decorate.has_scholarship_and_bursary? %>
-                          <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} are available" %>
-                        <% elsif subject.decorate.has_scholarship? %>
-                          <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} are available" %>
-                        <% elsif subject.decorate.has_bursary? %>
-                          <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} available" %>
-                        <% end %>
-                        <% if subject.decorate.early_career_payments? %>
-                          <% financial_info.concat(', \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).') %>
-                        <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
-                          <% financial_info.concat('.') %>
-                        <% end %>
-                        <span class="govuk-hint govuk-!-margin-bottom-0" data-qa="subject__info"><%= financial_info %></span>
+                        <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
+                          <% if subject.decorate.has_scholarship_and_bursary? %>
+                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} are available" %>
+                          <% elsif subject.decorate.has_scholarship? %>
+                            <% financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} are available" %>
+                          <% elsif subject.decorate.has_bursary? %>
+                            <% financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} available" %>
+                          <% end %>
+                          <% if subject.decorate.early_career_payments? %>
+                            <% financial_info.concat(', \n with early career payments of £2,000 each in your second, third and fourth year of teaching (£3,000 in some areas of England).') %>
+                          <% elsif subject.decorate.has_scholarship? || subject.decorate.has_bursary? %>
+                            <% financial_info.concat('.') %>
+                          <% end %>
 
-                        <% if subject.subject_knowledge_enhancement_course_available %>
-                          <span class="govuk-!-display-block" data-qa="subject__ske_course">
-                            You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
-                            <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
-                          </span>
+                          <span class="govuk-hint govuk-!-margin-bottom-0" data-qa="subject__info"><%= financial_info %></span>
+
+                          <% if subject.subject_knowledge_enhancement_course_available %>
+                            <span class="govuk-!-display-block" data-qa="subject__ske_course">
+                              You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
+                              <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
+                            </span>
+                          <% end %>
                         <% end %>
                       <% end %>
                     </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,4 +26,4 @@ feature_flags:
   maintenance_banner: false
   cache_courses: false
   provider_autocomplete: true
-  bursaries_and_scholarships_announced: false
+  bursaries_and_scholarships_announced: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -26,3 +26,4 @@ feature_flags:
   maintenance_banner: false
   cache_courses: false
   provider_autocomplete: true
+  bursaries_and_scholarships_announced: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -10,3 +10,4 @@ redis_url: redis://localhost:6379/9
 feature_flags:
   new_filters: true
   cache_courses: true
+  bursaries_and_scholarships_announced: true

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -26,6 +26,7 @@ describe 'Search results', type: :feature do
   end
 
   before do
+    activate_feature(:bursaries_and_scholarships_announced)
     stub_subjects
     stub_courses_request
 
@@ -49,6 +50,15 @@ describe 'Search results', type: :feature do
         expect(first_course.funding_options.text).to eq('Student finance if you’re eligible')
         expect(first_course.main_address.text).to eq('Hove Park School, Hangleton Way, Hove, East Sussex, BN3 8AA')
         expect(first_course).not_to have_show_vacancies
+      end
+    end
+
+    context 'with the bursaries_and_scholarships_announced flag inactive' do
+      it 'does not return any funding options' do
+        deactivate_feature(:bursaries_and_scholarships_announced)
+        visit results_path(page: page_index)
+
+        expect(page).not_to have_content 'Student finance if you’re eligible'
       end
     end
   end

--- a/spec/features/result_filters/subjects_spec.rb
+++ b/spec/features/result_filters/subjects_spec.rb
@@ -222,10 +222,30 @@ RSpec.feature 'Results page new subject filter' do
       )
     end
 
-    it 'displays financial information' do
-      subjects = filter_page.subject_areas.first.subjects
-      expect(subjects.fourth.info.text).to eq('Bursaries of £6,000 available.')
-      expect(subjects.fourth.ske_course.text).to eq('You can also take a subject knowledge enhancement (SKE) course.')
+    context 'when the `bursaries_and_scholarships_announced` flag is active' do
+      before do
+        activate_feature(:bursaries_and_scholarships_announced)
+        filter_page.load
+      end
+
+      it 'displays financial information' do
+        subjects = filter_page.subject_areas.first.subjects
+
+        expect(subjects.fourth.info.text).to eq('Bursaries of £6,000 available.')
+        expect(subjects.fourth.ske_course.text).to eq('You can also take a subject knowledge enhancement (SKE) course.')
+      end
+    end
+
+    context 'when the `bursaries_and_scholarships_announced` flag inactive' do
+      before do
+        deactivate_feature(:bursaries_and_scholarships_announced)
+        filter_page.load
+      end
+
+      it 'displays financial information' do
+        expect(page).not_to have_content 'Bursaries of £6,000 available.'
+        expect(page).not_to have_content 'You can also take a subject knowledge enhancement (SKE) course.'
+      end
     end
   end
 


### PR DESCRIPTION
### Context

We don't have information regarding bursaries of scholarships at the moment. We also need to pull the SKE related stuff out as we're not sure which will have it.

### Changes proposed in this pull request

- Put all of the bursary/scholarship/SKE content behind a flag 

- Subject page content

|Before|After|
|-----------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/135849519-75abccf8-b74d-44c2-bfef-08f1fddc4e59.png)|![image](https://user-images.githubusercontent.com/42515961/135849423-dd78476b-fcf1-4f70-aabf-c17d204b48e5.png)|

- Subject page filters

|Before|After|
|-----------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/135849936-467361b9-35a8-4c19-a28d-3242e85f203e.png)|![image](https://user-images.githubusercontent.com/42515961/135850079-cf14f92f-7f75-4691-b021-06c46c8cccf8.png)|


- Results page 

|Before|After|
|-----------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/135850448-c5febb95-770f-4754-a81b-993e9feddbd6.png)|![image](https://user-images.githubusercontent.com/42515961/135850320-8e1daa2f-9ea8-4e7f-bd55-1fef41a8030a.png)|

- Course page

|Before|After|
|-----------|-----------|
|![image](https://user-images.githubusercontent.com/42515961/135850810-9258ab23-fe0f-4511-8885-d2aeeb7fcfed.png)|![image](https://user-images.githubusercontent.com/42515961/135850894-ea71fb49-73b4-4bfb-8660-ef7b9f86bd9a.png)|

### Guidance to review

Have i got everything bursary/scholarship/ske related? The doc was missing a few things. Might be worth having a bit of a manual test with courses in different states.

### Trello card

https://trello.com/c/DPLthMSD/4003-dev-changes-to-find-when-the-new-cycle-is-open-but-funding-has-not-been-anncounced

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
