### PR TITLE
Add `subject_codes` to list of array query params

### DIFF
--- a/app/services/convert_deprecated_csharp_parameters_service.rb
+++ b/app/services/convert_deprecated_csharp_parameters_service.rb
@@ -1,7 +1,7 @@
 class ConvertDeprecatedCsharpParametersService
   def call(parameters:)
     boolean_parameter_names = %w[fulltime hasvacancies parttime senCourses]
-    array_parameter_names = %w[qualifications subjects]
+    array_parameter_names = %w[qualifications subjects subject_codes]
 
     have_legacy_params = false
     params_hash = parameters

--- a/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
+++ b/spec/services/convert_deprecated_csharp_parameters_service_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe ConvertDeprecatedCsharpParametersService do
         'senCourses' => 'True',
         'qualifications' => 'QtsOnly,PgdePgceWithQts,Other',
         'subjects' => '1,2,3',
+        'subject_codes' => { '0' => '00' },
       }
     end
 
@@ -28,6 +29,7 @@ RSpec.describe ConvertDeprecatedCsharpParametersService do
         'senCourses' => true,
         'qualifications' => %w[QtsOnly PgdePgceWithQts Other],
         'subjects' => %w[1 2 3],
+        'subject_codes' => ['00'],
       })
     end
   end


### PR DESCRIPTION

### Context

We have seen a few errors flagged today in production that are caused by invalid `subject_codes` query params:

https://sentry.io/organizations/dfe-bat/issues/2686958196/?project=1780060

### Changes proposed in this pull request

- Ensure that hash values for `subject_codes` are converted to arrays.

### Guidance to review

- I don't fully understand how we are getting the invalid params. Find itself doesn't seem to generate them in my testing. I don't think they are legacy parameters either because `subject_codes` is quite new - that at least explains why we are starting to see this now rather than earlier.

### Trello card

https://trello.com/c/NLdQD0Q6/4021-fix-errors-when-find-search-receives-invalid-subjectcodes

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
