### PR TITLE
Fix bug with subjects in filters

### DIFF
--- a/app/views/result_filters/_hidden_fields.html.erb
+++ b/app/views/result_filters/_hidden_fields.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <% if params["subject_codes"].present? %>
-  <% request.params['subject_codes'].each do |subject_id| %>
-    <%= form.hidden_field(:subject_codes, multiple: true, value: subject_id) %>
+  <% request.params['subject_codes'].each do |subject_code| %>
+    <%= form.hidden_field(:subject_codes, multiple: true, value: subject_code) %>
   <% end %>
 <% end %>

--- a/app/views/result_filters/_hidden_fields.html.erb
+++ b/app/views/result_filters/_hidden_fields.html.erb
@@ -4,8 +4,8 @@
   <% end %>
 <% end %>
 
-<% if params["subjects"].present? %>
-  <% request.params['subjects'].each do |subject_id| %>
-    <%= form.hidden_field(:subjects, multiple: true, value: subject_id) %>
+<% if params["subject_codes"].present? %>
+  <% request.params['subject_codes'].each do |subject_id| %>
+    <%= form.hidden_field(:subject_codes, multiple: true, value: subject_id) %>
   <% end %>
 <% end %>

--- a/spec/features/result_filters/send_spec.rb
+++ b/spec/features/result_filters/send_spec.rb
@@ -25,13 +25,20 @@ RSpec.feature 'Results page new SEND filter' do
     before do
       stub_courses(
         query: base_parameters.merge(
+          'filter[subjects]' => '00',
+        ),
+        course_count: 10,
+      )
+      stub_courses(
+        query: base_parameters.merge(
           'filter[send_courses]' => 'true',
           'filter[study_type]' => 'full_time,part_time',
+          'filter[subjects]' => '00',
         ),
         course_count: 10,
       )
 
-      results_page.load
+      visit results_path(subject_codes: ['00'])
       results_page.send_filter.checkbox.check
       results_page.apply_filters_button.click
     end
@@ -52,6 +59,7 @@ RSpec.feature 'Results page new SEND filter' do
             'degree_required' => 'show_all_courses',
             'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
             'senCourses' => 'true',
+            'subject_codes' => ['00'],
           },
         )
       end


### PR DESCRIPTION
### Context

Fix issue with subjects not being retained when filters are applied

### Changes proposed in this pull request

- Update the hidden fields to use the new subject_codes field rather than the deprecated params

### Trello
https://trello.com/c/8sXFu9UP/4014-find-send-filter-bug

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
