### PR TITLE
Toggle feature flags in QA

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -10,3 +10,5 @@ feature_flags:
   send_web_requests_to_big_query: true
   new_filters: true
   cache_courses: true
+  provider_autocomplete: false
+  bursaries_and_scholarships_announced: false


### PR DESCRIPTION
### Context

We want to allow the team to view Find as it will be on re-opening day

### Changes proposed in this pull request

Toggle feature flags in QA env:

- Deactivate provider autocomplete
- Do not display funding information

### Trello card
https://trello.com/c/XhsClFWL/4015-toggle-feature-flags-in-qa

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
