### PR TITLE
Show 30 search results per page

### DIFF
--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -7,7 +7,7 @@ class ResultsView
   DISTANCE = '2'.freeze
   SUGGESTED_SEARCH_THRESHOLD = 3
   MAXIMUM_NUMBER_OF_SUGGESTED_LINKS = 2
-  RESULTS_PER_PAGE = 10
+  RESULTS_PER_PAGE = 30
   MILES = '50'.freeze
 
   def initialize(query_parameters:)

--- a/spec/fixtures/api_responses/empty_courses.json
+++ b/spec/fixtures/api_responses/empty_courses.json
@@ -1,7 +1,7 @@
 {
   "data": [],
   "links": {
-    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026filter%5Bhas_vacancies%5D=true\u0026filter%5Blatitude%5D=51.4600848\u0026filter%5Blongitude%5D=-0.1201408\u0026filter%5Bradius%5D=5\u0026filter%5Bsend_courses%5D=true\u0026filter%5Bsubjects%5D=W1\u0026include=site_statuses.site%2Cprovider%2Csubjects\u0026page%5Bpage%5D=1\u0026page%5Bper_page%5D=10\u0026sort=distance"
+    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Bfunding%5D=salary\u0026filter%5Bhas_vacancies%5D=true\u0026filter%5Blatitude%5D=51.4600848\u0026filter%5Blongitude%5D=-0.1201408\u0026filter%5Bradius%5D=5\u0026filter%5Bsend_courses%5D=true\u0026filter%5Bsubjects%5D=W1\u0026include=site_statuses.site%2Cprovider%2Csubjects\u0026page%5Bpage%5D=1\u0026page%5Bper_page%5D=30\u0026sort=distance"
   },
   "meta": {
     "count": 0

--- a/spec/fixtures/api_responses/sixty_courses.json
+++ b/spec/fixtures/api_responses/sixty_courses.json
@@ -1,0 +1,6637 @@
+{
+    "data": [
+        {
+            "id": "12964529",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "29SS",
+                "name": "History",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-29T14:11:54.165Z",
+                "uuid": "f107f809-a984-4ded-961f-08f75cd8122b",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "We do not offer Equivalency Tests.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-29T14:11:54Z",
+                "about_accrediting_body": null,
+                "provider_code": "N42",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "On the NTTP History course, students will train towards a professional teaching qualification, achieving Qualified Teacher Status. The course requires a study of academic literature and completion of professional assignments, alongside two school based placements. The course is designed to show that trainee teachers demonstrate that they have met the standards for Qualified Teacher Status. \r\nYou will explore a wide ranging content, and be expected to convey the subject with passion and enthusiasm to students. The material taught will be in line with Placement School curriculum, but you can assume to have a spread of modern, medieval and ancient history lessons.\r\nThe development of core history skills is a key focus in both KS3 and KS4, and you will be taught how best to convey complex historical events, as well as embed both sourcework and historiography to lessons. Through support of excellent mentors, in supportive schools, we will ensure you have the best opportunity to develop into an outstanding History Teacher.\r\nYou will receive a practice-led, hands on experience. Trainees are supported by a Subject Based Tutor within school, the Professional Tutor of the school, the Lead Subject Mentor from the NTTP SCITT, the Programme Facilitators. Subject Studies and General Professional Study sessions enhance your knowledge of teaching and learning and help to develop your pedagogy. Constant self-reflection allows trainees to assess their strengths and development potential, which should allow progression and confidence.\r\nYou will spend the majority of your course in the classroom; working with dedicated professionals. This is the best place to learn the art of teaching.   During your placements you will teach pupils in the 11 to 16 age range. \r\n\r\nSubject Studies are delivered as twilight sessions and take place in the first half of the year so that you have the tools to succeed in your school placements. Sessions are delivered by your Lead Subject Mentor and other experienced teachers.\r\nA selection of subject studies sessions are as follows: \r\nWhat is Humanities? – Understanding why students need to study Humanities subjects\r\nChallenging mis/preconceptions in Humanities – how to tackle stereotyping in History\r\nDifferentiation within Humanities – How do you stretch students in a content heavy subject?\r\nAssessment for learning in Humanities – Measuring learning within humanities\r\nUse of sourcework in lesson – How to make sourcework engaging for students\r\nTeaching outside the classroom – making Humanities an outdoor subject\r\nApproaches and Methodologies towards KS5 Humanities – ",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9000,
+                "financial_support": null,
+                "how_school_placements_work": "We have long-established partnerships and rewarding connections with a wide variety of secondary schools across the county.  Ideally, you will be required to spend a minimum of 12 weeks in two of our placement schools whilst on the course.  You will work closely with our trained school based tutors receiving weekly one-to-one meetings to monitor your progress throughout your first and second placement.\r\nTo qualify for QTS we will provide trainees with enough time in schools to demonstrate that they have achieved all the Teachers’ Standards.\r\nYou will train with pupils in the 11 to 16 age range, however in many of our partnership schools there will be the opportunity to experience Post 16 Education too.\r\nYou will be allocated to your placement school as a result of an initial induction and skills audit conducted early in the course.  Your placement school will be identified to meet your needs and therefore may not be your nearest school.\r\n\r\n",
+                "interview_process": "As with any interview, the key to success is preparation. Make sure you do your research into the course, as well as the issues surrounding education and teaching in general. Policies and practices change quickly, so your knowledge needs to be up to date.\r\nThe Interview process will entail: \r\n•\tAdministrative Questions \t\t\t\t-\t10 minutes\r\n•\tPresentation - “Why I want to become a teacher”\t-\t5 minutes\r\n•\tPresenting a ‘Starter’ of your choice\t\t\t-\t5 minutes\r\n•\tInterview \t\t\t\t\t\t-\t40 minutes\r\n•\tLiteracy written task\t\t\t\t- \t20 minutes\r\n•\tSubject Knowledge Task\t\t\t\t- \t30 minutes\r\n•\tPortfolio of work/video for Art and Performing Art subjects\r\n\r\nYour interviewers will be looking for you to demonstrate a number of qualities. You should therefore try to tailor your answers and contributions to reflect these qualities. They are:\r\n-\tA commitment to and understanding of secondary education and the role of the teacher\r\n-\tGood personal, intellectual and communication skills\r\n-\tA positive attitude towards children and working with children\r\n-\tAn enthusiasm for and understanding of your subject (s) and teaching in general.  \r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "You must have an Honours Degree at class 1 or 2, relevant to the subject you wish to train for and preferably a minimum of 50% of your degree being in that subject. Your A-Level grades will also be taken into consideration.  \r\n\r\nIt is preferable to have had some experience of working with secondary aged young people\r\nIf you hold a non UK degree and/or other qualifications, you should check its validation with NARIC (www.naric.co.uk) who will inform you of its UK equivalence.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12958448",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2H6W",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17801,
+                    "address4": "Greater Manchester",
+                    "provider_name": "The Manchester Metropolitan University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Manchester Metropolitan University",
+                    "year_code": "2019",
+                    "provider_code": "M40",
+                    "provider_type": "university",
+                    "postcode": "M15 6GX",
+                    "website": "https://www.mmu.ac.uk/education/pgce/",
+                    "address1": "Brooks Building",
+                    "address2": "Bonsall Street",
+                    "address3": "Manchester",
+                    "email": "courses@mmu.ac.uk",
+                    "telephone": "0161 247 6969",
+                    "region_code": "north_west",
+                    "created_at": "2021-07-06T10:54:41.761Z",
+                    "updated_at": "2021-09-13T10:36:47.838Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:01:15.423Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "COULD YOU BECOME AN ORIGINAL INFLUENCER?\r\n\r\nAs one of the city’s most established providers – with almost 150 years training education professionals under our belts – we know teaching inside out.\r\n\r\nIn many ways, we think teachers are the original influencers. They inspire. They engage. They explain. And they have a lasting impact on the pupils they teach.\r\n\r\nWe’ve been educating teachers, practitioners and professionals since 1878. We’re proud of our history. We’re proud of our present. And we’re proud to be one of the largest teacher training establishments in the country. Each year, we welcome over 700 trainee teachers onto our PGCE courses. We have a partnership of over 1,500 regional schools, colleges and educational organisations. We adopt leading research into our teaching through our Education and Social Research Institute (ESRI). \r\n\r\nSHARING SELFIES TO SHARING KNOWLEDGE\r\n\r\nSharing selfies is fun, but there is real joy in sharing knowledge. It’s finding new ways to explain complex theories to students and inspiring a love of learning. Discovering innovative global teaching methods. Using research to make a difference in the classroom.\r\n\r\nYou might debate how pupils learn when they live below the poverty line or explore the effect of the growth mind-set. You might research ways to include bilingual students in your lessons or global methods of teaching maths and how this could help your class.\r\n\r\nWhichever subject you’re hoping to teach, we’ll help you to develop the practical skills you need to teach, to inspire and to engage your class.",
+                    "train_with_disability": "From study skills to dyslexia screenings - we've got it covered - https://www.mmu.ac.uk/student-life/wellbeing/disability/.\r\n\r\nIf you are a care leaver, estranged from your family, a carer, under 18 or pregnant, we have a dedicated Inclusion Service to help you through your studies - https://www.mmu.ac.uk/student-life/wellbeing/inclusion/.\r\n\r\nCome and visit our Open or Visit Days and speak to a member of staff from Disability Service - https://www.mmu.ac.uk/study/open-days.\r\n\r\nOr simply contact the Disability Service on 0161 247 3491 or (disability.service@mmu.ac.uk)",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.4666748,
+                    "longitude": -2.2465299,
+                    "ukprn": "10004180",
+                    "urn": "133844",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "M40",
+                "changed_at": "2021-09-21T09:23:05.928Z",
+                "uuid": "374fe87e-8e6b-40d4-8d47-5304658c0d27",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-21T09:23:05Z",
+                "about_accrediting_body": null,
+                "provider_code": "1HJ",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Our School Direct course consists of a variety of learning experiences, focused on practical training in teaching and learning related skills. This practical training is underpinned by the development of participant’s knowledge and understanding of education theories, ideas and concepts and by enhancing their awareness of current educational issues and developments. \r\n\r\nThis course will be delivered in partnership with Manchester Metropolitan University, who will award both Qualified Teacher Status and 60 Masters level credits as a PGCE on successful completion.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 20000,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will become part of your main placement school team from September, this is earlier than University led programmes.  You will receive intensive support from our experienced team of teachers and mentors from the beginning of your placement.  You will build your skills through observation, reflection, and attendance at both alliance training sessions and university led sessions.  This will support you in building your skill set towards teaching whole class lessons, and then onto a significant timetable by the end of the year.",
+                "interview_process": "All programmes include a panel interview where we are looking to find our more about your skills, knowledge, experience and passion.  \r\n\r\nThe interview process takes place over a half-day at our lead School St Peter's RC High School.\r\n- an introductory talk\r\n- a personal interview designed to identify your suitability and commitment to teaching\r\n- a short presentation \r\n- a subject knowledge assessment\r\n- identity and qualification checks (please provide photographic ID, proof of address and copies of your academic qualifications)\r\n\r\nAll offers we make after interview will be conditional on; clearance through the Disclosure and Barring service, validation of any declared qualification and the acquisition of any pending qualifications.  Individual offers may have additional conditions and you are advised to carefully read these.\r\n",
+                "other_requirements": "We also recommend you check the Department of Education website at (www.education.gov.uk/get-into-teaching) for the latest updates.\r\n\r\n A Disclosure and Barring Service Check and satisfactory DfE Fitness to Teach health form are required",
+                "personal_qualities": "Our strongest applicants have undertaken some observation in a school and reflected on their experiences and the role of the teacher.",
+                "required_qualifications": "- Degree classification minimum of a 2:2 undergraduate honours degree awarded by a UK university, or an equivalent higher education qualification. Your degree needs to support the subject knowledge requirements of the National Curriculum for Geography.\r\n\r\n- Appropriate post-16 qualifications, A-level Geography is desirable.\r\n\r\n- GCSEs at grade C/4 or above in English Language and Mathematics. \r\n\r\n\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963544",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "V577",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:04:58.964Z",
+                "uuid": "0feede99-f95d-4d1f-8e34-a01444d15555",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "The degree needs to have a scientific content.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:04:58Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above do NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2020)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963548",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X210",
+                "name": "English",
+                "study_mode": "part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:56:55.514Z",
+                "uuid": "5a499a83-16df-448e-90a2-a89a365f85e4",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": null,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\nWe will consider accepting equivalency tests in lieu of GCSE English \u0026 Maths ( grade 4 (C) or above ) on an individual basis.\r\n",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:56:55Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September 2022 until June 2024. Carefully designed, delivered by experienced practising teachers  to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid- September. \r\n\r\nYou will undertake most of the remaining cohort training alongside full time trainees during your first year, whilst also spending two days in school. You therefore need to commit to three days per week in year one. In year two you will generally spend three days in school and will undertake bespoke training as appropriate either as part of the part time cohort or individually. \r\n\r\nAdditionally, our programme offers: \r\n\r\n* A minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\n* Weekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\n\r\nOur schools comprise predominantly of comprehensive schools including schools. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through: \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are four formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term of Year 2. \r\n\r\nWritten submissions are evenly spread throughout the programme. The wellbeing of our trainees is of the utmost importance to us, we provide various options to support you. \r\n\r\nPGCE (Post Graduate Certificate in Education – 60 Master credits)  lectures are held locally. Trainees undertake 3 additional assignments. Award is validated by University of Buckingham. ",
+                "course_length": "TwoYears",
+                "fee_details": "The fees above include the PGCE element of the programme in addition to the QTS.\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. The QTS only part time programme will be £10500 in total ( correct as at 01/10/2020)",
+                "fee_international": 11500,
+                "fee_uk_eu": 11500,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements are carefully selected to ensure they give excellent but contrasting experiences whilst considering a reasonable travelling distance from your home.  \r\n\r\nWe know many of our Professional Tutors and School Mentors well and try to match our trainees with their mentor to build that strong professional relationship. \r\n\r\nAs a part-time trainee, you'll have two placement schools. Effectively, you will have 6 terms, 3 per year.  Terms 1, 4, 5, 6 will be in School A and terms 2 \u0026 3  in School B. The two schools will provide a contrasting learning environment. \r\n\r\nEvery Thursday during the first year of training you will receive general professional and subject knowledge sessions, complimented by specific bespoke training as appropriate in your second year.  \r\n\r\nYou will start undertaking structured observations of teachers followed by team teaching, part lesson then full lesson teaching. \r\n \r\n Our schools comprise predominantly of comprehensive schools but include a Church of England school. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings.  \r\n\r\n Schools play such an important part in the programme, and that’s why we can provide you with an outstanding foundation on which to build your future career. You will have an expert school-based Mentor and a designated Senior Link (Professional Tutor) in each placement school and they will be trained by, and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. \r\n\r\n“You all, along with everyone at school, made my first term of training to teach the best experience ever. I was able to learn so much from everyone and you were all incredibly supportive in the process! I honestly can’t sing your praises highly enough!” \r\n\r\n“The support provided at each school was outstanding, both the support from my mentor and regular training sessions allowed me to start my NQT year feeling confident and equipped with the correct knowledge to start my career. I would highly recommend both schools as fantastic places to start your career as a teacher”.   \r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools.  \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\n* Welcome by a member of the SCITT team\r\n\r\n* Document check \u0026 hand in of your pre completed subject audit form\r\n\r\n* Tour of the school in which the interview takes place\r\n\r\n* A 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking SKE \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other safer recruitment processes to verify their suitability to work with young people. \r\n\r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS) - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training. Arrangements for completing DBS check applications will be explained as part of the selection and induction process.\r\n\r\nChecking the Prohibited Teachers List\r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent  communication, time-management, planning and organisation skills\r\n\r\n* A positive engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": "ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969238",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "26J6",
+                "name": "Design and Technology (Product Design)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17408,
+                    "address4": "Newcastle upon Tyne",
+                    "provider_name": "University of Newcastle Upon Tyne",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Dawn Bell",
+                    "year_code": "2019",
+                    "provider_code": "N21",
+                    "provider_type": "university",
+                    "postcode": "NE1 7RU",
+                    "website": "https://www.ncl.ac.uk/ecls/study/postgrad/teacher/",
+                    "address1": "Admissions",
+                    "address2": "Level 3",
+                    "address3": "King's Gate",
+                    "email": "pgce-education@ncl.ac.uk",
+                    "telephone": "0191 208 6017",
+                    "region_code": "north_east",
+                    "created_at": "2021-07-06T10:50:15.994Z",
+                    "updated_at": "2021-08-03T08:26:11.916Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T11:04:10.485Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The PGCE Team pride ourselves on providing our students with an excellent standard of education, training and practical teaching experience and are delighted that Newcastle university achieved A Gold Award, in the Teaching Excellence Framework (TEF), evidencing that Newcastle University consistently delivers outstanding teaching, learning and outcomes, for our students. Similarly, we were given a ‘judgement of Confidence by the The Quality Assurance Agency for Higher Education (QAA). We also pride ourselves personal support we give to our students and you will have full access to the extensive services of the ‘Student Support Service’.\r\n\r\nNewcastle University has a reputation for world-class research (16th in the UK) and the PGCE team work closely with our colleagues to ensure our subject and professional programmes are research led and well informed.\r\n\r\nOur PGCE programme, rated Good by Ofsted in 2017, provides rigorous academic and school training. University and school-based components are integrated so that learning is relevant to your practice and development as a confident and capable teacher.  To support you, you will have access to a wide range of study facilities, including all relevant course materials , a well-stocked Education Resource Centre and the comprehensive facilities of the university. You will also have full access to the extensive services of the ‘Student Support Service’ \r\n",
+                    "train_with_disability": "The PGCE Team welcome applications from students with disabilities.  Advice, information and guidance is available from the university Student Support Services, who liaise with us over students’ support requirements, and may liaise with external agencies where appropriate. Disabled Students' Allowances (DSA) is a non-means tested grant available to U.K. disabled students who are applying for, or are attending, a course of Higher Education. There are specific eligibility conditions related to residence in the UK, which have to be met to qualify for this funding.  DSA allowance covers some additional study-related costs that students will incur because of a disability, ongoing medical condition or mental health condition. Extra costs may include specialist equipment, a non-medical helper or travel costs. If you are invited to an interview for PGCE is often a good opportunity to arrange to meet with one of the Disability Advisers, to talk about your support requirements. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 54.9789749,
+                    "longitude": -1.6135961,
+                    "ukprn": "10007799",
+                    "urn": "133852",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N21",
+                "changed_at": "2021-10-05T13:57:27.198Z",
+                "uuid": "c3a4de06-2b55-4d26-872f-e00bb0c4039c",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:57:27Z",
+                "about_accrediting_body": "",
+                "provider_code": "14U",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This is a one-year full time Initial Teacher Education course leading to the academic award of Postgraduate Certificate of Education (PGCE) and Qualified Teacher Status (QTS). At university, trainees undertake three Masters level modules towards their PGCE: Subject Pedagogy in Practice, Developing Critical Perspectives and Curriculum Development Through Enquiry in Practice. Successful trainees are awarded 60 Masters level credits which they can choose to carry forward to the full Master’s course at a later stage. Our School Direct programme provides a wealth of opportunity for trainees to demonstrate evidence of the Teachers’ Standards required for QTS.\r\n\r\nOur School Direct programme is designed to train teachers in the classroom. Our vision to develop expert teachers and leaders of the future starts with all trainees becoming part of the staff team from the beginning of the academic year. Trainee teachers will learn from experienced colleagues and work closely with the staff in the Design and Technology department. You will be given experience of KS3, KS4 and KS5. The vast majority of the year is spent in the host school that you apply to and you will be allocated a contrasting placement which will include six weeks of teaching elsewhere. Contrasting placements are key to the development of all trainee teachers in order to develop a broader understanding of different educational settings.",
+                "course_length": "OneYear",
+                "fee_details": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/f8x1/#fees-and-funding)",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/3072f/)",
+                "how_school_placements_work": "You will spend the majority of the year and undertake most of your teaching commitments at your host school. A contrasting placement will be arranged for you with consideration given to your location, transport, childcare, etc. By placing you in a contrasting school you will gain invaluable experience which help you to develop a range of teaching skills. We only use schools that we know will give you the help and support you need during your placement, including a professional tutor and subject mentor. Weekly mentor meetings and at least one formal lesson observation will occur each week during your teaching practices.",
+                "interview_process": "Newcastle University’s Admissions Team will conduct an initial eligibility check, to determine whether you meet the eligibility criteria. The school you have applied to will then consider your application and agree whether to invite you to interview. If you are selected for interview, you will be sent information about the interview process, together with guidance on how to prepare. The interview process will take approximately half a day at whichever school you have applied to within the alliance. It is important that you spend some time in the school that you are applying to and you will be given an opportunity to talk to some key staff. You will be required to teach an observed lesson; you will be told in advance about the content and the age group you will be teaching as well as any other relevant information to help you prepare. An interview will be the last part of the day where the professional tutor from the school and an Emmanuel Teacher Training Partnership representative will be present.\r\n\r\n",
+                "other_requirements": "You will be required to undergo an enhanced DBS and fitness to teach check to verify your suitability for working with young people. \r\n\r\nWe recommend you spend at least a few recent working days in a UK secondary classroom before applying. This will inform your application and any later performance in the selection process.\r\n\r\nSubject Knowledge Enhancement (SKE) can be organised where necessary and funding arranged to cover costs. You could get a tax-free SKE bursary of £175 per week.",
+                "personal_qualities": "We are looking for trainee teachers who possess a range of personal qualities including:\r\n\r\n* The ability to communicate in English competently, confidently and clearly to a level that facilitates good quality oral and written communication with pupils, parents and colleagues.\r\n* Self-motivation\r\n* Confidence\r\n* Patience\r\n* Compassion\r\n* Enthusiasm\r\n* Resilience\r\n* Initiative\r\n* Team player\r\n* Good organisational skills\r\n* Effective time management\r\n* Passion\r\n* The desire and drive to transform children through education.\r\n",
+                "required_qualifications": "An honours degree (2:2 or above) or equivalent. At least 50% of your degree should be in the subject that you intend to teach. We may accept closely related degree subjects.\r\n\r\nGCSEs or O Levels (grades A–C/ 4-9) in English language and mathematics, or equivalent.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12970122",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "D658",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17445,
+                    "address4": "Worcestershire",
+                    "provider_name": "Haybridge Alliance SCITT",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Sally Koyuncu",
+                    "year_code": "2019",
+                    "provider_code": "2B3",
+                    "provider_type": "scitt",
+                    "postcode": "DY8 2XS",
+                    "website": "http://www.teachwithhaybridge.co.uk",
+                    "address1": "Haybridge High School \u0026 Sixth Form",
+                    "address2": "Brake Lane",
+                    "address3": "Hagley",
+                    "email": "abarker@haybridge.worcs.sch.uk",
+                    "telephone": "01562 881110",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:50:52.983Z",
+                    "updated_at": "2021-09-20T12:57:54.382Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-28T17:50:57.160Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Haybridge Alliance School Centred Initial Teacher Training (SCITT) is based at Haybridge High School and Sixth Form and is recognised as providing exceptional teaching and learning with vast experience in delivering and supporting Initial Teacher training (ITT) courses and placements.\r\n\r\nHaybridge High School is a well-regarded 11-18 comprehensive school with a track record for excellence including four consecutive Ofsted ratings of ‘Outstanding’.  Our Alliance schools are from a range of phases operating within diverse catchment areas with different challenges.\r\nHaybridge Alliance SCITT is the lead provider coordinating the SCITT programme and overall training experience.  All secondary and primary schools in the Alliance will provide school-based placements for the training year recruited.\r\n\r\nThe quality of the programmes together with the support received by our trainees ensures that a high calibre of newly qualified teachers enter the profession.\r\n\r\nThroughout the duration of the course a weekly programme of professional studies workshops are delivered by practising teachers from across the schools in the partnership.  The focus of the programme is to address the development needs of the next cohort of teachers who will teach in our schools.  A programme of subject studies is  provided by local Specialist Leaders in Education.  These sessions are designed to develop the understanding and delivery of a subject pedagogy, reviewing topics such as lesson planning and assessment.  This stimulating programme of professional and subject studies explores the philosophy of education and the pedagogy associated with the teaching of a subject.\r\n",
+                    "train_with_disability": "\r\nWe strive to promote equal opportunities within Haybridge Alliance SCITT and Haybridge High School and Sixth Form has full access for people with all types of disabilities. \r\n\r\nWe offer bespoke support to cater for any physical, mental or learning disabilities dependent upon the needs of each trainee.\r\n\r\nAccommodation is not available through the Haybridge Alliance SCITT and trainees will be expected to find their own accommodation for the duration of the course. \r\n\r\nThe Haybridge Alliance SCITT does not have child care facilities. \r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.4234721,
+                    "longitude": -2.1488906,
+                    "ukprn": "10034167",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B3",
+                "changed_at": "2021-09-30T12:22:20.417Z",
+                "uuid": "9dee9f9e-fc69-46ee-af5f-85af37fdcbac",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-30T12:22:20Z",
+                "about_accrediting_body": null,
+                "provider_code": "18E",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The course will begin in September 2022 and last for one academic year with a trainees time being divided between school based placements (approximately 80%) and structured training days (approximately 20%) which will take place at either Hales Valley Teaching Hub or at one of our partner organisations (Haybridge Teaching School Alliance) and focus upon key educational theory and practice. \r\n\r\nOn the 44 week programme a trainee’s time is divided between Teaching Experiences and structured training sessions looking at subject delivery and wider professional issues. The teaching commitment will build up over the year: 30-40% in the Autumn term, 50% in the Spring and 80% in the Summer term. During the course trainees will be supported by their school-based practitioner who will be a good or outstanding teacher and leader within the school.\r\n\r\nTrainees will be assessed on a combination of evidence gathered during the teaching experiences, a range of tasks linked to Hales Valley/partnership workshops as well as three formal assignments that focus on key areas of teaching and learning.",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Once individuals have accepted a place, they can then make applications for tuition fee loans through Student Finance England, to cover the cost of their training. ",
+                "how_school_placements_work": "SCITT is a school-led training course which gives you the chance to learn ‘on the job’ in a school. You work as part of the teaching team from day one, learning from experienced, highly-skilled colleagues and you immediately put your new skills into practice.\r\nYou spend on average 80% of the week in one of our 20 primary partnership schools teaching in Early Years and Key Stage 1. \r\nWe have worked very closely with our partnership schools over the last eight years and have excellent relationships with them. They share our ethos, understanding the importance and value of school led teacher training.\r\nYou will have two school experiences throughout the year ensuring you gain experience in both Early Years and Key Stage 1 enabling you to teach 3-7 year olds.  You spend your first and last school experience in the same class, in the same school. Your second school placement is in different school ensuring you gain a wider experience in your training. \r\nYou also spend time in Key Stage 2 in order to gain further experience.",
+                "interview_process": "",
+                "other_requirements": "Successful candidates will be required to carry out an enhanced DBS check before commencing the programme. ",
+                "personal_qualities": "",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12957745",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2PPK",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:58:25.622Z",
+                "uuid": "7bfb3bd2-46b5-45ed-9fb1-c33d65c311d9",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:58:25Z",
+                "about_accrediting_body": null,
+                "provider_code": "R23",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Our SCITT curriculum begins early in September and involves teaching practice in school each week from Monday to Thursday, with Friday as a training  day. Training will be hosted and delivered by experienced ITT specialists, subject experts and classroom practitioners who currently teach in our partner schools. \r\n\r\nIn addition, there will be subject pedagogy days during the year where trainees will focus on teaching science specifically. These will be delivered by the Science Learning Centre at Ashton Community Science College. Biology, Chemistry and Physics trainees study together on these days and this is really useful because you will find that in most schools you will teach combined science at KS3. Learning together really helps you develop your subject knowledge across the three sciences and we can also organise additional courses for you via the Science Learning Centre to meet your individual needs.\r\n\r\nYou will audit your subject knowledge for the topics you will need to teach at KS3 and 4. Lead Subject Mentors will guide you towards great resources for this and you will be encouraged to join a professional subject association. A shared drive enables you to share resources with each other and school mentors. \r\n\r\nLeeds Beckett University provide the PGCE for our SCITT and this is all online. The modules perfectly compliment the training we deliver and you will gain 60 Master's level credits (https://courses.leedsbeckett.ac.uk/PGCE_distancelearning/)\r\n\r\nOur programme documentation has been described by Ofsted: \"Documentation is very well designed and contributes significantly to trainees' success on the course\" \r\n\r\nAssessment of trainees for QTS is based on all of the following:\r\n- Regular observations of practice with development discussion and \r\n action steps\r\n- Progress towards meeting the expectations of the curriculum\r\n- A final assessment against the requirements of the Teachers Standards at the end of the programme.\r\n\r\nWe have been highly praised by Ofsted for our approach to trainee workload, keeping our requirements concise yet effective.",
+                "course_length": "OneYear",
+                "fee_details": "£9250 PGCE and QTS\r\n£7000 QTS only",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will complete placements in two partner schools. The first placement will begin in September, an excellent time to see how rules and routines are established at the start of the academic year. You will start with focused lesson observations across the whole school before you join your subject department and begin to plan teach parts of lessons. After a few weeks you will be planning and delivering whole lessons, building up to approximately 7 hours per week by Christmas. \r\n\r\nThe second placement begins after Christmas in a different school which will give you a contrasting experience and broaden your professional development. Again, you will gradually increase your teaching timetable and for the last few weeks will be full time in school, teaching up to 12 hours per week at that point in May and June.\r\n\r\nPlacements are selected for you on the basis of high quality mentoring, strong subject departments, contrasting schools and reasonable commuting distance. We work with approximately 15 schools in Lancashire. \r\n\r\nOn both placements you will teach the 11-16 age range in your subject. \r\nThere may also be opportunities to spend some time in other partner schools and settings as training needs arise. There will normally be additional opportunities to experience primary education and sixth form education on the programme. \r\n",
+                "interview_process": "We  currently have a blended approach to conducting interviews. Typically, the interview will take place via remote access with assessment tasks completed at a training centre. You will be asked to prepare a lesson plan beforehand and we will ask you about your ideas in the interview. There will also be a subject task and a written task which are normally completed at a named venue.\r\n\r\nWe are looking for the potential to be an excellent trainee, someone who is ready to start training in a school setting from early September. We are also looking for potential employees in our schools.\r\n\r\nThe admissions team are Safer Recruitment trained and we are committed to safeguarding children",
+                "other_requirements": "Applicants who are successful at interview will need the following before they can start the programme:\r\n-\tDBS and barred list check\r\n-\tMedical check\r\n\r\nIt is important that you have a good awareness of what the role of a teacher involves so that you can be sure it is the right career choice for you. We offer school experience for people at all stages of this career decision, including after interview, in order to support you with this.\r\n\r\nWe welcome applicants of all ages, from university graduation to mature career changers.\r\n",
+                "personal_qualities": "We are looking for people who are keen to learn in a school setting and this model suits trainees who are able to learn as they go along and incorporate their own experience into this learning process. Successful applicants will have an understanding of the professionalism and resilience needed to become a teacher and to be reflective learners. A real commitment to a career in teaching, a love of their subject and positive attitude towards young people are essential qualities. ",
+                "required_qualifications": "UK Bachelors degree or equivalent\r\nGCSE Maths and English at grade C/4 or above\r\n\r\nIdeally your degree would be a class 2:2 or above and in a subject relevant to the secondary subject you wish to teach, but there are Subject Knowledge Enhancement courses available for shortage subjects such as Maths, Science, English, and Geography.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964174",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "38RW",
+                "name": "Primary with Mathematics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:58:52.562Z",
+                "uuid": "fbdeca0e-f70b-4535-b6ea-cff8ad7f845a",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Candidates are offerred equivalencies where they have accepted their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:58:52Z",
+                "about_accrediting_body": null,
+                "provider_code": "24H",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "“The quality of training across the partnership is outstanding. A fully comprehensive training programme is in place and ensures complete coverage of the primary curriculum.” Ofsted 2017\r\n\r\n\r\nThis programme aims to support you to become an outstanding primary class teacher, whilst developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\nYou will have the opportunity to access specialist training days and experiences to develop your specialism in Maths, overseen by a national mastery specialist teacher. The programme aims to support you to become an outstanding primary class teacher, developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience underpinned by an innovative and thorough taught programme, leading to the award of QTS and a PGCE, with our partners Nottingham Trent University. \r\n\r\nTrainees spend the greatest proportion of their time in school – please see ‘how placements work’.\r\n\r\nThe taught programme is delivered by outstanding practitioners, who work as teachers in our schools and as leaders of their subjects. This includes English, Maths, Science, Teaching \u0026 Learning, Inclusion and the Foundation Subjects – all up to date theory and practice that is being used with high impact in our schools now. As practising teachers who also guide other schools, our trainers have a wealth of current experience and ideas that you can use. The taught days, alongside a range of fun and immersive opportunities, including our residential, will ensure that you remain motivated throughout the programme and driven to become an exceptional teacher:\r\n\r\n“Laura, Tom and Cath inspired us throughout the programme, kept us going when things got hard and gave us new and innovative ideas to try in the classroom”- ILTT Trainee \r\n\r\nNottingham Trent University provide the PGCE qualification, which brings 60 masters credits. Sessions on campus give you academic underpinning to your teaching practice, with two assignments that weave into your experience in school. The first module takes place with the general primary course and covers Learning Theory, the second module and research project focuses on Maths.\r\n \r\n\r\n [For more information about our course, click here] (https://www.inspiringleadersscitt.com/the-course)\r\nRead comments from our trainees about how our training course inspired them via twitter page @ilscitt\r\n\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\n\r\nFor more information visit our websites:\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n\r\n0116 3184066 or email us at info@iltt.org.uk\r\n",
+                "how_school_placements_work": "“The highly practical, school-based nature of the training which is valued by the trainees because it means they learn from the very best teachers’ practice and are given the time to apply their learning, academic research and training in their own classroom situations.” Ofsted 2017\r\n\r\nYour time in school is the largest part of the training and that in which you apply learning from different strands. It is in school where your teaching is shaped and your individual development needs addressed.\r\nSchool placements are not just about being in class – you will be part of the school team, taking a full part in the life of the school and making a real difference to the experiences for the children.\r\nOur General Primary course will require you working in two contrasting schools across our partnership.\r\nWe call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to gain experience over three age phases: Year 1 or 2; Year 3 or 4; Year 5 or 6.\r\nHost placements are decided based on your home location, your access to transport and other needs. \r\nAlternative placements are still arranged considering your travel, but are also selected to give you a contrasting experience and meet your emerging needs.\r\n\r\nIn each placement you will work in partnership with a Class Mentor, to the advantage of the children, planning and reviewing together. Your class mentor will give you on-going advice and model good practice.\r\nYour professional progress will be supported by an experienced teacher in school – your Learning Coach, who will observe and meet with you weekly.\r\n“I am in no doubt that the support I received from my in-school learning coach enabled me to complete this course and secure my first job as a teacher”- trainee 2017/18\r\n\r\nYour Professional Tutor will work closely with your host school and make visits during the placements.\r\n\r\n\r\n[For more information about our course, click here](https://www.inspiringleadersscitt.com/the-course)\r\n",
+                "interview_process": "\r\n\r\n“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)\r\n",
+                "other_requirements": "\r\nPlease be aware that the welfare of our children is our highest priority, and all offers of training places are subject to DBS, identity and reference checks.\r\n\r\n\r\nCall us on 0116 318 4066 or email (info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\nWe are looking for candidates that are determined to change the lives of children and will put relationships at the heart of everything you do. If you are determined to make an impact on children’s lives, we will support and develop you to be a successful teacher. \r\n",
+                "required_qualifications": "A UK degree is required. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's/equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nA commitment to preparing for teacher training is desirable. This can be through virtual means or via prior school experience. *Talk to us about our Readiness for Teaching programme. (Free virtual sessions to support you in preparing for teaching.) \r\n\r\nILTT has a Self-Assessment Document that will help you to gain the right experience in school to support your application.\r\n\r\nIf you would like to find out more,  please get in touch via our email\r\n(info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966086",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "W541",
+                "name": "Media studies",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "qts",
+                "description": "QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T13:59:01.206Z",
+                "uuid": "b3ef2bbc-8232-4055-a88f-01afa4c7c01e",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:01Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS). \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12965473",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2PFF",
+                "name": "Mathematics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17977,
+                    "address4": "Hampshire",
+                    "provider_name": "Wildern Partnership",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Gina Farmer",
+                    "year_code": "2019",
+                    "provider_code": "1WH",
+                    "provider_type": "scitt",
+                    "postcode": "SO304EJ",
+                    "website": "http://wildernpartnership.co.uk/",
+                    "address1": "Wildern Partnership, Wildern School",
+                    "address2": "Wildern Lane",
+                    "address3": "Hedge End",
+                    "email": "scitt@wildernpartnership.co.uk",
+                    "telephone": "01489779458",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:56:35.286Z",
+                    "updated_at": "2021-09-29T14:21:16.671Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T14:41:26.603Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The Wildern Partnership SCITT is an outstanding local teacher training provider, developed through years of collaboration with a diverse range of partnership schools, colleges and universities.\r\n\r\nWe offer a school based, collaborative, quality and cross phase training programme which is adapted to your individual needs.\r\n\r\nThe full time one-year training programme in both Primary and Secondary commences in September. Successful completion of your training with us will result in QTS, along with a Postgraduate Certificate of Education (PGCE) at Masters level.\r\n\r\nIn addition to the academic support available we support your wellbeing through; professional coaching; a high level of pastoral care; subsidised gym membership.\r\n\r\n\r\n",
+                    "train_with_disability": "We pride ourselves on supporting those trainees with specific learning difficulties and disabilities, offering bespoke individualised provision.\r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.9188716,
+                    "longitude": -1.3007123,
+                    "ukprn": "10033371",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1WH",
+                "changed_at": "2021-10-01T10:29:27.160Z",
+                "uuid": "2a18c226-c384-4522-a744-a636daed6783",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Candidates will be required to use a third party. Please see our website for details.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T10:29:27Z",
+                "about_accrediting_body": "",
+                "provider_code": "1LC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Wildern Partnership SCITT aims to develop resourceful and reflective early career teachers who are able to motivate learners to engage, achieve and develop. \r\n\r\nOur curriculum is underpinned by four principal strands:\r\n\r\nBehaviours and Relationships; Diversity and Inclusion; Subject Pedagogy and Assessment. \r\n\r\nTeaching timetables build up at an individual rate fully supported by a mentor.\r\n\r\nCurriculum related expectations drive formative and summative assessment through bespoke target setting.\r\n\r\nPhase 1 – Scaffold (Lead School)\r\n\r\n-       Outstanding practice modelled, theory and practice analysed.\r\n-\t Integrated learning experience for general professional studies and \r\nsubject knowledge for teaching.\r\n- \tCore group training where Secondary and Primary trainees received \r\nphased and combined training by Wildern Partnership Specialists.\r\n\r\nPhase 2 – Scaffold and Develop\r\n\r\n-\tTeaching Groups, micro teaching and working with individual children building to whole class planning, teaching and assessment. Individual support from outstanding school based subject leaders and highly trained school based mentors.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study.\r\n \r\nPhase 3 – Develop (Contrasting Setting)\r\n\r\n-\tCurriculum related expectations consolidated and developed in a contrasting setting.\r\n-\tTeaching classes, groups and individual children, supported and assessed by highly trained school based mentors. Embedding subject knowledge for teaching and supporting pupil progress.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n\r\nPhase 4 - Develop and Refine \r\n\r\n-\tReturn to lead school.\r\n-\tBegin to embed practice from second school experience.   \r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-      Time spent in alternative settings/school as part of an enrichment programme.\r\n-      Optional start of second subject or SEND enrichment programme.\r\n\r\nPhase 5/6 – Refine and Enrich\r\n\r\n-\tRefine teaching practice to develop autonomy in the classroom.\r\n- \tSCITT support for local Early Career Teachers, School CPD in mentoring / subject knowledge / MA level study / diverse bespoke needs.\r\n-\tPreparing for Employment in Education.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-\tFurther completion of teaching time, should any long periods of absence arise throughout the year.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "This is a school direct course, therefore the school placement is already determined when you apply.\r\n",
+                "interview_process": "Secondary SCITT  and School Direct Tuition Fee applicants – \r\nIf shortlisted for an interview you will be invited to Wildern School or a partnership school where you will; plan and facilitate, a teaching activity, undertake a Subject Knowledge Audit, English and Maths skills audit, complete a written task,take part in an organisational group activity and have an individual formal interview.\r\n\r\nAs this is a School Direct placement, should you be successful in the initial interview, you will be required to attend a second interview with the relevant school.\r\n\r\nPLEASE NOTE: Due to the Covid-19 pandemic the interview process is subject to change. Should this be the case, the SCITT Administration Team will inform applicants. ",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "Applicants must hold a degree of a UK university, higher education institution or an acceptable equivalent at 2:2 or above. Their degree should include a minimum content of 50% which is directly related to the subject which they are training to teach. \r\n\r\nApplicants must be in possession of appropriate prior qualifications including GCSE grade C or above in English (or English Language) and Mathematics.\r\n\r\nApplicants are required to have passed the professional skills tests before the start of the course.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964172",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2VPH",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:59:44.031Z",
+                "uuid": "a48edf67-b66f-4236-84b9-afd87c0a53ec",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalencies are offerred to trainees that accept their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:44Z",
+                "about_accrediting_body": null,
+                "provider_code": "24H",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "\r\n“The quality of training across the partnership is outstanding. A fully comprehensive training programme is in place and ensures complete coverage of the primary curriculum.” Ofsted 2017\r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience underpinned by an innovative and thorough taught programme, leading to the award of QTS and a PGCE, with our partners Nottingham Trent University. \r\n\r\nTrainees spend the greatest proportion of their time in school – please see ‘how placements work’.\r\n\r\nThe taught programme is delivered by outstanding practitioners, who work as teachers in our schools and as leaders of their subjects for the partnership. This includes English, Maths, Science, Teaching \u0026 Learning, Inclusion and the Foundation Subjects – all up to date theory and practice that is being used with high impact in our schools now. As practising teachers who also guide other schools, our trainers have a wealth of current experience and ideas that you can use. The taught days, alongside a range of fun and immersive opportunities, including our residential, will ensure that you remain motivated throughout the programme and driven to become an exceptional teacher:\r\n“Laura, Tom and Cath inspired us throughout the programme, kept us going when things got hard and gave us new and innovative ideas to try in the classroom”- ILTT Trainee\r\n\r\nNottingham Trent University provide the PGCE qualification, which brings 60 masters credits. Sessions on campus give you academic underpinning to your teaching practice, with two assignments that weave into your experience in school. \r\n\r\nYour progress across the course is supported and monitored by our highly experienced Professional Tutor team, who will give both pastoral and developmental support over the year, ensuring that you are able to make the most of all elements of the course. \r\n\r\n [For more information about our course, click here] (https://www.inspiringleadersscitt.com/the-course)\r\nRead comments from our trainees about how our training course inspired and supported them on our twitter page @ilscitt\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\nFor more information visit our websites:\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n\r\n0116 3184066 or email us at info@iltt.org.uk\r\n",
+                "how_school_placements_work": "\r\n“The highly practical, school-based nature of the training which is valued by the trainees because it means they learn from the very best teachers’ practice and are given the time to apply their learning, academic research and training in their own classroom situations.” Ofsted 2017\r\n\r\nYour time in school is the largest part of the training and that in which you apply learning from the other strands. School placements are not just about being in class – you will be part of the school team, taking a full part in the life of the school and making a real difference to the experiences and outcomes for the children in your care.\r\nOur General Primary course will require you working in two contrasting schools across our partnership.\r\nWe call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to gain experience over three age phases: Year 1 or 2; Year 3 or 4; Year 5 or 6.\r\nHost placements are decided based on your home location, your access to transport and other needs. \r\nAlternative placements are still arranged considering your travel, but are also selected to give you a contrasting experience and meet your emerging needs.\r\n\r\nIn each placement you will work in partnership with a Class Mentor, to the advantage of the children, planning and reviewing together. Your class mentor will give you on-going advice and support as well as modelling good practice.\r\nYour professional progress will be formally supported by an experienced teacher in school – your Learning Coach, who will observe and meet with you weekly.\r\n“I am in no doubt that the support I received from my in-school learning coach enabled me to complete this course and secure my first job as a teacher”- trainee 2017/18\r\n\r\nYour Professional Tutor will work closely with your host school and make visits during the placements.\r\n\r\n\r\n[For more information about our course, click here](https://www.inspiringleadersscitt.com/the-course)\r\n",
+                "interview_process": "“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)\r\n",
+                "other_requirements": "\r\nPlease be aware that the welfare of our children is our highest priority, and all offers of training places are subject to DBS, identity and reference checks.\r\n\r\n\r\nCall us on 0116 318 4066 or email (info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\nWe are looking for candidates that are determined to change the lives of children and will put relationships at the heart of everything you do. If you are determined to make an impact on children’s lives, we will support and develop you to be a successful teacher. \r\n",
+                "required_qualifications": "A UK degree is required. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's/equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nA commitment to preparing for teacher training is desirable. This can be through virtual means or via prior school experience. *Talk to us about our Readiness for Teaching programme. (Free virtual sessions to support you in preparing for teaching.) \r\n\r\nILTT has a Self-Assessment Document that will help you to gain the right experience in school to support your application.\r\n\r\nIf you would like to find out more,  please get in touch via our email\r\n(info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963536",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Q358",
+                "name": "Mathematics",
+                "study_mode": "part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:59:06.496Z",
+                "uuid": "f6432a74-83d4-4b26-86d5-3f3ebf37bce6",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\nWe will consider accepting equivalency tests in lieu of GCSE English \u0026 Maths (grade 4 (C) or above ) on an individual basis.\r\n",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:06Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September 2022 until June 2024. Carefully designed, delivered by experienced practising teachers  to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid- September. \r\n\r\nYou will undertake most of the remaining cohort training alongside full time trainees during your first year, whilst also spending two days in school. You therefore need to commit to three days per week in year one. In year two you will generally spend three days in school and will undertake bespoke training as appropriate either as part of the part time cohort or individually. \r\n\r\nAdditionally, our programme offers: \r\n\r\n* A minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\n* Weekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\n\r\nOur schools comprise predominantly of comprehensive schools including schools. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through: \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are four formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term of Year 2. \r\n\r\nWritten submissions are evenly spread throughout the programme. The wellbeing of our trainees is of the utmost importance to us, we provide various options to support you. \r\n\r\nPGCE (Post Graduate Certificate in Education – 60 Master credits)  lectures are held locally. Trainees undertake 3 additional assignments. Award is validated by University of Buckingham. ",
+                "course_length": "TwoYears",
+                "fee_details": "The fees above include the PGCE element of the programme in addition to the QTS.\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. The QTS only part time programme will be £10500 in total ( correct as at 01/10/2020)",
+                "fee_international": 11500,
+                "fee_uk_eu": 11500,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements are carefully selected to ensure they give excellent but contrasting experiences whilst considering a reasonable travelling distance from your home.  \r\n\r\nWe know many of our Professional Tutors and School Mentors well and try to match our trainees with their mentor to build that strong professional relationship. \r\n\r\nAs a part-time trainee, you'll have two placement schools. Effectively, you will have 6 terms, 3 per year.  Terms 1, 4, 5, 6 will be in School A and terms 2 \u0026 3  in School B. The two schools will provide a contrasting learning environment. \r\n\r\nEvery Thursday during the first year of training you will receive general professional and subject knowledge sessions, complimented by specific bespoke training as appropriate in your second year.  \r\n\r\nYou will start undertaking structured observations of teachers followed by team teaching, part lesson then full lesson teaching. \r\n \r\n Our schools comprise predominantly of comprehensive schools but include a Church of England school. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings.  \r\n\r\n Schools play such an important part in the programme, and that’s why we can provide you with an outstanding foundation on which to build your future career. You will have an expert school-based Mentor and a designated Senior Link (Professional Tutor) in each placement school and they will be trained by, and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. \r\n\r\n“You all, along with everyone at school, made my first term of training to teach the best experience ever. I was able to learn so much from everyone and you were all incredibly supportive in the process! I honestly can’t sing your praises highly enough!” \r\n\r\n“The support provided at each school was outstanding, both the support from my mentor and regular training sessions allowed me to start my NQT year feeling confident and equipped with the correct knowledge to start my career. I would highly recommend both schools as fantastic places to start your career as a teacher”.   \r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools.  \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\n* Welcome by a member of the SCITT team\r\n\r\n* Document check \u0026 hand in of your pre completed subject audit form\r\n\r\n* Tour of the school in which the interview takes place\r\n\r\n* A 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking SKE \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other safer recruitment processes to verify their suitability to work with young people. \r\n\r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS) - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training. Arrangements for completing DBS check applications will be explained as part of the selection and induction process.\r\n\r\nChecking the Prohibited Teachers List\r\n\r\nChecking references and gaining reassurance where necessary",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": "ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969992",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "S626",
+                "name": "Mathematics",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS, full time or part time with salary",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "salary",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17803,
+                    "address4": "Brighton and Hove",
+                    "provider_name": "University of Sussex",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Coordinator",
+                    "year_code": "2019",
+                    "provider_code": "S90",
+                    "provider_type": "university",
+                    "postcode": "BN1 9QQ",
+                    "website": "http://www.sussex.ac.uk/education/ite",
+                    "address1": "Sussex School of Education",
+                    "address2": "Essex House",
+                    "address3": "Falmer, Brighton",
+                    "email": "iteadmissions@sussex.ac.uk",
+                    "telephone": "01273 873238",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:54:44.013Z",
+                    "updated_at": "2021-09-20T12:03:01.948Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T12:02:30.208Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Sussex Schools Partnership offers high quality professional and academic teaching courses leading to Qualified Teacher Status (QTS), a PGCE of 90 Masters Level Credits and a progression route onto a Masters in Education. \r\n\r\n\r\nWith a history of innovation we pioneered a model of school-based teacher training 50 years ago, now adopted nationally. Schools are involved at every stage of the selection, training and assessment of our beginner teachers. This long standing relationship results in excellent support from experienced teachers mentoring trainees on placement and dedicated University tutors offering models of successful pedagogy. As a small friendly department we offer our trainees a personal approach and  aftercare support and training as Newly Qualified Teachers\r\n\r\n\r\nWe train 'thinking' teachers with a over riding desire to make a difference to the lives of young people.   \r\nA research intensive university, we believe teachers benefit from critical engagement in evidence-based practice, reflection on research and continuing professional development as well as excellent practical classroom skills. \r\n\r\nOur University sits on a leafy campus at the edge of the South Downs National Park, accessible by road or rail from East and West Sussex, Brighton and Hove, Surrey, Kent, Hampshire and South London. The historic seaside city of Brighton is minutes away, with its pebble beaches and vibrant social and cultural opportunities.\r\n\r\n\r\nCourse outcomes are consistently high;  100% achieving QTS on first attempt, \r\n94% completing with Merit or Distinction,  \r\n98% securing a teaching post and \r\n99% of ex-trainees rating the course 'good' or 'very good'.  \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+                    "train_with_disability": "The University of Sussex welcomes applications from all candidates who have the potential to make excellent teachers regardless of disability and additional needs. \r\n\r\nWe have previously successfully supported trainee teachers with dyslexia, dyspraxia, aspergers, mental wealth conditions and a range of physical, hearing and visual impairments.\r\n\r\nAll trainee teachers  are first screened for mental and physical fitness to teach by the University's Occupational Health Department before admission to the programme.  Following this, if you have a disability or health condition, you will register with the University Student Support service and an assessment is arranged to establish your needs. The team will identify the additional support and adjustments  recommended to help you be as successful as possible on the course.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.8670895,
+                    "longitude": -0.087914,
+                    "ukprn": "10007806",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "S90",
+                "changed_at": "2021-10-01T10:21:16.592Z",
+                "uuid": "a0a85357-8c8c-4554-8b76-8c5d9952524b",
+                "program_type": "school_direct_salaried_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-24T10:16:42Z",
+                "about_accrediting_body": "Offering a Postgraduate Certificate in Education (PGCE) in Primary (ages 5-11) and Secondary (11-16) with specialisms in over eight subjects.  For the latter, professional practice is focused on Key Stages 3 and 4. \r\n\r\nCommitted to high-quality teacher education built upon genuine partnerships, inspired by best classroom practice, and engaged in teaching as an intellectual and ethical vocation. Our goal is to recognise, support and develop a generation of reflective practitioners who are ready, willing and able to improve the life chances of every young person they teach.",
+                "provider_code": "2CC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Successful applicant(s) for this course are usually placed at Knole Academy Sevenoaks.  \r\nOur well-established and long-running programme provides trainees with the opportunities to undertake a practical and theoretical training programme in a vibrant and dynamic primary or secondary school environment.   \r\nOur School Direct programme is delivered in conjunction with our accrediting training provider, the University of Sussex.  Trainees will undertake four days of training per week in their placement school and attend the University of Sussex on Fridays to undertake sessions that cover the theory and practice of teaching.  Trainees will attend a 3-week induction in September at the University of Sussex, thereafter the main school placements will commence with the first week being comprised of a detailed induction by your school's professional and subject mentors.  Trainees will carry out detailed lesson observations for the first two to three weeks followed by around 5 hours of teaching per week, with the number of hours increasing throughout the year as your professional skills and confidence increases.\r\nTrainees will also continue to have professional development sessions with their relevant mentors throughout the year.  Sessions will focus on the development of your subject knowledge and the craft of teaching through observing other teachers, team-teaching, joint planning sessions, etc.  We will also organise for our trainees a 4-6 weeks placement in a complementary school during the latter part of the academic year.  This will provide trainees with a comprehensive understanding of teaching in different school environments. \r\nAll trainee teachers must demonstrate that they have met the Teachers’ Standards in order to gain Qualified Teacher Status (QTS). You will keep a portfolio of evidence to show that you have done so. \r\nPart-time participants will undertake the programme over a 2-year training programme with hours increasing year-on-year.  During the first year, you will teach two days per week with Fridays at Sussex, and submit the main 6,000 word written assessment comprised of a series of lessons that you will design, teach, evaluate and analyse at Master’s Degree level.  In the second year you will teach for three days per week with a 5-week block of teaching at the end of your course.  \r\nSuccessful School Direct trainees will gain Qualified Teacher Status (QTS) with the option to achieve a Postgraduate Certificate in Education (PGCE) from the University of Sussex worth 60 Masters level credits.\r\n[Kent Oaks Consortium](http://www.kentoaksconsortium.co.uk/)\r\n[University of Sussex Teacher Training](http://www.sussex.ac.uk/education/ite/schooldirect)\r\n",
+                "course_length": "1 year FT, 2 Year PT",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "All primary and secondary schools within the consortium are based in West Kent, including the lead school, Knole Academy, and they undergo continuous quality assurance in order to provide rigorous training standards.  We currently have seven partner school within the consortium.  We have limited availability in each secondary school subject area placements and primary school placements, therefore applicants are advised to apply as early as possible.",
+                "interview_process": "Candidates’ applications will be processed via the university clearing system, UCAS. After an initial screening to check you meet the minimum entry requirements your application will then be read by an expert panel who will invite successful applicants to interview. The interview will take place at the lead school (Knole Academy) or in one of our partnership schools and is likely to include a preliminary interview comprised of:\r\n\r\n * A Short 20 Minutes Teaching Session - potential secondary trainees are required to teach a given task and primary trainees can choose an appropriate activity. Tasks can be found on the Resources page.\r\n * Written Tasks - designed to assess the quality of candidates’ written English and their understanding of current issues in education \r\n * Student Interview - a selection of students across the year groups will conduct an informal interview for secondary applicants\r\n * Formal Interview - panel interview with members of the selection panel \r\n * A Brief (10 Minutes) Presentation – this will be on an aspect of your subject which you feel is misunderstood or difficult to teach.\r\n\r\nCandidates will be advised of the exact format in advance.  There will then be a second interview/meeting with The University of Sussex.\r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": "Trainees will be paid as an unqualified teachers' pay of around £17,700 per annum"
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969830",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "M778",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-24T10:20:48.544Z",
+                "uuid": "e4d37b9a-0cc3-4f8c-ae1e-e5eaa183041d",
+                "program_type": "higher_education_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-24T10:20:48Z",
+                "about_accrediting_body": null,
+                "provider_code": "N36",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "university",
+                "about_course": "Overview\r\nChoosing to study a PGCE in Primary Education is your first step to inspiring children in learning about their world, and we here at Newman University would love to support you in joining the profession. We understand that the Primary 3-11 age range is a crucial time for children’s development and learning. It is at this formative and particularly receptive stage of development that attitudes towards learning are formed, attitudes that will impact on future life course development. \r\nThe PGCE Primary (3-11) is designed to prepare you for teaching across the Primary age range. There are three modules developed to support your knowledge and understanding of theory, policy and practice, including the Early Years, National Curriculum and SEND frameworks. Two level 7 modules are linked to children’s learning and development as well as curriculum, assessment and pedagogy and you will study these consecutively in the first and second term. The final training module, studied across all three school terms, enables you to observe, reflect on and then undertake the role of the teacher in the Primary phase. The course will enable you to meet the requirements for Qualified Teacher Status (QTS). For those wishing to work within Catholic schools, or who wish to develop their understanding of Religious education, there is also the opportunity to undertake the Catholic Certificate in Religious Studies (CCRS) – see Additional Information for details.\r\nTo ensure that the course content is as up-to-date and relevant to current teaching theory and practice as possible, this course will be re-validated at least every five years or sooner, if external changes require it.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "Unfortunately we are unable to accept international students as we do not hold a Tier 4 Licence,",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Please refer to our website for further details www.newman.ac.uk ",
+                "how_school_placements_work": "School-based learning is central to the PGCE programme and will be a feature of all three terms of your PGCE year. You undertake placements in at least two primary schools providing opportunities to observe and practise a range of methods and approaches. School-based learning includes observation of experienced teachers, a structured programme of group and whole class teaching and a series of directed activities to explore wider school issues.\r\n\r\n",
+                "interview_process": "Our aim is to make this a two way informative process that is as enjoyable as possible, despite being an interview. We want every candidate to have the opportunity to demonstrate their potential to be a good teacher and to thrive as a teacher in their following career.\r\n\r\nFull details of the interview process will be sent to applicants who have progressed successfully to this stage, further details can also be found on the Newman website.\r\n\r\nInterview candidates will be invited to our Faculty of Education to meet academic staff and tutors. \r\n\r\nThe interview day is made up of 2 main components:\r\n● Micro-teaching session with a small group of other candidates, \r\nInterviewers will be looking for you to include: a brief introduction; a main body, engaging the audience and making good use of the available time; a definitive ending summarizing the learning\r\n● Personal interview. The interviewer will use your personal statement as a starting point, to find out about you and your interests, experiences and skills relevant to becoming a teacher\r\n\r\nWe will be looking for:\r\n● Your passion to become an outstanding teacher\r\n● Good communication skills, including an ability to speak confidently  and communicate effectively with individuals and groups\r\n● A knowledge of the National Curriculum in your subject or age area and current educational developments",
+                "other_requirements": "Obtaining a Disclosure and Barring (DBS) clearance and meeting the requirements for Fitness to Teach are also required.\r\n\r\nSchool experience is desirable, but not an essential requirement prior to interview. However, having experience in a school will:\r\n\r\n * Allow you to add additional information at interview about the experience that you have had when working with children\r\n * Give you an advantage when you start the course as you will be able to make links between your learning and how this relates to school",
+                "personal_qualities": "The quality and variety of your personal statement is an important factor in the decision to call you to interview. Candidates must attend an interview at Newman University.\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12965470",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "26JT",
+                "name": "Modern Languages",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17977,
+                    "address4": "Hampshire",
+                    "provider_name": "Wildern Partnership",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Gina Farmer",
+                    "year_code": "2019",
+                    "provider_code": "1WH",
+                    "provider_type": "scitt",
+                    "postcode": "SO304EJ",
+                    "website": "http://wildernpartnership.co.uk/",
+                    "address1": "Wildern Partnership, Wildern School",
+                    "address2": "Wildern Lane",
+                    "address3": "Hedge End",
+                    "email": "scitt@wildernpartnership.co.uk",
+                    "telephone": "01489779458",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:56:35.286Z",
+                    "updated_at": "2021-09-29T14:21:16.671Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T14:41:26.603Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The Wildern Partnership SCITT is an outstanding local teacher training provider, developed through years of collaboration with a diverse range of partnership schools, colleges and universities.\r\n\r\nWe offer a school based, collaborative, quality and cross phase training programme which is adapted to your individual needs.\r\n\r\nThe full time one-year training programme in both Primary and Secondary commences in September. Successful completion of your training with us will result in QTS, along with a Postgraduate Certificate of Education (PGCE) at Masters level.\r\n\r\nIn addition to the academic support available we support your wellbeing through; professional coaching; a high level of pastoral care; subsidised gym membership.\r\n\r\n\r\n",
+                    "train_with_disability": "We pride ourselves on supporting those trainees with specific learning difficulties and disabilities, offering bespoke individualised provision.\r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.9188716,
+                    "longitude": -1.3007123,
+                    "ukprn": "10033371",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1WH",
+                "changed_at": "2021-10-01T10:29:57.137Z",
+                "uuid": "e3c2c028-7902-4b8d-a403-9b0e09aa8449",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Candidates will be required to use a third party. Please see our website for details.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T10:29:57Z",
+                "about_accrediting_body": "",
+                "provider_code": "1LC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Wildern Partnership SCITT aims to develop resourceful and reflective early career teachers who are able to motivate learners to engage, achieve and develop. \r\n\r\nOur curriculum is underpinned by four principal strands:\r\n\r\nBehaviours and Relationships; Diversity and Inclusion; Subject Pedagogy and Assessment. \r\n\r\nTeaching timetables build up at an individual rate fully supported by a mentor.\r\n\r\nCurriculum related expectations drive formative and summative assessment through bespoke target setting.\r\n\r\nPhase 1 – Scaffold (Lead School)\r\n\r\n-       Outstanding practice modelled, theory and practice analysed.\r\n-\t Integrated learning experience for general professional studies and \r\nsubject knowledge for teaching.\r\n- \tCore group training where Secondary and Primary trainees received \r\nphased and combined training by Wildern Partnership Specialists.\r\n\r\nPhase 2 – Scaffold and Develop\r\n\r\n-\tTeaching Groups, micro teaching and working with individual children building to whole class planning, teaching and assessment. Individual support from outstanding school based subject leaders and highly trained school based mentors.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study.\r\n \r\nPhase 3 – Develop (Contrasting Setting)\r\n\r\n-\tCurriculum related expectations consolidated and developed in a contrasting setting.\r\n-\tTeaching classes, groups and individual children, supported and assessed by highly trained school based mentors. Embedding subject knowledge for teaching and supporting pupil progress.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n\r\nPhase 4 - Develop and Refine \r\n\r\n-\tReturn to lead school.\r\n-\tBegin to embed practice from second school experience.   \r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-      Time spent in alternative settings/school as part of an enrichment programme.\r\n-      Optional start of second subject or SEND enrichment programme.\r\n\r\nPhase 5/6 – Refine and Enrich\r\n\r\n-\tRefine teaching practice to develop autonomy in the classroom.\r\n- \tSCITT support for local Early Career Teachers, School CPD in mentoring / subject knowledge / MA level study / diverse bespoke needs.\r\n-\tPreparing for Employment in Education.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-\tFurther completion of teaching time, should any long periods of absence arise throughout the year.\r\n\r\n\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "This is a school direct course, therefore the school placement is already determined when you apply.\r\n",
+                "interview_process": "Secondary SCITT  and School Direct Tuition Fee applicants – \r\nIf shortlisted for an interview you will be invited to Wildern School or a partnership school where you will; plan and facilitate, a teaching activity, undertake a Subject Knowledge Audit, English and Maths skills audit, complete a written task,take part in an organisational group activity and have an individual formal interview.\r\n\r\nAs this is a School Direct placement, should you be successful in the initial interview, you will be required to attend a second interview with the relevant school.\r\n\r\nPLEASE NOTE: Due to the Covid-19 pandemic the interview process is subject to change. Should this be the case, the SCITT Administration Team will inform applicants. ",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "Applicants must hold a degree of a UK university, higher education institution or an acceptable equivalent at 2:2 or above. Their degree should include a minimum content of 50% which is directly related to the subject which they are training to teach. \r\n\r\nApplicants must be in possession of appropriate prior qualifications including GCSE grade C or above in English (or English Language) and Mathematics.\r\n\r\nApplicants are required to have passed the professional skills tests before the start of the course.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969838",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Y390",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17626,
+                    "address4": "Leeds",
+                    "provider_name": "Leeds Trinity University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Leeds Trinity University",
+                    "year_code": "2019",
+                    "provider_code": "L24",
+                    "provider_type": "university",
+                    "postcode": "LS18 5HD",
+                    "website": "https://www.leedstrinity.ac.uk",
+                    "address1": "Leeds Trinity University",
+                    "address2": "Brownberrie Lane",
+                    "address3": "Horsforth",
+                    "email": "admissions@leedstrinity.ac.uk",
+                    "telephone": "0113 283 7123",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:52:55.297Z",
+                    "updated_at": "2021-09-22T14:14:08.925Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T13:50:19.392Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Leeds Trinity University has been synonymous with high quality teacher training since 1966, when we were founded as a Catholic teacher training college. \r\n\r\nOver the years, we’ve diversified and expanded to become renowned for teaching excellence and producing highly employable graduates across many subject areas, but an unwavering commitment to outstanding teacher training has remained at the heart of what we do. \r\n\r\nRecognising that people begin PGCE courses with different levels of experience and skills, we train you in three stages to build your confidence and capability with a mix of research-informed practice, school-based training and plenty of one-to-one support. \r\n\r\nWe work with over 600 schools – from small rural schools to large, inner-city high schools. We work with ‘Outstanding’ schools leading innovations in education, as well as schools that may have difficulties in reaching outcome targets at the end of key stages. \r\n\r\nWhen you train with Leeds Trinity, you’ll experience best practice in school improvement, whichever school you train in.\r\n\r\nYou’ll work with expert school mentors while on placement and receive help, advice and support from University-based link tutors. This combination means you’ll get specialist training on teaching the most difficult aspects of subject content, and understanding children and young people at various ages and stages of development.\r\n\r\nAfter you graduate, we offer excellent support for teachers in the early stages of their career, and have a very strong Early Career Teacher (ECT) programme, with CPD, an active online community, and an annual conference.",
+                    "train_with_disability": "We’re committed to ensuring that every student with potential, regardless of their background or circumstances, has the opportunity to benefit from higher education. \r\n\r\nIf you have a disability or additional needs, Leeds Trinity University will endeavour to put in place reasonable adjustments to accommodate any additional requirements throughout your teacher training year. We’re able to support with conditions such as: \r\n\r\n-\tDyslexia\r\n-\tSpecific learning difficulties\r\n-\tAsperger syndrome/autism\r\n-\tVisual/hearing impairments\r\n-\tPhysical and mobility restrictions\r\n-\tLong-term medical conditions\r\n-\tA mental health condition. \r\n\r\nIf you register with our Disability Service, a member of the team will develop a Learning Support Plan tailored to your specific needs. The support within this plan could include exam adjustments, extended library loans, specialist one-to-one study skills, dyslexia screening and assessments, learning materials provided in alternative formats and alternative assessments.\r\n\r\nWith your permission, they’ll share this plan with your University-based personal tutor so that they know how to best support you during your University-based training. They can also share this plan with the School Partnerships team, who are able to inform the host schools for your placements so they can discuss how to best support you during your school-based training. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.8481606,
+                    "longitude": -1.6459213,
+                    "ukprn": "10003863",
+                    "urn": "133838",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "L24",
+                "changed_at": "2021-08-25T13:14:39.980Z",
+                "uuid": "1d3f1642-015f-4840-b334-2567637d790b",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "Degree subject should match or be closely related to Biology.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-08-25T13:14:39Z",
+                "about_accrediting_body": null,
+                "provider_code": "2C3",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "On successful completion of the course students are awarded QTS, PGCE, comprising 60 credits at Master Level 6. \r\n\r\nStudents are placed in two highly performing schools, mentored by good and outstanding teachers. \r\n\r\nThey will experience all aspects of school life which is invaluable when applying for future teaching positions. \r\n\r\nStudents will spend more than 120 days in schools on placement. \r\n\r\nWe arrange for students visit provision to increase their awareness of where children transition from and to (pre and post secondary), providing a holistic understanding of childrens progression. \r\n\r\nStudents will also have the opportunity to view best practice for SEN and EAL children. \r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "The course begins with an induction at Horizon CC before commencing the first placement in an alternative school. After Christmas the remainder of the school year is spent at Horizon CC in their Science department.\r\n\r\nLocated in a suite of state of the art, fully resourced labs, the Science Department at Horizon offers a fantastic environment in which to begin your teaching journey. In total we have 7 full Science labs, 6 STEM rooms and one electronics room – all of which are maintained and resourced by two experienced lab technicians. Our schemes of learning aim to equip students with the knowledge, skills and mindset that will enable them to succeed to potential in their Science GCSEs and prosper in post-16 opportunities beyond this. We provide many opportunities for students to visit places of significant scientific interest in both Britain and Europe, and our dedicated STEM lead is currently planning a trip to CERN in Geneva for some of our keenest scientists. The Department has a wealth of experience in developing early career teachers, so why not come and join this excellent team!\r\n\r\n ",
+                "interview_process": "We invite applicants who successfully meet the application criteria to attend a Selection Event at Horizon Community College.  \r\n\r\nThe event will be led by staff from our partnership schools along with a staff member from Tykes Teaching Alliance. The event will last approximately two to three hours and will include:\r\n\r\nA meet \u0026 greet – an introductory talk about the course and Tykes   Teaching School Alliance \r\nA learning walk – where you will be shown around school by a group of pupils\r\nAn individual interview\r\nA teaching task \r\n\r\nAt this stage we assess your;\r\n•         ability to communicate clearly, both orally and on paper\r\n•         knowledge of the area of education you are interested in\r\n•         interest in, and commitment to, a career in teaching\r\n•         ability to work effectively with children in an educational setting (for primary education courses you will need to bring the reference from the educational setting you attended)\r\n \r\nPlease note that during the Covid-19 pandemic we are conducting Selection Events remotely via Zoom. \r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966468",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "T805",
+                "name": "Primary (3-7)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17512,
+                    "address4": "Leicestershire",
+                    "provider_name": "Inspiring Leaders with Discovery Schools Trust",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Fossebrook Primary School",
+                    "year_code": "2019",
+                    "provider_code": "1BJ",
+                    "provider_type": "scitt",
+                    "postcode": "1 School Lane",
+                    "website": "http://www.inspiringleadersscitt.com",
+                    "address1": "Discovery Schools NSPCC Training Centre",
+                    "address2": "NSPCC National Training Centre",
+                    "address3": "Leicester",
+                    "email": "jvenables@iltt.org.uk",
+                    "telephone": "01163184066",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:51:32.479Z",
+                    "updated_at": "2021-10-05T14:44:51.060Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T14:44:51.060Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Inspiring Leaders Teacher Training, is an Ofsted 'Outstanding' rated partnership of schools working across Leicestershire, Leicester and Rutland, working together to develop outstanding teachers and leaders of the future. \r\n\r\nAs Discovery Schools Academy Trust  we are committed to helping every child the opportunity to 'Discover their Potential' and believe the best way to achieve this is through outstanding teaching and leadership. \r\n\r\nAll of the schools you will be based within, aspire for our schools to be the best paces for children to learn and develop their full potential. To achieve this we need to recruit, support and invest in teachers with the passion and determination to provide outstanding opportunities and experiences for our children. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience alongside an innovative and inspiring taught programme, leading to the award of QTS and a PGCE, with our partners the University of Leicester.\r\n\r\nWe are passionate, experienced and successful at developing great teachers with 100% of our trainees being successfully employed in the past 3 years.\r\n\r\nWe offer more than just a one year teacher training programme by supporting trainees into employment in our schools and delivering ongoing career opportunities tailored to their needs.\r\n\r\n[For more information visit our websites:]\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n\r\nCall us on 0116 3184066 or email us at info@iltt.org.uk\r\n",
+                    "train_with_disability": "We are an equal opportunities provider and provide support for all our students with their learning requirements. \r\n\r\nOur partner universities provide support for trainees with different needs and learning requirements. \r\n\r\nThis can be discussed at the screening and interview process. ",
+                    "accrediting_provider_enrichments": [
+                        {
+                            "Description": "We work tirelessly to ensure that all of our trainees are supported and become great teachers. In 2018/19 of those who completed the course – 100% of them moved into jobs in local schools and are now accessing high quality support in their first year of teaching.\r\n\r\nWe work with the University of Leicester to award PGCE to all trainees on our programme.",
+                            "UcasProviderCode": "2A5",
+                            "validation_context": null
+                        }
+                    ],
+                    "latitude": 52.6672396,
+                    "longitude": -1.1643891,
+                    "ukprn": "10055365",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1BJ",
+                "changed_at": "2021-10-05T14:05:34.199Z",
+                "uuid": "778daece-05ca-4ee5-bfdf-3e630c9fb083",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "We offer equivalencies for those candidates that have accepted their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:05:34Z",
+                "about_accrediting_body": null,
+                "provider_code": "5W1",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Trainees will work alongside others on the 5-11 pathway to ensure that they are also gaining an overview of primary education to recognise their role within the bigger picture of a child’s journey in school. Placements will provide experiences in EYFS and Key Stage 1. The first term will be in KS1 to ensure that knowledge and theory from teaching can be embedded. Trainees will then move into an EYFS setting during their alternative placement. \r\nSchool based training alongside training sessions and high quality tutoring and mentoring will provide opportunities for trainees to plan, teach and manage learning for children aged 3-7 years. Trainees will therefore have the ability to assess and progress learning, build professional relationships and maintain high quality learning environments. \r\nSpecialist sessions will be provided by an SLE in Early Years supported by other relevant personnel to ensure that the trainees have a broad view of the EYFS provision. Additional sessions will allow trainees to experience specialist knowledge at a greater depth and couple it with tasks and experiences in their host schools\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "course_length": "OneYear",
+                "fee_details": "Financial Support\r\n\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\n\r\n\r\n \r\n[Click here:](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "how_school_placements_work": "\r\nOur EYFS course will require you working in two contrasting schools across our partnership, depending on the location selected. We call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to cover these 3 age phases: EYFS, Year 1 and Year 2. \r\n\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "interview_process": "“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)",
+                "other_requirements": "Call us on 0116 318 4066 or email info@iltt.org.uk\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\n\r\nWe are looking for candidates that have a good awareness of current educational issues and have a deep understanding and open mind about how they affect children and schools. As well as an ability to act with professionalism and integrity. ",
+                "required_qualifications": "\r\nA UK degree is required to join the course. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's or equivalent at grade C/4 or above in English, Mathematics and Science.\r\n Work experience is recommended. \r\n\r\nILTT has a School Readiness Programme that will help you to gain the right pre- course experience to support your application.\r\n\r\n[If you would like us to help you gain this school based experience please get in touch via our email info@iltt.org.uk\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12960407",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "258T",
+                "name": "Modern Languages",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17149,
+                    "address4": "",
+                    "provider_name": "York St John University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Office",
+                    "year_code": "2019",
+                    "provider_code": "Y75",
+                    "provider_type": "university",
+                    "postcode": "YO31 7EX",
+                    "website": "http://www.yorksj.ac.uk",
+                    "address1": "Lord Mayor's Walk",
+                    "address2": "York",
+                    "address3": "",
+                    "email": "pgce@yorksj.ac.uk",
+                    "telephone": "01904 876598",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:47:24.309Z",
+                    "updated_at": "2021-09-28T10:57:41.367Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:20:12.968Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": null,
+                    "train_with_disability": null,
+                    "accrediting_provider_enrichments": null,
+                    "latitude": 53.9649139,
+                    "longitude": -1.0800959,
+                    "ukprn": "10007713",
+                    "urn": "133914",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "Y75",
+                "changed_at": "2021-09-14T08:52:47.888Z",
+                "uuid": "22aeba32-6426-4923-bbaa-62925b179717",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-14T08:52:47Z",
+                "about_accrediting_body": "YSJ supports and trains student teachers who are intelligent risk takers who base their professional decisions on a deep-rooted understanding of pupil’s learning and effective pedagogies.  \r\n\r\nInitial Teacher Education with York St John University in collaboration with the White Rose Alliance will provide you with high quality training that not only responds to the demands of the Teachers' Standards and changes in the wider education landscape but also encompasses and embraces that which criticises and critiques current practice, encouraging, acknowledging and rewarding research-led reflection on pedagogy.",
+                "provider_code": "196",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This WRA School Direct course leads to a PGCE qualification and Qualified Teacher Status (QTS). The secondary course age range is 11-16 with 16-18 enhancement. Languages trainees will be expected to teach their first language (French) to the full age range and their second language (German or Spanish) to Key Stage 3.\r\n\r\nThe course structure enables trainees to begin their development in school from the start of the course and build their confidence and teaching knowledge through their two school placements. \r\n\r\nTrainees will spend most of the training year based in their placement schools developing their teaching skills at their own pace, underpinned by weekly WRA Professional Studies (PS) sessions held at King James's School , and weekly academic/subject pedagogy training sessions held at York St John University providing specialist support for the PGCE qualification.  Trainees are also able to access and benefit from the full range of university services e.g. writing and academic support, wellbeing services, library and IT, careers, etc.\r\n\r\nThe weekly WRA PS programme covers the core areas of the Initial Teacher Training (ITT) Core Content Framework (CCF) to equip trainees with the essential skills and knowledge they need to develop as professional educators.  Feedback from a former trainee : \"Can't rate these sessions highly enough in terms of how they have helped my progression through the year\".\r\n\r\nTrainee progress is monitored closely throughout the course and assessment made by mentors regarding their achievement of QTS status at the end of the course. Trainees will be required to complete 2 Masters level assignments for their PGCE qualification.\r\n\r\nWRA trainees have access to a comprehensive support structure covering every aspect of their training through staff in their placement schools (subject mentor, department/pastoral staff, ITT coordinator), their university (link tutor, coordinator, subject peers) and the White Rose Alliance (lead teacher, senior mentor, administrator and cohort peers). Feedback from a former trainee:\" Support from all aspects of the course has been excellent and has allowed me to really grow in confidence and competence throughout the year\". \r\n\r\nWhilst the intention is for university and White Rose Alliance sessions to be delivered in person, where this is not possible due to Covid-19 restrictions or exceptional circumstances, alternative arrangements will be made to run university \u0026 White Rose Alliance sessions virtually. \r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "For the majority of the course, trainees are school-based. Trainees will be in their placement school unless attending sessions at their link university (in general terms one day per week), weekly Professional Studies sessions at King James's School on Wednesday mornings or School Experience Days at WRA partner schools.\r\n\r\nWRA partner schools are:\r\n\r\n* King James's School, Knaresborough\r\n* Bradford Grammar School\r\n* Stokesley School\r\n* The Grammar School at Leeds\r\n* Thirsk School and Sixth Form College\r\n* Ripon Grammar School\r\n* Sherburn High School\r\n* Boroughbridge High School\r\n* Ryedale School\r\n* Richmond School \u0026 Sixth Form College\r\n\r\nTrainees undertake 2 school placements: Placement 1 from September to Christmas and Placement 2 from January to June.\r\n\r\nSchool placements provide structured opportunities for trainees to observe experienced teachers and other professionals, and receive support as they progressively build confidence and skills towards independent teaching. During school placements trainees will be expected to cover the 11-16 age range plus obtain experience of some 11-18 teaching during their course. In school you will be given the opportunity to participate in all aspects of school life and the wider school context eg. attending school meetings, extra-curricular activities, school training days and other professional development activities, that will support you in developing your knowledge and understanding of the whole school environment. You will be supported during your school placements by a subject mentor and other school staff who are committed to your education and training.   \r\n\r\nWhen allocating school placements, we consider a number of factors including trainee home location and accessibility to transport (ie. ability to drive, access to own vehicle or reliant on public transport).  Not all WRA partner schools are able to provide placements for all subjects \u0026 therefore on occasions, it may be necessary for trainees to undertake placements in non-WRA schools. Trainees should expect, and be prepared for, some reasonable daily travel at their own cost. We will however, endeavour to  provide the most appropriate placements we can.   \r\n\r\nShould there be any impact on school placements as a result of Covid-19, virtual or alternative educational experiences will be arranged.",
+                "interview_process": "WRA interviews take place remotely. Candidates will generally be given one week's notice of interview whenever possible \u0026 dates/times are flexible. \r\n\r\nCandidates invited to interview will be required:\r\n* to complete an initial subject audit form for each of their 2 languages\r\n* to complete a Prior Achievement Booklet \r\n* to undertake a subject test in French (45 minutes) via email (before the interview if possible)\r\n* to prepare a lesson plan \u0026 resources for an imaginary 15 minute teaching/learning activity (to discuss during the formal interview)\r\n* have a formal interview (45 minutes) via Zoom. The panel for the formal interview will comprise 2 members of a combination of White Rose Alliance staff, partner school staff or university staff. \r\n\r\nThe initial subject audit forms and subject test will be reviewed by a subject specialist who will provide advice to the interview panel.\r\n\r\nCandidates will be advised of the interview outcome as soon as possible after their formal interview, once all information from the interview activities has been collated. ",
+                "other_requirements": "Standard university conditions will apply to all offers made at interview. These include proof of qualifications (candidates will be required to produce degree certificate \u0026 GCSE Maths \u0026 English certificates for verification), obtain Enhanced DBS clearance \u0026 complete a medical check.",
+                "personal_qualities": "\r\n* Strong subject knowledge \u0026 willingness to develop it\r\n* Enthusiasm for subject and a desire to share this\r\n* Passion for both learning and teaching\r\n* Genuine interest in young people and their development\r\n* Strong and committed work ethic\r\n* Ability to build good working relationships with others\r\n* Excellent organisation and time management skills\r\n* Confidence in communicating with young people and adults of all levels\r\n* Resilience to cope under pressure\r\n* Creativity\r\n* Self-motivation\r\n* Resourcefulness and adaptability\r\n* Openness to constructive criticism\r\n* Reflective approach\r\n* Sense of humour\r\n* Patience\r\n ",
+                "required_qualifications": "\r\n* Honours degree in chosen subject at 2.2 or above. If degree subject is not in subject applied for, but applicant holds an A Level in the subject \u0026 can demonstrate subject-related experience, applicant may still be considered; applicant is likely to be required to complete a subject knowledge enhancement (SKE); this would become a condition from any offer made at interview. \r\n* GCSE Grade Cs or above (or equivalent) in English and Mathematics.\r\n* First language must be French and have ability to teach second language (ie. German or Spanish) to Key Stage 3 before course commencement.\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966056",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "G719",
+                "name": "Modern Languages (French, German, Spanish)",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "qts",
+                "description": "QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T14:01:25.962Z",
+                "uuid": "e5ddec7d-e1ab-4d7d-a10c-86427d802269",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:01:25Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS). \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963390",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "27RK",
+                "name": "English",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17773,
+                    "address4": "Coventry",
+                    "provider_name": "The University of Warwick",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Centre for Teacher Education",
+                    "year_code": "2019",
+                    "provider_code": "W20",
+                    "provider_type": "university",
+                    "postcode": "CV4 8EE",
+                    "website": "http://www2.warwick.ac.uk/fac/soc/cte/thinking-about-being-a-teacher/",
+                    "address1": "Westwood Campus",
+                    "address2": "University of Warwick",
+                    "address3": "Kirby Corner Road",
+                    "email": "cte.admissions@warwick.ac.uk",
+                    "telephone": "024 761 50269",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:54:26.825Z",
+                    "updated_at": "2021-10-04T12:47:19.281Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T11:46:03.644Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "WARWICK. HELPING YOU FIND YOUR OWN PATH TO TEACHING SUCCESS.\r\n\r\nWe understand that teaching is more than just a job. We also know that you are more than just another applicant. That’s why our approach is tailored around your needs. We’re focused on getting you prepared to enter the classroom and ready for all the challenges that teaching throws at you. We won’t drop you in at the deep end, but we will help you become accustomed to different school environments.\r\n\r\nWe have a long history of providing students with the best access to the contacts, resources and facilities needed to fulfil teaching promise. You’ll also benefit from our research-informed teaching, delivered at an acclaimed university with a reputation for excellence. That teaching will come from people who truly understand about the journey that you’re taking. We have been training teachers for over 50 years and are part of the Russell Group, whose members represent outstanding teaching and learning experience.  We are rated an \"Outstanding\" provider of teacher training by Ofsted \r\n\r\nWe work in partnership with over 500 schools to deliver the highest quality training. You will be taught and supported by highly experienced tutors, class teachers and school mentors who have national reputations for the quality of their training. Upon completing a PGCE with Warwick you will gain 90 credits at master’s level. \r\n",
+                    "train_with_disability": "All trainees are provided with a named personal tutor and a subject specific mentor in placement. \r\nWarwick provide a range of support for students with disabilities and other needs through the Student Disabilities Team.\r\n\r\nwarwick.ac.uk/services/disability",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.3879174,
+                    "longitude": -1.5613053,
+                    "ukprn": "10007163",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W20",
+                "changed_at": "2021-09-27T11:51:19.066Z",
+                "uuid": "d4fa9f57-6076-46b7-9467-c0f896553c89",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-27T11:51:19Z",
+                "about_accrediting_body": null,
+                "provider_code": "179",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "School Direct programmes contain a core Professional Studies element and a series of Subject Studies sessions designed for your chosen specialism.  Some of these take place at the placement school and some at the University of Warwick.\r\n\r\nTrainees then take what they have learned in the training room directly into the classroom where they put it into practice under the supervision and guidance of mentors and fellow colleagues who will provide support, feedback and key guidance to ensure that all trainees make the required progress. Professional Studies sessions, based at Caludon Castle School, are facilitated by leading practitioners who have a track record of excellence in teaching.\r\n\r\nTopics covered include:\r\n\r\nUnderstanding learning\r\nBehaviour for learning\r\nOutstanding lesson planning\r\nUsing ICT to enhance learning and teaching\r\nLiteracy and numeracy\r\nQuestioning techniques\r\nDifferentiation\r\n\r\nThe course will include:\r\n\r\n•\tmaintaining subject knowledge in English Language and Literature\r\n•\ttaking the fear out of grammar teaching\r\n•\tpromoting good accuracy\r\n•\treading for pleasure and for comprehension       \r\n•\tdelivering Literature at Key Stage 3, 4 and 5       \r\n•\tdesigning and supporting learning outside the classroom\r\n•\tlinking English to the wider curriculum\r\n•\tsupporting Post-16 English teaching\r\n\r\nTrainees will have experience in at least two secondary or primary schools (depending on phase and potential Covid restrictions) and have the opportunity to immerse themselves in school life, participating in extra-curricular activities, parent meetings, and cross-curricular events.  Trainees, also get the chance to spend some time working with children with special educational needs.\r\n\r\nAll programmes lead to QTS and PGCE status, including the award of 90 CATS credits towards Master’s accreditation, upon meeting the assessment criteria, specified by the University of Warwick.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "Successful School Direct candidates will complete their Post Graduate Certificate of Education (PGCE 11-18) with the University of Warwick, allowing them to achieve Qualified Teacher Status (QTS) as well as gaining 90 CATs points towards their Master’s. Practical, school-based training will take place at the lead school.  The School Direct programme will involve candidates being supported in and engaged with the schools from the beginning of September 2022, developing relevant professional skills and learning from the wealth of experience that exists both within the schools and the university. High quality support will be available at all times from the schools and the university to help candidates on their journey towards becoming outstanding classroom practitioners. ",
+                "interview_process": "If shortlisted for selection, applicants will be invited to an interview day, where they will be involved in a range of activities, including teaching a short lesson to students, undertaking a literacy exercise, and undergoing a panel interview.  All applicants offered a place will subsequently be required to produce a clear enhanced disclosure certificate from the Disclosure and Barring Service and to pass the 'Fitness to Teach' requirements laid down by the Department for Education, before taking up their place on the course.",
+                "other_requirements": "",
+                "personal_qualities": "Applicants need to have a passion for teaching and show a sincere professional interest in working with children.  Applicants need to be in good health.  Applicants are required to show a commitment to their subject, as well as a desire to train in a school-based environment. They are encouraged to highlight in particular any prior teaching experience in their application.",
+                "required_qualifications": "Selection criteria are broad and we welcome applications from all sections of the community.  Candidates must have at least 5 GCSE's at 4 (C) grade or above, including English and Mathematics. Primary school applicants need to have a grade 4 (C) or above in Science as well. We prefer at least a high second-class UK honours degree for all subjects although a 2.2 is acceptable.  Applicants are advised that 50% of their degree should focus on the relevant subject, but if a candidate wishes to teach in a subject different from their degree, then they must undertake a SKE.\r\n\r\n.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963549",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X542",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:02:34.736Z",
+                "uuid": "f4094fe9-1f22-4d71-bcc8-228ba60421d4",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "It is important that your degree has a science composition.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:02:34Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above does NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2021)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12967529",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "V611",
+                "name": "Early Years",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17369,
+                    "address4": "Worcestershire",
+                    "provider_name": "University of Worcester",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions",
+                    "year_code": "2019",
+                    "provider_code": "W80",
+                    "provider_type": "university",
+                    "postcode": "WR2 6AJ",
+                    "website": "https://www.worcester.ac.uk/about/academic-schools/school-of-education/get-into-teaching-at-worcester/home.aspx",
+                    "address1": "Henwick Grove",
+                    "address2": "",
+                    "address3": "Worcester",
+                    "email": "admissionsb@worc.ac.uk",
+                    "telephone": "01905 855111",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:49:48.599Z",
+                    "updated_at": "2021-09-10T14:20:48.294Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T14:38:58.568Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Worcester has a long-standing reputation for training excellent, highly employable teachers. Personalised academic and professional tutoring, from a range of experienced tutors and mentors, ensures that you will be supported throughout your course and in transition from trainee to teacher. With extensive research profiles, your learning is shaped by those helping to shape education itself. \r\n\r\nYou will benefit from our excellent partnerships with schools, in a wide range of locations. With excellent support and dedicated school experience tutors, you will have the opportunity to flourish as an effective teacher.\r\n\r\nOur PGCE courses offer Master's-level credits as well as Qualified Teacher Status, and provide excellent opportunities.\r\n\r\nOur Primary courses include a high quality tailored programme of training in all National Curriculum subjects, in addition to SEND and RE. \r\n\r\nTrainee teachers at Secondary level can choose to add depth to their qualifications by involvement in additional enhancement activities in key areas such: as Special Educational Needs and Disabilities; working with learners who have English as an Additional Language; developing expertise in Citizenship; developing skills in a second STEM subject; preparing to be Education Leaders; developing skills in Technology Enhanced Learning; teenage mental health education; education in climate emergency; research in education.\r\n\r\nAt Secondary level we also offer pre-training Subject Knowledge Enhancement courses in a range of subjects for those who need them.\r\n\r\nOur inclusive courses attract applicants from a range of career and study backgrounds, including career changers and we welcome applications from all who meet our entry requirements. ",
+                    "train_with_disability": "The University of Worcester offers a wide range of support and advice to disabled students and also to parents, staff and those external agencies supporting disabled students.\r\n\r\nOur Disability and Dyslexia Service offers support, advice and guidance to students who have a disability, medical condition or Specific Learning Difficulty (SpLD). This support lasts throughout a student’s studies at the University of Worcester. We also work with and offer support and advice to University staff on how to meet the needs of disabled students.\r\n\r\nWe can provide assistance through:\r\n \r\n* Supporting disabled students with general enquiries\r\n* Implementing special arrangements for lectures, exams and field trips. This might include notes in advance or special arrangements in exams.\r\n* Where appropriate, we can arrange note takers, academic support tutors, library assistance, interpreters and transcribers.\r\n* Help with applying for the Disabled Students Allowance (DSA) which is there to fund these types of support in higher education.\r\n* Limited loans of equipment\r\n* Confidential advice and support for students and staff\r\n* Training and awareness raising workshops\r\n* Assistive technology ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.1970053,
+                    "longitude": -2.2428253,
+                    "ukprn": "10007139",
+                    "urn": "133911",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W80",
+                "changed_at": "2021-10-05T14:03:00.870Z",
+                "uuid": "10c60456-2efe-4f5b-93a9-6c60996ae448",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalency tests can be accessed through the University of Worcester",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:54:19Z",
+                "about_accrediting_body": "Our accredited partner, the University of Worcester, offer an immersive and inspiring, school-centred training route into teaching.\r\n\r\nAt Worcester the PGCE: School Direct Primary is tailored to your needs - building on your existing strengths and expertise. Our course is inclusive and innovative in its design and delivery, and places you at the heart of a thriving school community.\r\n\r\n\r\n*Full immersion in the daily life of a school \r\n*Breadth and depth of experience across a range of schools\r\n*Outstanding additional opportunities for enrichment and extension\r\n*A dynamic taught programme, \r\n*Unparalleled personal and academic support throughout the programme and beyond\r\n",
+                "provider_code": "2L6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Arden Forest Teaching Alliance, led by Welford on Avon Primary School is delivering an Early Years School Direct Initial Teacher Training course in association with the University of Worcester beginning September 2021.\r\n\r\nFor the majority of the training year you will based at your ‘host school’.\r\nIn addition, you will spend one term on a complementary placement, in a contrasting school setting.\r\n\r\n\"As a partnership of schools, we are fully committed to offering the best possible support and training to grow the next generation of teachers. We have a wealth of experience and expertise in supporting those new to the profession and feel that our school Direct programme will give teachers the best possible start in their career”\r\n\r\nJulie Leeman – Headteacher, Welford on Avon Primary School\r\n\r\nAlongside your time in school, learning from experienced and highly skilled teachers, you will attend a number of taught sessions led by both the University of Worcester and lead schools from with the partnership, to support your academic practice. \r\nYou will complete a number of Masters level assignments which will further your understanding of effective teaching pedagogies and theories.\r\nYou will be supported, whilst on the programme, by an experienced  school mentor and a University link tutor who will help guide your development, assess your progress and support you to maximise your potential.\r\n\r\nThe course is carried out over a full academic year, starting in September 2022",
+                "course_length": "OneYear",
+                "fee_details": "UK/EU £9,250 ( subject to change during 21/22\r\n\r\nInternational Fees £13,700\r\n\r\n",
+                "fee_international": 13700,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "Successful trainees will be based at one of our partner schools, located in and around South Warwickshire.\r\n\r\nYou will have three school experience placements. SE1 and SE3 will take place in your host school and usually in the same year group ( Nursery or Reception). SE2 will be a contrasting setting and in a Key Stage One classroom.  \r\nThroughout their training we aim to give trainees a broad experience in our Early Years and Key Stage 1 settings. In addition, we will provide short experiences observing and working with our KS2 classrooms. ",
+                "interview_process": "Further details of the interview progress will be shared with the successful applicants.",
+                "other_requirements": "All successful applicants will be subject to a full DBS check.",
+                "personal_qualities": "As an Early Years Teacher, you will inspire, excite and nurture children through a crucial stage of their development. Your aim is to motivate children a providing a safe and secure environment for them to develop their social and communication skills.\r\nAs an early years teacher you will motivate and stimulate a child's learning abilities, often encouraging learning through experience preparing them for the start of their primary school years. ",
+                "required_qualifications": "Details of qualifications are available through the University of Worcester. \r\n\r\nAn undergraduate degree\r\n\r\nGSCE passes in English, Maths, and Science (or equivalencies)\r\n\r\nEquivalencies in Maths, English \u0026 Science are accepted from some providers \u0026 this will be checked on application.  The University of Worcester do hold their own equivalency tests and therefore we do accept applications without these relevant qualifications in place.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969936",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "P947",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-19T15:57:00.385Z",
+                "uuid": "60037c96-ec88-4461-9094-2344510c66be",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-19T15:57:00Z",
+                "about_accrediting_body": null,
+                "provider_code": "1BO",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The School Direct course is a flexible approach to teacher training. The majority of your time will be spent in school, training in the classroom and being supported by experienced teachers and mentors. You will also spend time studying at the University.  Successful completion of the course leads to Qualified Teacher Status (QTS)* and a postgraduate qualification.\r\n  *The title of this award is subject to change due to an ongoing government consultation. For the latest information, please visit www.gov.uk/dfe\r\n\r\nYou will be a registered student with NTU and your qualification will be an NTU award. This means that NTU has responsibility for the quality of your training and you will benefit from the combined expertise of the University and lead placement school. \r\n\r\nThis secondary PGCE teaching degree is based around five modules which are core to all trainees.  The curriculum has been organised so that you will gain substantial support for the study of all modules at the start of the course through front-loaded University-based sessions, before your placements begin. The Learning and Teaching in the Subject module will largely be completed in this period, meaning that you will have clarity about academic expectations and your tutors will have an insight into required support. The other modules will be completed at different stages during the year to ensure both reasonable workload and to allow for the progressive impact of the Learning and Teaching in the Subject and Learning and Teaching in the Wider Context modules (underpinned by the Skills of Enquiry module which is assessed across these two modules) on the Secondary Education Independent Study and Secondary Professional Practice modules which run right until the end of the courses.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "As a School Direct trainee, you will be entitled to the same financial support as trainees on other postgraduate teacher training courses.\r\n\r\nIf you are a UK or EU trainee, you should be eligible for a student loan, maintenance loan or maintenance grant to cover the cost of your study, and will only start paying the loans back when you start earning over £21,000 per annum.\r\n\r\nYou may be eligible to receive a training bursary, dependent on the subject you train for and a degree classification.\r\n",
+                "how_school_placements_work": "Successful candidates will spend the majority of their time at Brunts Academy where they will be assigned a subject specific mentor and undertake the teaching, in their chosen subject area, of students from age 11-18 as appropriate.  Some days will be spent at University - see course content.\r\n\r\nCandidates will spend a minimum of 2 days at a primary school in the first term.  During the primary placement candidates will:\r\n* begin to appreciate the similarities and distinctiveness of learning and teaching in KS2 and the primary phase more generally;\r\n*gain awareness of pupils’ capabilities and prior knowledge in the key stage immediately prior to that for which they are training; \r\n*contribute to their growing knowledge and understanding of standards, progression and transition in their subject/related disciplines. \r\n\r\nCandidates will also undertake a second placement at the beginning of the spring term at another school/academy.  This placement is arranged by the Director of ITT.  This provides candidates with an opportunity to broaden their experience by teaching in a school in a different setting/location/context.",
+                "interview_process": "Following the submission of a successful application form candidates will be invited for an initial interview at NTU prior to being interviewed at the Lead School, Brunts Academy. ",
+                "other_requirements": "Candidates will be subject to an interview with both the training school and NTU as part of the selection process.  Candidates will undertake:\r\n*Disclosure and Barring Service check; \r\n*Prohibition Order check. \r\n\r\nTwo references are required, one academic and one vocational.  Evidence of mainstream UK school experience (paid or voluntary) in their application is desirable, although not essential. ",
+                "personal_qualities": "Every day you'll get the chance to inspire young people and use your skills to give something back – making sure every pupil gets the same access to a quality education and the opportunity to succeed. \r\n\r\nYou will need:\r\n*good communication skills\r\n*good organisational skills\r\n*the ability to develop relationships with others\r\n*to be passionate about your subject \r\n*to be dedicated to teaching\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12968705",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2C9T",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-10T15:13:09.069Z",
+                "uuid": "17ad7cf4-2bd8-4924-8346-01b1f812e2b0",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-10T15:13:09Z",
+                "about_accrediting_body": null,
+                "provider_code": "S95",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "The Stourport SCITT (School Centred Initial Teacher Training) is committed to providing the best school based training experience in the area. The final qualification is for Qualified Teacher Status (QTS), with a PGCE accredited through Birmingham City University. There is extensive subject knowledge support and a strong connection with placement schools, in order to ensure a 'joined up' approach to the course, trainee wellbeing and support. \r\n\r\nThe secondary chemistry teaching programme is based in a school from the very beginning and closely follows the national curriculum. Each successful applicant should be able to teach across all science areas up to Key Stage 4 and be willing to teach the full age range, from 11 to 18. Applicants will be given a full opportunity to demonstrate their knowledge and understanding at the interview and selection stage. Excellent support for trainees is offered by outstanding teachers and science departments committed to providing the best school placement experiences. Trainees will be based at the SCITT Training Rooms and will be offered places at two different secondary schools within the local area during the course.\r\n\r\nPlease contact us direct on 01562 542574 option 3, email jhomer@saet.co.uk or check out our website on www.stourportscitt.com. We will be pleased to answer any questions you may have regarding the course, the support or the final qualification.\r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "As we are very much ‘school centred’ you will spend a large proportion of the year in schools, so you will be immersed in school life from day one. We work with many schools across Worcestershire, Herefordshire and Shropshire.  These are from a range of settings; from urban schools to more rural locations.  We place trainees sensitively and would not normally expect you to have to travel for more than 30 minutes from home to get to your placement school.  \r\n\r\nYou will teach students within secondary age ranges, pertinent to your subject area. The school placements are with two contrasting schools to maximise your teaching experience. Placement one is at the very beginning of the Autumn term, giving you an invaluable insight in to the start of the school year and the expectations surrounding this important time for children.  \r\n\r\nYour development will be supported by five intensive training blocks, delivered by experts and practicing teachers to ensure that you have excellent, current pedagogy.  You will be given a mentor in each of your placements whom you will meet each week to discuss your progress.  You will also be thoroughly immersed in the pastoral role of a teacher; you will be assigned to support a tutor group to gain an excellent understanding of the critical work a tutor does to monitor academic progress as well as caring for students’ welfare.\r\n\r\nYou will also gain first-hand experience of how your placement school delivers spiritual, moral, social and cultural education, as well as sex and relationships education. Your placement school will also offer you experience in the extra-curricular provision offered to students. Past trainees have supported school trips, sporting events, drama productions and many other enrichment activities.\r\n",
+                "interview_process": "If your application is successful you will be called to interview very quickly.  Your interview will normally take place in a school setting appropriate to the age range you wish to teach. You will attend only one interview session, and this will take either a full morning or afternoon. You will be formally interviewed by one of the SCITT team and a subject specialist. In your formal interview we will discuss your application in further detail and your motivation for teaching.  \r\n\r\nWe are looking for applicants with a clear passion for both teaching and their subject; strong candidates will also show that they are at ease with pupils.  As part of this process you will also teach a short episode (30 to 40 minutes) in your subject area to a class.  We are not looking for the 'finished article' at this stage but you should aim to show your enthusiasm for your subject and positive relationships with students. Once the lesson has finished you will have the opportunity to write a reflection on your lesson. We will also ask you to sit a recent external examination paper in your subject.\r\n\r\nOnce the interview process is complete we meet as a panel to discuss all elements of the process. We would then make a decision and inform candidates within three working days of interview.\r\n",
+                "other_requirements": "We will conduct a Data Barring Service (DBS) check for each applicant, at no cost.",
+                "personal_qualities": "We are looking for professional individuals with a genuine passion for teaching children and becoming part of the next generation of teachers. Ideally you will have school experience,  if you need assistance with organising this, we are more than happy to help. ",
+                "required_qualifications": "The minimum academic requirements for this Chemistry course are:\r\n\r\n* English GCSE (or equivalent) at grade 4 or above\r\n* Mathematics GCSE (or equivalent) at grade 4 or above\r\n* Post 16 qualifications with a strong interest in Chemistry\r\n* Relevant degree at classification 2:2 or above\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966089",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X322",
+                "name": "Physics",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T14:08:11.484Z",
+                "uuid": "d144d9f1-b70c-4564-ad5b-2ed7ba0e1c75",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:08:11Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS) \u0026 a PGCE. \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12957754",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "N503",
+                "name": "Business studies",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "14_to_19",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:04:43.771Z",
+                "uuid": "a75095a1-b23c-493e-b998-d1724415191d",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:04:43Z",
+                "about_accrediting_body": null,
+                "provider_code": "R23",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "We are looking for Business graduates who are keen to teach their subject up to A level in a school and sixth form setting. Our SCITT curriculum begins early in September and involves teaching practice in school each week from Monday to Thursday, with Friday as a training day. Training will be hosted and delivered by experienced ITT specialists, subject experts and classroom practitioners who currently teach in our partner schools.  \r\n\r\nIn addition, there will be subject pedagogy days during the year where trainees will focus on teaching your subject and age phase specifically. These will be delivered by a experienced curriculum leaders in the 14-19 age phase. The days incorporate learning walks and lesson experience alongside input from the Lead Subject Mentors and directed tasks for you to consolidate your learning.\r\n\r\nYou will audit your subject knowledge for the topics you will need to teach. Lead Subject Mentors and tutors will guide you towards high quality resources for this and you will be encouraged to join a professional subject association. The learning platform enables you to share resources with each other and school mentors. \r\n\r\nLeeds Beckett University provide the PGCE for our SCITT and this is all online. The modules perfectly compliment the training we deliver and you will gain 60 Master's level credits (https://courses.leedsbeckett.ac.uk/PGCE_distancelearning/)\r\n\r\nOur programme documentation has been described by Ofsted: \"Documentation is very well designed and contributes significantly to trainees' success on the course\" \r\n\r\nAssessment of trainees for QTS is based on all of the following:\r\n- Regular observations of practice with development discussion and action step setting\r\n- Progress towards meeting the expectations of the curriculum\r\n- A final assessment against the requirements of the Teachers Standards at the end of the programme.\r\n\r\nWe have been highly praised by Ofsted for our approach to trainee workload, keeping our requirements concise yet effective.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "PGCE and QTS £9250\r\nQTS only £7000",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will normally complete placements in two partner schools. Placement training will begin in September, and you will start with focused lesson observations before you join your subject department and begin to plan and teach parts of lessons. After a few weeks you will be planning and delivering whole lessons, building up to approximately 7 hours per week by Christmas. You will gradually increase your teaching timetable and for the last few weeks will be full time in school, teaching up to 12 hours per week at that point in May and June.\r\n\r\nPlacements are selected for you on the basis of high quality mentoring and strong subject departments. You will teach the 14-19 age range in your subject in two different settings. There may also be opportunities to spend some time in other partner schools and settings as training needs arise. You will gain experience of pastoral care and careers guidance appropriate for 14-19 students alongside subject teaching. There will normally be brief opportunities to experience KS3 as well as 14-19.\r\n",
+                "interview_process": "We currently have a blended approach to conducting interviews. Typically, the interview will take place via remote access with assessment tasks completed at a training centre. You will be asked to prepare a lesson plan beforehand and we will ask you about your ideas in the interview. There will also be a subject task and a written task which are normally completed at a named venue.\r\n\r\nWe are looking for the potential to be an excellent trainee, someone who is ready to start training in a school setting from early September. We are also looking for potential employees in our schools.\r\n\r\nThe admissions team are Safer Recruitment trained and we are committed to safeguarding children",
+                "other_requirements": "Applicants who are successful at interview will need the following before they can start the programme:\r\n-\tDBS and barred list check\r\n-\tMedical check\r\n\r\nIt is important that you have a good awareness of what the role of a teacher involves so that you can be sure it is the right career choice for you. We offer school experience for people at all stages of this career decision, including after interview, in order to support you with this.\r\n\r\nWe welcome applicants of all ages, from university graduation to mature career changers.",
+                "personal_qualities": "We are looking for people who are keen to learn in a school setting and this model suits trainees who are able to learn as they go along and incorporate their own experience into this learning process. Successful applicants will have an understanding of the professionalism and resilience needed to become a teacher and to be reflective learners. A real commitment to a career in teaching, a love of their subject and positive attitude towards young people are essential qualities.\r\n",
+                "required_qualifications": "UK Bachelors degree or equivalent in Business and/or Economics\r\nGCSE Maths and English at grade C/4 or above\r\n\r\nIdeally your degree would be a class 2:2 or above \r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969938",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "U792",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-19T16:01:24.179Z",
+                "uuid": "514e9075-b4df-4c77-b36c-2f52685099bd",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-19T16:01:24Z",
+                "about_accrediting_body": null,
+                "provider_code": "1BO",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The School Direct course is a flexible approach to teacher training. The majority of your time will be spent in school, training in the classroom and being supported by experienced teachers and mentors. You will also spend time studying at the University.  Successful completion of the course leads to Qualified Teacher Status (QTS)* and a postgraduate qualification.\r\n  *The title of this award is subject to change due to an ongoing government consultation. For the latest information, please visit www.gov.uk/dfe\r\n\r\nYou will be a registered student with NTU and your qualification will be an NTU award. This means that NTU has responsibility for the quality of your training and you will benefit from the combined expertise of the University and lead placement school. \r\n\r\nThis secondary PGCE teaching degree is based around five modules which are core to all trainees.  The curriculum has been organised so that you will gain substantial support for the study of all modules at the start of the course through front-loaded University-based sessions, before your placements begin. The Learning and Teaching in the Subject module will largely be completed in this period, meaning that you will have clarity about academic expectations and your tutors will have an insight into required support. The other modules will be completed at different stages during the year to ensure both reasonable workload and to allow for the progressive impact of the Learning and Teaching in the Subject and Learning and Teaching in the Wider Context modules (underpinned by the Skills of Enquiry module which is assessed across these two modules) on the Secondary Education Independent Study and Secondary Professional Practice modules which run right until the end of the courses.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "As a School Direct trainee, you will be entitled to the same financial support as trainees on other postgraduate teacher training courses.\r\n\r\nIf you are a UK or EU trainee, you should be eligible for a student loan, maintenance loan or maintenance grant to cover the cost of your study, and will only start paying the loans back when you start earning over £21,000 per annum.\r\n\r\nYou may be eligible to receive a training bursary, dependent on the subject you train for and a degree classification.",
+                "how_school_placements_work": "Successful candidates will spend the majority of their time at Brunts Academy where they will be assigned a subject specific mentor and undertake the teaching, in their chosen subject area, of students from age 11-18 as appropriate.  Some days will be spent at University - see course content.\r\n\r\nCandidates will spend a minimum of 2 days at a primary school in the first term.  During the primary placement candidates will:\r\n* begin to appreciate the similarities and distinctiveness of learning and teaching in KS2 and the primary phase more generally;\r\n*gain awareness of pupils’ capabilities and prior knowledge in the key stage immediately prior to that for which they are training; \r\n*contribute to their growing knowledge and understanding of standards, progression and transition in their subject/related disciplines. \r\n\r\nCandidates will also undertake a second placement at the beginning of the spring term at another school/academy.  This placement is arranged by the Director of ITT.  This provides candidates with an opportunity to broaden their experience by teaching in a school in a different setting/location/context.",
+                "interview_process": "Following the submission of a successful application form candidates will be invited for an initial interview at NTU prior to being interviewed at the Lead School, Brunts Academy. ",
+                "other_requirements": "Candidates will be subject to an interview with both the training school and NTU as part of the selection process.  Candidates will undertake:\r\n*Disclosure and Barring Service check; \r\n*Prohibition Order check. \r\n\r\nTwo references are required, one academic and one vocational.  Evidence of mainstream UK school experience (paid or voluntary) in their application is desirable, although not essential. ",
+                "personal_qualities": "Every day you'll get the chance to inspire young people and use your skills to give something back – making sure every pupil gets the same access to a quality education and the opportunity to succeed. \r\n\r\nYou will need:\r\n*good communication skills\r\n*good organisational skills\r\n*the ability to develop relationships with others\r\n*to be passionate about your subject \r\n*to be dedicated to teaching\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963535",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Q208",
+                "name": "Business studies",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "14_to_19",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:03:47.979Z",
+                "uuid": "30ebc997-1b46-41b3-8e92-3a4ca0b4ec61",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:03:47Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above do NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2020)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964543",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2JSC",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-04T15:20:39.920Z",
+                "uuid": "12874da0-34a3-466d-a92c-93b752c471a5",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-07-19T19:09:28Z",
+                "about_accrediting_body": null,
+                "provider_code": "T87",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "The Tudor Grange SCITT geography programme blends theory and practice, helping you to confidently develop your understanding and skills. All aspects of pedagogy will be covered, and you will have opportunities to watch outstanding practitioners demonstrating their skills in the classroom. \r\n\r\nEducational theories are taught and practical application in the classroom is explored. The emphasis is on evaluation and reflection throughout to help you consider the relevance of these concepts, enabling you to discover more about the kind of teacher you want to be. \r\n\r\nTeaching geography allows us to educate children and enrich their lives in order to prepare themselves for future success. This focus on cultural capital is something that separates geography from other subjects by making every topic applicable to real-life and allowing students to acknowledge the world around them. The subject studies sessions include a range of individual and group activities, and often follow on from the professional studies sessions. Although there is scope to become more bespoke by concentrating on areas of concern for individual trainees, for example: focusing on “teaching tricky topics” that are identified as part of the subject knowledge audit, which is completed before the course begins. Your geography specific Subject Leader will work with you directly to develop your teaching style and be another avenue of support during your teacher training year.\r\n\r\nThe course content is wide ranging and you will learn about how to plan lessons specific to your subject to help all the young people in your classrooms make progress; how to enable positive behaviour in classrooms; and how to work with parents. \r\n\r\nFeedback will be both formal and informal and always based around helping you to reflect on your own strengths and next steps. Trainees have regular collaborative progress checks and a scheduled weekly mentor meeting whilst on placement, so you can be sure that you will know how you’re doing at all times. The final recommendation for QTS is based around a combination of reports and your classroom practice.\r\n\r\nAs an accredited provider, we work in partnership with Birmingham City University for the PGCE element of the programme and all of the learning here is aimed at developing your pedagogical understanding. It is a complimentary programme, which enhances your classroom practice.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "We strongly believe that the best place for a trainee teacher is in schools, developing your skill set through a cycle of observation, reflection, practise and feedback. Therefore the course is split into 25% Professional Studies sessions and 75% in school placements. Trainees are placed in at least two schools, which are carefully selected in order to provide a range of different experiences, giving you the best chances of developing your practice. For example, you might be placed in a rural school for one of your placements and an urban school for another. This increases your chances of employment and ensures you are a well-rounded practitioner.  \r\n\r\nWhilst on placement, you will be in the role of a teacher, and will therefore be able to take opportunities to learn about how the school day works – thus, you should plan to work full school days, including attending meetings before and after school, as well as preparing for parents’ evenings and after school activities, like awards ceremonies. We are also passionate about protecting our teachers and ensuring work/life balance is achieved. There are specific professional studies sessions related to this. Furthermore, although your timetable will increase so that by the end of the year, your teaching commitment is similar to that of a Newly Qualified Teacher, we gradually build up your timetable, at a rate that is right for you. It is our deep belief that mastering the craft of teaching is more important than arbitrarily increasing the number of lessons that you plan and teach.\r\n\r\nTrainees are assigned a personal subject specific mentor whilst on placement, who will work with you to set achievable targets, to help you to become the very best teacher you can be. You will constantly be working towards the Teachers’ Standards and will be supported and guided by Tudor Grange SCITT throughout the program. \r\n\r\nThe programme is an 11-16 offer, with post 16 enhancement. In reality, this means that when you are confidently mastering KS3 and 4 teaching, we will seek to find opportunities for you at post-16. We find that this helps with employability.",
+                "interview_process": "We sift all UCAS applications following a consistent criteria set out in-house, looking at candidate personal qualities, academic achievements and previous relevant experience in schools/working with young people, or vulnerable groups.\r\n\r\nFollowing a successful sift, candidates will be invited to an interview day, which dependant on applicant numbers, may be ran over one or two days. \r\nThe interview process consists of four parts;\r\nA subject knowledge audit – This is not a pass/fail test of your subject knowledge rather an audit of your strengths and areas for improvement. This allows us to understand your baseline and develop strategies for how we can work with you to fill any subject knowledge gaps prior to the course beginning, and to continue to provide bespoke support.\r\nUnseen task - Information on the task is given on the interview day.\r\nPanel interview – Your education philosophy and values, resilience, and knowledge of National Curriculum will all be explored during the panel interview.\r\n20 minute session delivery to a KS3 class – You will be provided with a topic for the session (set by the class teacher) a week in advance to allow you to prepare. During the session we will be looking at how candidates have demonstrated learner progress, their relationships with young people, and their ability to plan.\r\n\r\nWe aim to share outcomes of the interview process on the day, including detailed and meaningful feedback where applicable. All offers made by us are conditional, and will be explained when the offer is made\r\n",
+                "other_requirements": "All successful candidates will be subject to;\r\nAn enhanced DBS check, candidates must fund this themselves although Tudor Grange SCITT will make the application.\r\nAn occupational health check.\r\nConfirmation of right to work in the UK.",
+                "personal_qualities": "The Tudor Learning Habits;\r\n- Positive self regulation\r\n- Process not product\r\n- Open to failure and feedback\r\n- Courageous and gritty\r\n\r\nThe Tudor Character Habits;\r\n- Honesty and truthfulness\r\n- Kindness and empathy\r\n- Responsibility and integrity \r\n- Generosity and gratitude ",
+                "required_qualifications": "All candidates must hold;\r\n\r\nA Bachelor’s degree (or equivalent).\r\nEnglish GCSE - Minimum Grades C/4 (or equivalent).\r\nMaths GCSE - Minimum Grade C/4  (or equivalent).\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963331",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "3XXU",
+                "name": "Religious Education",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17446,
+                    "address4": "Hertfordshire",
+                    "provider_name": "University of Hertfordshire",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "School of Education",
+                    "year_code": "2019",
+                    "provider_code": "H36",
+                    "provider_type": "university",
+                    "postcode": "AL10 9AB",
+                    "website": "https://go.herts.ac.uk/teachertraining",
+                    "address1": "University of Hertfordshire",
+                    "address2": null,
+                    "address3": "Hatfield",
+                    "email": "admcom@herts.ac.uk",
+                    "telephone": "01707 284800",
+                    "region_code": "eastern",
+                    "created_at": "2021-07-06T10:50:56.422Z",
+                    "updated_at": "2021-09-29T07:53:45.803Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-30T14:17:19.435Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Hertfordshire is a leading regional provider of [Initial Teacher Education](https://www.herts.ac.uk/study/schools-of-study/education/initial-teacher-education).  Consistently high achieving in its Ofsted inspections and in the Guardian and Times League tables, it is rightly proud of its excellent reputation with local and regional schools who often employ our student teachers.\r\n\r\nThe School of Education has an excellent record of employment for trainees on their Initial Teacher Education programmes, and those who actively seek a teaching post at the end of their programme are successful in joining the profession.\r\n\r\nAfter completing Initial Teacher Education there are opportunities to continue your studies with the University through the [MA Education Framework](https://www.herts.ac.uk/study/schools-of-study/education/postgraduate-courses-education/ma-education-framework).",
+                    "train_with_disability": "The University of Hertfordshire is committed to promoting equality of opportunity to ensure that it meets the needs of disabled people and has policies that are intended to support all students both in their studies and in developing their professional practice.\r\n\r\nIf you have a disability or other need we encourage you to disclose this and any other relevant information that could support your studies.\r\nThe School of Education at the University of Hertfordshire provides both academic and practice placement support for teachers in training with disabilities and other needs.\r\n\r\nOne key aspect of the PGCE course is to raise awareness of mental health and well-being and to support the removal of unnecessary workload. \r\n[University of Hertfordshire disability support](https://www.herts.ac.uk/life/student-support/disability-services)\r\n[University of Hertfordshire statement on disability disclosure by students](https://www.herts.ac.uk/life/student-support/disability-services/statement-on-disability-disclosure-by-students)\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.7518204,
+                    "longitude": -0.2387957,
+                    "ukprn": "10007147",
+                    "urn": "133783",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "H36",
+                "changed_at": "2021-09-03T08:32:53.636Z",
+                "uuid": "10510422-f13b-49f0-aff6-cdc0395d883e",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-03T08:32:53Z",
+                "about_accrediting_body": null,
+                "provider_code": "1HS",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The PGCE Secondary course is a full time, one year Initial Teacher Education qualification introducing you to the requirements for teaching to the 11 – 16 age range. Where appropriate, opportunities to experience post 16 provision will be available. It has been designed to enable you to demonstrate evidence of having met the Teachers’ Standards that lead to Qualified Teacher Status. Whilst undertaking the University-led PGCE route into teaching you will work towards securing 60 Master’s level credits. This is an integral part of the programme. We strongly believe that innovative and effective teaching and learning is made possible through a teacher’s full engagement with research informed practice and underpinning theories of learning.\r\nThis is fostered in two modules and developed through School Based Training. You will be well supported in becoming a critically reflective teacher capable of inspiring pupils to learn, achieve and flourish. You will be supported and taught by specialist tutors with excellent experience, knowledge and research informed expertise. Partnership schools provide opportunities for you to learn about pedagogical approaches relevant to your subject specialism and the professional responsibilities of all teachers.\r\nYou will have two School Based Training placements, where, with the support of a teacher mentor and a university subject tutor, you will develop your skills to become an excellent classroom teacher. Training to teach is exciting, rewarding and demanding. By the end of the course you will be well prepared for employment as a Newly Qualified Teacher (NQT).",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": 14505,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "Schools in the University of Hertfordshire schools\u0026#39; partnership have a proven track record of strong engagement with Initial Teacher Education. Schools are evaluated and monitored in relation to the quality and effectiveness of school based training provision. School’s commit to enact the terms of the University of Hertfordshire Partnership for Initial Teacher Education.\r\n\r\nDuring the course you will undertake School Based Training in two contrasting secondary schools:\r\n* The first school placement will take place between September and December\r\n* The second school placement will take place between January and June\r\nYour School Based Training will total a minimum of 120 days. In addition to the two main placements you will:\r\n* visit a primary school to consider Year 6 transition\r\n* visit a special school to explore effective differentiation and inclusion for pupils with complex learning needs\r\n* visit a school demonstrating excellent provision for pupils with English as an additional language\r\n\r\nThe University of Hertfordshire partners with a wide and diverse range of schools with whom we have a strong working partnership based upon the vision to work together to develop teachers with the confidence to:\r\n\r\n* make professional judgements to enable the development and learning of all (Agency)\r\n* articulate how research has informed their practice and contribute to new thinking and new ways of working (Professional Voice)\r\n* respond innovatively to a changing educational landscape (Resilience)\r\n* strive to ensure a child\u0026#39;s learning and life chances are not limited by social or economic factors (Social Justice)\r\n\r\nDuring School Based Training you will be teaching students in the 11-16 age range. Where appropriate, you will have the opportunity to experience post 16 provision.",
+                "interview_process": null,
+                "other_requirements": "You are required to pass the [Professional Skills tests (http://sta.education.gov.uk/) in literacy and numeracy before starting the course.\r\nYou are required to complete a Disclosure and Barring Service (DBS) check and a Declaration of Disqualification by Association form. You will also need to respond to targeted and relevant health questions. Guidance will be provided after you have been offered a place.\r\nWe recommend that you undertake observation time in a state secondary school prior to interview but this is not essential. [Activities to support observation in school - either before or after interview - that you may\r\nfind useful](https://www.herts.ac.uk/__data/assets/pdf_file/0006/164436/Secondary-School-experience-\r\ntasks.pdf)",
+                "personal_qualities": "In your application and during the interview process, you will need to demonstrate an ability to train to teach through the following:\r\n\r\n* Genuine care for children’s learning, progress and achievement\r\n* A commitment and passion for your subject specialism\r\n* Your motivation and interest in training to teach\r\n* Excellent interpersonal and communication skills\r\n* A commitment to working with children and adolescents and improving their educational outcomes\r\n* The ability to be organised, adaptable and resilient\r\n* A willingness to work and learn from others and to be responsive to feedback",
+                "required_qualifications": "Qualifications needed You will need to have these UH entry requirements\r\nHonours degree (2.2 or higher) from a UK university. Usually the degree should have a minimum 50% content of the subject applied for.\r\nEnglish language and mathematics GCSE grade 4 or above and Science grade 4 or above for primary teacher training [or a qualification recognised as equivalent by the University]( https://www.herts.ac.uk/study/entry-\r\nrequirements/undergraduate-degrees/gcse-equivalent-entry-requirements ).\r\nEquivalent overseas qualifications are accepted when recognised as comparable by NARIC. We may require demonstration of English language proficiency through IELTS (Academic version) with an overall score of 6.5\r\n(minimum of 6.0 in each band).\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966654",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "F3X1",
+                "name": "Physics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-01T10:33:44.886Z",
+                "uuid": "3d8b9b49-2efc-4527-b8f4-7dd67eb568b6",
+                "program_type": "higher_education_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "We offer our own Equivalency tests. We are unable to accept third party equivalency tests. Details will be provided for any successful offer of a place.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T10:33:44Z",
+                "about_accrediting_body": null,
+                "provider_code": "S27",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "university",
+                "about_course": "The Southampton University Led Secondary M level PGCE course provides an excellent route into teaching where you will equip yourself with the very latest research and practice. The course has consistently been rated highly by former trainees and has been successful in a series of recent Ofsted inspections. Our PGCE Secondary programme is designed and taught jointly by the Southampton Education School in partnership with over 125 schools across the region in eight different subject areas, and has a very good track record of moving successful trainees into employment, locally and beyond. You’ll engage with research-led approaches to enhance the quality of teaching you can offer your students and begin your career with confidence. Two thirds of the PGCE is spent in two school placements, starting in October, under the guidance of curriculum mentors who are all experienced classroom teachers. One third is spent in university, under the guidance of curriculum tutors, who all have extensive school teaching experience. \r\n\r\nThis innovative programme combines all the best elements of practical experience in school but also draws on cutting-edge developments in cognitive psychology and the extensive research expertise available here at one of the top Schools of Education in the UK, to deliver an exceptional training experience in science.\r\nThe programme is led by a team of dedicated, passionate and knowledgeable tutors, all with extensive experience of classroom teaching. Beyond this core team, some of the very best science teachers and senior leaders currently working in our area contribute to the high quality of the training provided. There will also be a structured opportunity to plan and conduct fieldwork sessions, and, of course, the opportunity to work with an exceptional team of school-based mentors.\r\nThe PGCE Secondary Science: Physics course\r\nhttps://www.southampton.ac.uk/courses/sciences-pgce\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 21000,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You’ll be placed in schools for most of your course. This university is based in Southampton, and your school placements will be within commuting distance. Our partnership covers an extensive area, which enables us to offer a wide range of school experiences, from large urban secondary schools to smaller rural schools. You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.\r\n\r\nEach trainee undertakes two block placements in schools within our Partnership. We aim to provide schools that offer contrasting placement experiences in order to develop a breadth and range of skills. During the placement blocks, one day per week is dedicated to training with the university in either curriculum or professional development. A regular programme of school based professional training is also delivered whilst trainees are on placement. Whilst on placement, each trainee is allocated a mentor from their subject area and a professional mentor to oversee the professional training. Trainees will also receive visits from their university tutor to support them in their teaching and professional development.\r\n",
+                "interview_process": "At interview, candidates will meet the tutor team and learn about key elements of the programme, including how trainees are supported and developed, how placements work and how trainees are assessed. Each candidate will give a short presentation related to their curriculum subject and will complete a written task followed by an individual interview with subject tutors.",
+                "other_requirements": "You will be required to obtain:\r\n* complete a form describing your state of health which will be checked against the DfE Fitness to Teach regulations \r\n* to provide an Enhanced Disclosure from the Disclosure and Barring Service (DBS) to confirm that there are no criminal offences on your record which should bar you from teaching. Visit www.disclosure.gov.uk for more information. \r\n\r\nThese must be completed before commencement of the programme to which you have applied.\r\n",
+                "personal_qualities": "Please refer to our website for further: https://www.southampton.ac.uk/courses/sciences-pgce#entry",
+                "required_qualifications": "Prospective candidates will have good knowledge of the subject, from a first degree award. The normal expectation is that students will have at least 50% of their first degree in their chosen subject. Minimum degree required: 2:2.\r\nCurrently, you must have GCSE passes at grade C/grade 4 or above in English Language and Mathematics. This is a government requirement, and ‘equivalent qualifications' are as designated by the PGCE admissions team (IELTS qualifications are not considered equivalent). If your qualifications are not considered to be appropriate, we can offer GCSE equivalent tests in English and Maths.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969939",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "S575",
+                "name": "Modern Languages (Spanish)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-19T16:03:53.588Z",
+                "uuid": "b37a048c-8e09-44e4-9c17-003d4c9e89f0",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-19T16:03:53Z",
+                "about_accrediting_body": null,
+                "provider_code": "1BO",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The School Direct course is a flexible approach to teacher training. The majority of your time will be spent in school, training in the classroom and being supported by experienced teachers and mentors. You will also spend time studying at the University.  Successful completion of the course leads to Qualified Teacher Status (QTS)* and a postgraduate qualification.\r\n  *The title of this award is subject to change due to an ongoing government consultation. For the latest information, please visit www.gov.uk/dfe\r\n\r\nYou will be a registered student with NTU and your qualification will be an NTU award. This means that NTU has responsibility for the quality of your training and you will benefit from the combined expertise of the University and lead placement school. \r\n\r\nThis secondary PGCE teaching degree is based around five modules which are core to all trainees.  The curriculum has been organised so that you will gain substantial support for the study of all modules at the start of the course through front-loaded University-based sessions, before your placements begin. The Learning and Teaching in the Subject module will largely be completed in this period, meaning that you will have clarity about academic expectations and your tutors will have an insight into required support. The other modules will be completed at different stages during the year to ensure both reasonable workload and to allow for the progressive impact of the Learning and Teaching in the Subject and Learning and Teaching in the Wider Context modules (underpinned by the Skills of Enquiry module which is assessed across these two modules) on the Secondary Education Independent Study and Secondary Professional Practice modules which run right until the end of the courses.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "As a School Direct trainee, you will be entitled to the same financial support as trainees on other postgraduate teacher training courses.\r\n\r\nIf you are a UK or EU trainee, you should be eligible for a student loan, maintenance loan or maintenance grant to cover the cost of your study, and will only start paying the loans back when you start earning over £21,000 per annum.\r\n\r\nYou may be eligible to receive a training bursary, dependent on the subject you train for and a degree classification.",
+                "how_school_placements_work": "Successful candidates will spend the majority of their time at Brunts Academy where they will be assigned a subject specific mentor and undertake the teaching, in their chosen subject area, of students from age 11-18 as appropriate.  Some days will be spent at University - see course content.\r\n\r\nCandidates will spend a minimum of 2 days at a primary school in the first term.  During the primary placement candidates will:\r\n* begin to appreciate the similarities and distinctiveness of learning and teaching in KS2 and the primary phase more generally;\r\n*gain awareness of pupils’ capabilities and prior knowledge in the key stage immediately prior to that for which they are training; \r\n*contribute to their growing knowledge and understanding of standards, progression and transition in their subject/related disciplines. \r\n\r\nCandidates will also undertake a second placement at the beginning of the spring term at another school/academy.  This placement is arranged by the Director of ITT.  This provides candidates with an opportunity to broaden their experience by teaching in a school in a different setting/location/context.",
+                "interview_process": "Following the submission of a successful application form candidates will be invited for an initial interview at NTU prior to being interviewed at the Lead School, Brunts Academy. ",
+                "other_requirements": "Candidates will be subject to an interview with both the training school and NTU as part of the selection process.  Candidates will undertake:\r\n*Disclosure and Barring Service check; \r\n*Prohibition Order check. \r\n\r\nTwo references are required, one academic and one vocational.  Evidence of mainstream UK school experience (paid or voluntary) in their application is desirable, although not essential. ",
+                "personal_qualities": "Every day you'll get the chance to inspire young people and use your skills to give something back – making sure every pupil gets the same access to a quality education and the opportunity to succeed. \r\n\r\nYou will need:\r\n*good communication skills\r\n*good organisational skills\r\n*the ability to develop relationships with others\r\n*to be passionate about your subject \r\n*to be dedicated to teaching\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969235",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "26HY",
+                "name": "Modern Languages (French)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17408,
+                    "address4": "Newcastle upon Tyne",
+                    "provider_name": "University of Newcastle Upon Tyne",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Dawn Bell",
+                    "year_code": "2019",
+                    "provider_code": "N21",
+                    "provider_type": "university",
+                    "postcode": "NE1 7RU",
+                    "website": "https://www.ncl.ac.uk/ecls/study/postgrad/teacher/",
+                    "address1": "Admissions",
+                    "address2": "Level 3",
+                    "address3": "King's Gate",
+                    "email": "pgce-education@ncl.ac.uk",
+                    "telephone": "0191 208 6017",
+                    "region_code": "north_east",
+                    "created_at": "2021-07-06T10:50:15.994Z",
+                    "updated_at": "2021-08-03T08:26:11.916Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T11:04:10.485Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The PGCE Team pride ourselves on providing our students with an excellent standard of education, training and practical teaching experience and are delighted that Newcastle university achieved A Gold Award, in the Teaching Excellence Framework (TEF), evidencing that Newcastle University consistently delivers outstanding teaching, learning and outcomes, for our students. Similarly, we were given a ‘judgement of Confidence by the The Quality Assurance Agency for Higher Education (QAA). We also pride ourselves personal support we give to our students and you will have full access to the extensive services of the ‘Student Support Service’.\r\n\r\nNewcastle University has a reputation for world-class research (16th in the UK) and the PGCE team work closely with our colleagues to ensure our subject and professional programmes are research led and well informed.\r\n\r\nOur PGCE programme, rated Good by Ofsted in 2017, provides rigorous academic and school training. University and school-based components are integrated so that learning is relevant to your practice and development as a confident and capable teacher.  To support you, you will have access to a wide range of study facilities, including all relevant course materials , a well-stocked Education Resource Centre and the comprehensive facilities of the university. You will also have full access to the extensive services of the ‘Student Support Service’ \r\n",
+                    "train_with_disability": "The PGCE Team welcome applications from students with disabilities.  Advice, information and guidance is available from the university Student Support Services, who liaise with us over students’ support requirements, and may liaise with external agencies where appropriate. Disabled Students' Allowances (DSA) is a non-means tested grant available to U.K. disabled students who are applying for, or are attending, a course of Higher Education. There are specific eligibility conditions related to residence in the UK, which have to be met to qualify for this funding.  DSA allowance covers some additional study-related costs that students will incur because of a disability, ongoing medical condition or mental health condition. Extra costs may include specialist equipment, a non-medical helper or travel costs. If you are invited to an interview for PGCE is often a good opportunity to arrange to meet with one of the Disability Advisers, to talk about your support requirements. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 54.9789749,
+                    "longitude": -1.6135961,
+                    "ukprn": "10007799",
+                    "urn": "133852",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N21",
+                "changed_at": "2021-10-05T14:10:37.130Z",
+                "uuid": "b40b7e0e-3b71-48bb-bb30-f65b3af7eb01",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:10:37Z",
+                "about_accrediting_body": "",
+                "provider_code": "14U",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This is a one-year full time Initial Teacher Education course leading to the academic award of Postgraduate Certificate of Education (PGCE) and Qualified Teacher Status (QTS). At university, trainees undertake three Masters level modules towards their PGCE: Subject Pedagogy in Practice, Developing Critical Perspectives and Curriculum Development Through Enquiry in Practice. Successful trainees are awarded 60 Masters level credits which they can choose to carry forward to the full Master’s course at a later stage. Our School Direct programme provides a wealth of opportunity for trainees to demonstrate evidence of the Teachers’ Standards required for QTS.\r\n\r\nOur School Direct programme is designed to train teachers in the classroom. Our vision to develop expert teachers and leaders of the future starts with all trainees becoming part of the staff team from the beginning of the academic year. Trainee teachers will learn from experienced colleagues and work closely with the staff in the MFL department. You will be given experience of KS3, KS4 and KS5. The vast majority of the year is spent in the host school that you apply to and you will be allocated a contrasting placement which will include six weeks of teaching elsewhere. Contrasting placements are key to the development of all trainee teachers in order to develop a broader understanding of different educational settings.",
+                "course_length": "OneYear",
+                "fee_details": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/f8x1/#fees-and-funding)",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/3072f/)",
+                "how_school_placements_work": "You will spend the majority of the year and undertake most of your teaching commitments at your host school. A contrasting placement will be arranged for you with consideration given to your location, transport, childcare, etc. By placing you in a contrasting school you will gain invaluable experience which help you to develop a range of teaching skills. We only use schools that we know will give you the help and support you need during your placement, including a professional tutor and subject mentor. Weekly mentor meetings and at least one formal lesson observation will occur each week during your teaching practices.",
+                "interview_process": "Newcastle University’s Admissions Team will conduct an initial eligibility check, to determine whether you meet the eligibility criteria. The school you have applied to will then consider your application and agree whether to invite you to interview. If you are selected for interview, you will be sent information about the interview process, together with guidance on how to prepare. The interview process will take approximately half a day at whichever school you have applied to within the alliance. It is important that you spend some time in the school that you are applying to and you will be given an opportunity to talk to some key staff. You will be required to teach an observed lesson; you will be told in advance about the content and the age group you will be teaching as well as any other relevant information to help you prepare. An interview will be the last part of the day where the professional tutor from the school and an Emmanuel Teacher Training Partnership representative will be present.\r\n\r\n\r\n",
+                "other_requirements": "You will be required to undergo an enhanced DBS and fitness to teach check to verify your suitability for working with young people. \r\n\r\nWe recommend you spend at least a few recent working days in a UK secondary classroom before applying. This will inform your application and any later performance in the selection process.\r\n\r\nSubject Knowledge Enhancement (SKE) can be organised where necessary and funding arranged to cover costs. You could get a tax-free SKE bursary of £175 per week.",
+                "personal_qualities": "We are looking for trainee teachers who possess a range of personal qualities including:\r\n\r\n* The ability to communicate in English competently, confidently and clearly to a level that facilitates good quality oral and written communication with pupils, parents and colleagues.\r\n* Self-motivation\r\n* Confidence\r\n* Patience\r\n* Compassion\r\n* Enthusiasm\r\n* Resilience\r\n* Initiative\r\n* Team player\r\n* Good organisational skills\r\n* Effective time management\r\n* Passion\r\n* The desire and drive to transform children through education.\r\n",
+                "required_qualifications": "An honours degree (2:2 or above) or equivalent. At least 50% of your degree should be in the subject that you intend to teach. We may accept closely related degree subjects.\r\n\r\nGCSEs or O Levels (grades A–C/ 4-9) in English language and mathematics, or equivalent.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966073",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "P225",
+                "name": "Physics",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "qts",
+                "description": "QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T14:06:28.665Z",
+                "uuid": "89d6c9c3-a56e-41be-b959-db793e017a41",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:06:28Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS). \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12968327",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2HNB",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17626,
+                    "address4": "Leeds",
+                    "provider_name": "Leeds Trinity University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Leeds Trinity University",
+                    "year_code": "2019",
+                    "provider_code": "L24",
+                    "provider_type": "university",
+                    "postcode": "LS18 5HD",
+                    "website": "https://www.leedstrinity.ac.uk",
+                    "address1": "Leeds Trinity University",
+                    "address2": "Brownberrie Lane",
+                    "address3": "Horsforth",
+                    "email": "admissions@leedstrinity.ac.uk",
+                    "telephone": "0113 283 7123",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:52:55.297Z",
+                    "updated_at": "2021-09-22T14:14:08.925Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T13:50:19.392Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Leeds Trinity University has been synonymous with high quality teacher training since 1966, when we were founded as a Catholic teacher training college. \r\n\r\nOver the years, we’ve diversified and expanded to become renowned for teaching excellence and producing highly employable graduates across many subject areas, but an unwavering commitment to outstanding teacher training has remained at the heart of what we do. \r\n\r\nRecognising that people begin PGCE courses with different levels of experience and skills, we train you in three stages to build your confidence and capability with a mix of research-informed practice, school-based training and plenty of one-to-one support. \r\n\r\nWe work with over 600 schools – from small rural schools to large, inner-city high schools. We work with ‘Outstanding’ schools leading innovations in education, as well as schools that may have difficulties in reaching outcome targets at the end of key stages. \r\n\r\nWhen you train with Leeds Trinity, you’ll experience best practice in school improvement, whichever school you train in.\r\n\r\nYou’ll work with expert school mentors while on placement and receive help, advice and support from University-based link tutors. This combination means you’ll get specialist training on teaching the most difficult aspects of subject content, and understanding children and young people at various ages and stages of development.\r\n\r\nAfter you graduate, we offer excellent support for teachers in the early stages of their career, and have a very strong Early Career Teacher (ECT) programme, with CPD, an active online community, and an annual conference.",
+                    "train_with_disability": "We’re committed to ensuring that every student with potential, regardless of their background or circumstances, has the opportunity to benefit from higher education. \r\n\r\nIf you have a disability or additional needs, Leeds Trinity University will endeavour to put in place reasonable adjustments to accommodate any additional requirements throughout your teacher training year. We’re able to support with conditions such as: \r\n\r\n-\tDyslexia\r\n-\tSpecific learning difficulties\r\n-\tAsperger syndrome/autism\r\n-\tVisual/hearing impairments\r\n-\tPhysical and mobility restrictions\r\n-\tLong-term medical conditions\r\n-\tA mental health condition. \r\n\r\nIf you register with our Disability Service, a member of the team will develop a Learning Support Plan tailored to your specific needs. The support within this plan could include exam adjustments, extended library loans, specialist one-to-one study skills, dyslexia screening and assessments, learning materials provided in alternative formats and alternative assessments.\r\n\r\nWith your permission, they’ll share this plan with your University-based personal tutor so that they know how to best support you during your University-based training. They can also share this plan with the School Partnerships team, who are able to inform the host schools for your placements so they can discuss how to best support you during your school-based training. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.8481606,
+                    "longitude": -1.6459213,
+                    "ukprn": "10003863",
+                    "urn": "133838",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "L24",
+                "changed_at": "2021-09-27T08:53:43.224Z",
+                "uuid": "cfc124b8-6fed-4bbf-9807-c51d47fafc1a",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Please contact provider for details",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-27T08:53:43Z",
+                "about_accrediting_body": "We work in partnership with Leeds Trinity University who accredit and co-deliver our course. The course is a blend of university and school based training and leads to a PGCE qualification QTS with Master’s credits. Master’s modules can be completed in the ECT year and act as a bridge into further professional development. \r\nAssessment is both summative and formative during each progressive stage. At the end of each stage you will be required to submit a portfolio of evidence which is moderated and validated by school based and university based tutors for Quality Assurance. \r\n",
+                "provider_code": "1ZX",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "We are looking for the next generation of outstanding teachers who are passionate about children and education but also care about our schools, the communities they serve and the distinctive ethos each of those schools have. \r\nThey may have experience of working with young people - perhaps voluntary work such as youth groups, sports teams, church groups, community groups and ideally some of which is in school so they have a good awareness of how schools operate and teachers work. They will be able to talk about how they have engaged, communicated with and inspired young people they have worked with. They might have non education work and life experience that they can draw on to show they will be a great role model to young people and a natural communicator and professional team player in a school. They might have experience that shows they can work under pressure, learn quickly and take constructive feedback to improve one's own performance\r\n\r\nWe work in partnership with Leeds Trinity University who accredit and co-deliver our course. The course is a blend of university and school based delivery which leads to a PGCE qualification with QTS and Master's credits. \r\nAssessment is both summative and formative during each of three progressive stages, each taking place over a twelve week period. At the end of each stage you will be required to submit a portfolio of evidence which is moderated and validated by school based and university based tutors for Quality Assurance. \r\n\r\n\r\nTrainee teachers will have school experience days. They will also have web access to Leeds Trinity University's Learning Platform for the PGCE and Master's element of the course and most schools provide web access to their own Learning Platforms and Staff Intranets and email systems to enable working for home for planning lessons and assessing children's work remotely. \r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 12500,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "If there is any impact on school placements as a result of Covid 19, we will inform you before the course starts.\r\n\r\nWe work in partnership with Leeds Trinity University who accredit and co-deliver our course. The course is a blend of school based and university based study, which leads to a PGCE qualification with 60 Master's credits. The school based approach means you will train by working alongside and being mentored by people who can demonstrate and model exemplary practice on a daily basis with the same children you will be teaching. \r\n\r\nYou will spend most of the training year in one school (the 'home school'). These schools are central to the selection process and our school based interview system. You can express a preference for your home school but we cannot guarantee to meet everyone's preference. \r\nYou will complete the course in your home school having experienced a shorter placement in an alternative, contrasting setting part way through the year. Whilst we make every attempt to make sure the alternative placement school is in an accessible location it may involve a few weeks of travelling further to get that all important contrasting experience. \r\nThroughout the course there are regular study days delivered by a blend of Leeds Trinity University staff and school based staff which take place at a local hub school or Leeds Trinity site. At the hub school you will work with a small group of fellow trainees from other Diocese of Leeds BKCAT Alliance Schools so not only will you be able to enjoy lively interactive sessions where others contribute to your learning you will also have that all important peer group for support and a social life when it's time to relax.\r\n",
+                "interview_process": "Interviews are subject specific and will include a formal interview about subject knowledge and teaching methods, understanding of the role and responsibility of teachers as well as observed sessions where you will be working with children. \r\n\r\nAs we are a large alliance we often work as a team to interview groups of applicants in one school. This means applicants should read about the schools they wish to be placed in and should also consider contacting them to ask for a visit so they understand the ethos of the school, its catchment and practicalities like travelling distances and are then better able to express a preference for home school placement. We cannot guarantee to offer successful applicants their first choice of school but we try hard to match applicants to schools for mutual benefit.\r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "You should be a graduate with a relevant degree, preferably with a 1st or 2:1 though we are willing to consider applicants who have a lower class degree but can demonstrate passion and aptitude for teaching and working well with children. You should have a degree in which the majority of the content is related to the subject you will be teaching. \r\n\r\nYou will need, by the start of the course, GCSE  in Maths and English and for primary also GCSE grade  in Science. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963487",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2KDG",
+                "name": "History",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17149,
+                    "address4": "",
+                    "provider_name": "York St John University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Office",
+                    "year_code": "2019",
+                    "provider_code": "Y75",
+                    "provider_type": "university",
+                    "postcode": "YO31 7EX",
+                    "website": "http://www.yorksj.ac.uk",
+                    "address1": "Lord Mayor's Walk",
+                    "address2": "York",
+                    "address3": "",
+                    "email": "pgce@yorksj.ac.uk",
+                    "telephone": "01904 876598",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:47:24.309Z",
+                    "updated_at": "2021-09-28T10:57:41.367Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:20:12.968Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": null,
+                    "train_with_disability": null,
+                    "accrediting_provider_enrichments": null,
+                    "latitude": 53.9649139,
+                    "longitude": -1.0800959,
+                    "ukprn": "10007713",
+                    "urn": "133914",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "Y75",
+                "changed_at": "2021-09-01T12:21:14.067Z",
+                "uuid": "949fcf10-7e8d-4e89-9523-b722fd2a7592",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Third party",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-01T12:21:14Z",
+                "about_accrediting_body": null,
+                "provider_code": "1DH",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Hope Sentamu Learning Trust and York St John University work in partnership to deliver high quality teacher education and training which leads to a PGCE qualification with QTS (Qualified Teacher Status).\r\nThe key aim of our school-centred School Direct PGCE programme is to deliver a high quality current and relevant programme of training and education that equips you with the professional knowledge, understanding, skills and attributes that you need to become highly effective teachers (and leaders) with both a strong subject and wider professional identity. The programme combines school experience with taught academic sessions in order to achieve this. To support this, you will follow an ambitious curriculum that is underpinned by the Initial Teacher Training Core Content Framework and York St John Partnership five key themes, that has been designed to integrate theory and practice. \r\n\r\nThe programme delivers contemporary and highly relevant education and training which provides excellent opportunities for you to develop knowledge and understanding of your subject and wider educational issues.  You will be equipped to become an outstanding teacher and leader with strong subject knowledge and a clear professional identity.  You will be supported by experts in both university and schools to ensure that you have opportunities to learn about current classroom practice and develop deep subject pedagogy.  The programme combines school experience with taught sessions on subject knowledge and pedagogy which occur at university and also in partnership schools. Two academic assignments will need to be passed so you meet the programme aims and gain the PGCE award.  These modules will underpin your own rigorous understanding of pedagogy and will provide you with 60 Masters level credits, which you may wish to use towards a full Masters qualification in the future.\r\nThe programme ensures that you fulfil the requirements of the current Teachers’ Standards for the award of QTS. The programme encourages you to engage critically with educational issues to enable you to develop as a reflective practitioner, with the ability to evaluate and adapt your practice to meet the diverse needs of pupils in secondary schools.  This is achieved through a range of learning, teaching and assessment strategies, including active learning and enquiry-based learning, which is considered essential in both modelling effective learning and teaching practice.\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "There are no other costs for the programme.",
+                "fee_international": 12500,
+                "fee_uk_eu": 9250,
+                "financial_support": "Financial support can be accessed through the [Funding Advice Team](https://www.yorksj.ac.uk/student-services/funding-advice/) at York St John University.  ",
+                "how_school_placements_work": "The Hope Sentamu Learning Trust PGCE School Direct programme is a full-time programme studied within one academic year (September - June) and covers the 11- 16 age phase with 16-19 enhancement.  You will be based within one school for the majority of your training where you will complete two placements.  There is also a 6-week contrasting placement in a different partnership school, either in the autumn or spring term. You are supported on your school placements by a mentor and other school staff who are committed to your education and training.  During these placements you will observe teaching, work collaboratively with experienced staff and gradually increase the percentage of your independent teaching.  Induction is a key part of the programme and each placement as we feel it is important for you to feel welcome in the school community and valued as members of staff from the start. You will attend school meetings such as staff meetings, participate in school training days and other professional development events as appropriate. You are given the opportunity to participate in all aspects of school life and the wider school context.  This helps you to understand your own professional identity and be a fully committed member of a school community. Once qualified and as you become an Early Career Teacher you will have access to university support resources in order to further support you transition from ITE into your first teaching role. ",
+                "interview_process": "The recruitment process is rigorous and thorough. It is designed to enable Hope Sentamu Learning Trust and York St John University to assess the suitability of candidates for training and to appoint the best candidates for the places available.  \r\n\r\nSelection is based on evidence given throughout the application process and includes:\r\n\r\n*Your personal statement\r\n\r\n*References\r\n\r\n*Detailed breakdown of degree content\r\n\r\n*Details of other academic, professional or vocational qualifications\r\n\r\n*Completion of a practical task at interview\r\n\r\n*Overall performance at interview\r\n\r\nInterview days take place in one of our partnership schools. Typical activities include a short teaching activity and an individual interview with a panel made up of Hope Sentamu Learning Trust staff and university staff.  Candidates may also have an interview with a pupil panel and take part in a group activity and literacy-based task.\r\nPlaces on the programme are limited and recruitment takes place regularly during the year.  If you are successful at interview you will be offered a conditional place.  Once the number of offered places meets the agreed programme numbers, the programme will be closed.  We therefore recommend that you apply as soon as possible to avoid missing out on the programme of your choice.\r\n",
+                "other_requirements": "Places are limited and recruitment takes place on a rolling basis. Once the number of students accepted reaches the course limit, courses will be closed. We recommend that you apply as soon as possible to avoid missing out on the course of your choice.",
+                "personal_qualities": "We are looking for student teachers who:\r\n\r\nHave a passion for teaching and a love of learning.\r\n\r\nAre committed to ensuring that all pupils can succeed no matter what their background or starting point.\r\n\r\nAre enthusiastic, combined with excellent organisational skills.\r\n\r\nHave the ability to reflect and develop as critical professionals.\r\n\r\nCan express ideas clearly and succinctly.\r\n\r\nHave a high level of resilience and respond well to constructive feedback.\r\n\r\nShow personal initiative and can work well with peers, pupils, tutors, staff and parents alike.\r\n",
+                "required_qualifications": "GCSE in English (or approved equivalent) at grade C/grade 4 or above\r\n\r\nGCSE in Mathematics (or approved equivalent) at grade C/grade 4 or above\r\n\r\nA first degree from a UK higher education institution or equivalent. The first degree should be specific to the subject-based PGCE you are applying for.  In some circumstances candidates without a subject specialist degree may be considered if you can provide evidence of strong subject knowledge, and have at least an A level in the subject.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966467",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "T282",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": {
+                    "id": 17512,
+                    "address4": "Leicestershire",
+                    "provider_name": "Inspiring Leaders with Discovery Schools Trust",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Fossebrook Primary School",
+                    "year_code": "2019",
+                    "provider_code": "1BJ",
+                    "provider_type": "scitt",
+                    "postcode": "1 School Lane",
+                    "website": "http://www.inspiringleadersscitt.com",
+                    "address1": "Discovery Schools NSPCC Training Centre",
+                    "address2": "NSPCC National Training Centre",
+                    "address3": "Leicester",
+                    "email": "jvenables@iltt.org.uk",
+                    "telephone": "01163184066",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:51:32.479Z",
+                    "updated_at": "2021-10-05T14:44:51.060Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T14:44:51.060Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Inspiring Leaders Teacher Training, is an Ofsted 'Outstanding' rated partnership of schools working across Leicestershire, Leicester and Rutland, working together to develop outstanding teachers and leaders of the future. \r\n\r\nAs Discovery Schools Academy Trust  we are committed to helping every child the opportunity to 'Discover their Potential' and believe the best way to achieve this is through outstanding teaching and leadership. \r\n\r\nAll of the schools you will be based within, aspire for our schools to be the best paces for children to learn and develop their full potential. To achieve this we need to recruit, support and invest in teachers with the passion and determination to provide outstanding opportunities and experiences for our children. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience alongside an innovative and inspiring taught programme, leading to the award of QTS and a PGCE, with our partners the University of Leicester.\r\n\r\nWe are passionate, experienced and successful at developing great teachers with 100% of our trainees being successfully employed in the past 3 years.\r\n\r\nWe offer more than just a one year teacher training programme by supporting trainees into employment in our schools and delivering ongoing career opportunities tailored to their needs.\r\n\r\n[For more information visit our websites:]\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n\r\nCall us on 0116 3184066 or email us at info@iltt.org.uk\r\n",
+                    "train_with_disability": "We are an equal opportunities provider and provide support for all our students with their learning requirements. \r\n\r\nOur partner universities provide support for trainees with different needs and learning requirements. \r\n\r\nThis can be discussed at the screening and interview process. ",
+                    "accrediting_provider_enrichments": [
+                        {
+                            "Description": "We work tirelessly to ensure that all of our trainees are supported and become great teachers. In 2018/19 of those who completed the course – 100% of them moved into jobs in local schools and are now accessing high quality support in their first year of teaching.\r\n\r\nWe work with the University of Leicester to award PGCE to all trainees on our programme.",
+                            "UcasProviderCode": "2A5",
+                            "validation_context": null
+                        }
+                    ],
+                    "latitude": 52.6672396,
+                    "longitude": -1.1643891,
+                    "ukprn": "10055365",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1BJ",
+                "changed_at": "2021-10-05T14:04:55.946Z",
+                "uuid": "3ae68b73-2c9b-4c1f-aefe-1e19c3e0ac89",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "We offer equivalencies to candidates that have accepted their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:04:55Z",
+                "about_accrediting_body": null,
+                "provider_code": "5W1",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "General Primary\r\nOur General Primary course will require you working in two contrasting schools across our partnership, depending on the location selected (Don't worry, if you apply to a Leicestershire course, we won't be sending you to Nottingham and visa versa). We call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to cover these 3 age phases: Year 1 and 2; Year 3 and 4; Year 5 and 6, ensuring you gain a variety of experience so you can work out where you would like to be when you qualify as a teacher.\r\n\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "course_length": "OneYear",
+                "fee_details": "Financial Support\r\n\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\n\r\n\r\n \r\n[Click here:](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "how_school_placements_work": "General Primary\r\nOur General Primary course will require you working in two contrasting schools across our partnership, depending on the location selected. We call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to cover these 3 age phases: Year 1 and 2; Year 3 and 4; Year 5 and 6, ensuring you gain a variety of experience so you can work out where you would like to be when you qualify as a teacher.\r\n\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "interview_process": "\r\n“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)",
+                "other_requirements": "Call us on 0116 318 4066 or email (info@iltt.org.uk)\r\n[Click here](https://www.inspiringleadersscitt.com)",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\n\r\nWe are looking for candidates that have a good awareness of current educational issues and have a deep understanding and open mind about how they affect children and schools. As well as an ability to act with professionalism and integrity. ",
+                "required_qualifications": "\r\nA UK degree is required to join the course. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's or equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nWork experience is recommended. \r\n\r\nILTT has a Self-Assessment Document that will help you to gain the right experience in school to support your application.\r\n\r\nIf you would like us to help you gain this school based experience please get in touch via our email\r\n(info@iltt.org.uk)\r\n[Click here](https://www.inspiringleadersscitt.com)",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966316",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2QWP",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-15T09:11:22.447Z",
+                "uuid": "ad5c689b-ae42-4865-81a9-5de4a48f552a",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Candidates should use a third party provider for equivalency tests.\r\n",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-15T09:11:22Z",
+                "about_accrediting_body": null,
+                "provider_code": "28E",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Astra trainees on the Chemistry course are prepared to teach across the full 11-16 curriculum, including Key Stage 3 Science, GCSE Chemistry, practical and mathematical skills and the role of technology in education, along with Sixth Form experience.\r\n\r\nThe Astra approach has at its core the principle of developing trainees as reflective professionals who have strong practical classroom skills and excellent subject knowledge. Trainees learn how to use current theory to inform their classroom practice and attention is paid to ensuring that trainees have a detailed understanding of Chemistry as a school subject, as well as outstanding skills in learning to plan and teach lessons which are creative and engaging.Subject studies are taught by a team of experienced practising classroom teachers with the Chemistry focus led by a current Head of Department.\r\n\r\n Astra trainees spend four days per week in their placement schools (minimum of 120 days across the year). All training and assessment will lead to the award of Qualified Teacher Status by the DfE.  Additionally, the optional PGCE qualification  includes 60 credits at Masters level which is the equivalent to one third of an MA.\r\n\r\nYour curriculum will follow the core content framework, with final assessment against the Teachers' Standard,  based on evidence of your teaching, wider contribution to school life and the ability to reflect on and evaluate these experiences.  Progress is monitored through weekly reflections on progress, objective setting, regular lesson observations and two QTS assignments. Trainees pursuing the PGCE will also write two assignments designed to deepen reflections on school experience in the light of educational research.\r\n\r\nWeekly QTS Professional Studies will develop understanding of education essential for entrants to the teaching profession, providing consideration to whole-school issues, such as behaviour management, special educational needs and educational theories that contextualise the teaching of your subject. Secondary subject studies also focus on the teaching of each subject, including its place in the National Curriculum; what is taught; how it is taught; how it is assessed; providing for young people with different backgrounds and abilities; teaching in accordance with examination specification requirements; and using ICT effectively to facilitate learning.\r\n\r\nFee-funded or bursary-led trainees are always supernumerary and the work in school will take a variety of forms including observing experienced teachers and team teaching, gradually taking responsibility for the learning of whole classes and getting involved in all aspects of school life. \r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "We endeavour to match the right trainee to the right partner school for their main placement based on their initial preference, geography / distance from home, and areas of specific interest. This course is offered at the locations shown on our website https://www.astra-alliance.com/402/scitt-and-school-direct-itt-places-2021-22\r\nYou will be given the opportunity to express your placement school preference if your application is shortlisted. \r\nWe aim for all trainees to experience two placements, although the main placement will be where the trainee is primarily based.  Trainees will also be expected to attend an induction day with their main placement school ahead of the September course start.  \r\n\r\n\r\nSecondary trainees will teach across the 11-16 age range (14-19 yrs for Business Studies ).  \r\n\r\nQTS studies take place with the SCITT every Wednesday, with the other four days per week being spent in school (approximately 120 days across the year).  If doing the PGCE, these sessions (approx 6 taught sessions) will be spread across the year. Bursary-led / unsalaried trainee timetable allocations is approximately 30% in the first term, rising to a maximum allocation of 75% in the final placement out of the four days in school.   \r\n\r\nAstra has over 50 partners signed up to the SCITT Partnership Agreement which demands that each school supplies dedicated and high quality one-to-one Mentor support and in-school Professional Studies to complement the core QTS programme offered by the SCITT each week.  Trainees will also be expected to attend events such as parents’ evening and contribute to report writing during the year.  While there is no guarantee of permanent employment with placement schools, a considerable number of our trainees do go on to secure employment within our partnership.\r\n\r\n",
+                "interview_process": "There are three Teaching School Hubs operating on behalf of the Astra SCITT for both primary and secondary recruitment across our network of over 50 schools:\r\nAstra SCITT/Astra Amersham Hub - Amersham and surrounding area\r\nAstra Aylesbury Hub - Aylesbury / surrounding area\r\nAstra Marlow Hub - Marlow / Maidenhead \r\nCandidates should apply  via DfE Apply to their preferred Astra SCITT Hub, which will then coordinate the recruitment process. If your application is shortlisted, candidates will be invited for a first stage interview at one of our Hub locations.   \r\n\r\nThe application and interview process for each hub is identical and is quality assured by the leadership team at the Astra SCITT. It will take one of the following formats: \r\n1. Stage 1 will be conducted remotely and consist of a panel interview, delivery of a short presentation, and some written tasks.  If successful at this stage, you will be invited to attend a Stage 2 interview, which will, where possible involve a visit to your potential main placement school to be observed leading a teaching activity with a small group of students; you will be told in advance about the content of the lesson you will need to plan, and the age group you will be teaching.  \r\n2. Stages 1 and 2 will both be conducted remotely, with you being asked to ‘teach’ part of a lesson to the interview panel following the main panel interview\r\n",
+                "other_requirements": "The potential to write at Masters level is a requirement for PGCE candidates. \r\n\r\nFor secondary trainees on the 11-16 programme we require the ability to teach up to A Level in your subject.  Candidates will be required to have an Enhanced DBS check, and health clearance. Requirement to complete a funded Subject Knowledge Enhancement course will be determined at the point of offer.\r\n\r\nHard copy evidence of all required academic qualifications will need to be provided before an unconditional offer can be made. \r\n\r\n",
+                "personal_qualities": "Candidates should have the potential to become outstanding teachers, demonstrated by strong subject knowledge; ability to communicate with enthusiasm about learning; ability to reflect on experiences of working with young people, and knowledge of the curriculum and educational issues. \r\n\r\nOther requirements include being ambitious to teach at a good or outstanding level; highly motivated (with the ability to also motivate students); high professional standards; a willingness to play a part in the wider school life; commitment to professional development, and strong communication skills.\r\n\r\nFurther experience of working with children, for example helping with a youth/sports club is desirable.  \r\n",
+                "required_qualifications": "* at least grade 4 (C) (or equivalent) for GCSE Maths and English. \r\n\r\n* at least grade 4 (C) (or equivalent) GCSE in a Science subject\r\n\r\n* Degree: 2:2 or above, although for QTS-only programmes we will consider applicants with a third class degree who can demonstrate an aptitude for teaching, dependent on the subject/specialism. Your degree should ideally be in or closely related to the subject you intend to teach.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12965968",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "37M5",
+                "name": "Art and Design",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-28T19:13:34.215Z",
+                "uuid": "a245871e-03a2-4f10-a25f-db13d4eddc7f",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-28T19:13:34Z",
+                "about_accrediting_body": "",
+                "provider_code": "12K",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "You will be trained in a highly supportive, creative, inspirational environment where you will develop the knowledge, understanding and skills needed to deliver high quality teaching and learning.  We pride ourselves in offering a personal service from an experienced and dedicated team.\r\n\r\nTrainees work a full academic year in their host school, and are part of the school community from the start - from the first day of term to the last.\r\n\r\nAll of our trainees have Wednesday afternoon off timetable to: \r\n\r\n* Attend a 'wider context programme' which is delivered by  experts within our schools with sessions varying from behaviour management to marking and assessment.\r\n\r\n* Take part in alternative setting experiences at a SEND school, an alternative provision and a local school with a high percentage of EAL pupils (English as an additional language).\r\n\r\n* To complete research and gather evidence to complete the PGCE assignments.\r\n\r\n* To network with other Association trainees.\r\n\r\nThis course leads to QTS, PGCE and Masters Credits.",
+                "course_length": "OneYear",
+                "fee_details": "The fee for UK and EU students is £9250.00 which is the standard rate for postgraduate courses.\r\n\r\nTrainees are entitled to the same financial support as trainees on other postgraduate teacher training courses\r\n\r\nThose from the UK and the EU are eligible for student loans to cover tuition fees and maintenance.\r\n\r\nBursaries are available from the National College for Teaching and Leadership in priority subject areas, this is dependent on your degree level and the subject you wish to teach and the information can be found from the DfE.\r\n\r\nScholarships are available from a number of sources.",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "* This course is school led and the majority of the training year\r\nwill be in your chosen school.\r\n\r\n* One day a week will be spent at Nottingham Trent University, for a maximum of twenty eight days. \r\n\r\n* You will have a six week second placement based on your development needs in the early part of the spring term. \r\n\r\n\r\n",
+                "interview_process": "As this course is run in partnership between Diverse Association and Nottingham Trent University, two interviews are required.\r\n\r\nThe university interview will establish the extent at which you are likely to meet the academic requirements of the programme, your commitment and passion for your chosen subject or phase, and the aptitude you have for teaching.\r\n\r\nThe Diverse Association interview will take place at the school you have chosen to train in, and involves the three activities below:\r\n\r\n* Pupil Panel\r\n* Teach a twenty minute lesson\r\n* Formal interview\r\n\r\nBoth parties discuss the outcome of the interview before a place is offered.",
+                "other_requirements": "",
+                "personal_qualities": "* You want to make a real difference and your enthusiasm is clear.  \r\n\r\n* You can articulate how you have influenced or positively impacted the lives of others.  \r\n\r\n* You know why you want to teach and can demonstrate your teaching skills. \r\n\r\n* You understand the challenges ahead in your journey to become a teacher.  \r\n\r\n* You know how to grow and learn from making mistakes. \r\n\r\n* You want to be part of the school community and understand the importance of this. \r\n",
+                "required_qualifications": "Applicants must hold a UK degree or equivalent qualification, preferably a 1st or 2:1 level although we will consider applications with a lower degree class.\r\n\r\nFor secondary applicants this must be in, or closely related to your teaching subject. We expect at least 50% of your degree is relevant to the subject you intend to teach.\r\n\r\nAll candidates require GCSE C or above in Maths and English (Primary also need science). We will also accept approved equivalent qualifications.\r\n\r\nYou can apply for the course not meeting these requirements, but you must obtain them before the course starts.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969839",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "M977",
+                "name": "Modern Languages (French and Spanish)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17626,
+                    "address4": "Leeds",
+                    "provider_name": "Leeds Trinity University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Leeds Trinity University",
+                    "year_code": "2019",
+                    "provider_code": "L24",
+                    "provider_type": "university",
+                    "postcode": "LS18 5HD",
+                    "website": "https://www.leedstrinity.ac.uk",
+                    "address1": "Leeds Trinity University",
+                    "address2": "Brownberrie Lane",
+                    "address3": "Horsforth",
+                    "email": "admissions@leedstrinity.ac.uk",
+                    "telephone": "0113 283 7123",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:52:55.297Z",
+                    "updated_at": "2021-09-22T14:14:08.925Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T13:50:19.392Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Leeds Trinity University has been synonymous with high quality teacher training since 1966, when we were founded as a Catholic teacher training college. \r\n\r\nOver the years, we’ve diversified and expanded to become renowned for teaching excellence and producing highly employable graduates across many subject areas, but an unwavering commitment to outstanding teacher training has remained at the heart of what we do. \r\n\r\nRecognising that people begin PGCE courses with different levels of experience and skills, we train you in three stages to build your confidence and capability with a mix of research-informed practice, school-based training and plenty of one-to-one support. \r\n\r\nWe work with over 600 schools – from small rural schools to large, inner-city high schools. We work with ‘Outstanding’ schools leading innovations in education, as well as schools that may have difficulties in reaching outcome targets at the end of key stages. \r\n\r\nWhen you train with Leeds Trinity, you’ll experience best practice in school improvement, whichever school you train in.\r\n\r\nYou’ll work with expert school mentors while on placement and receive help, advice and support from University-based link tutors. This combination means you’ll get specialist training on teaching the most difficult aspects of subject content, and understanding children and young people at various ages and stages of development.\r\n\r\nAfter you graduate, we offer excellent support for teachers in the early stages of their career, and have a very strong Early Career Teacher (ECT) programme, with CPD, an active online community, and an annual conference.",
+                    "train_with_disability": "We’re committed to ensuring that every student with potential, regardless of their background or circumstances, has the opportunity to benefit from higher education. \r\n\r\nIf you have a disability or additional needs, Leeds Trinity University will endeavour to put in place reasonable adjustments to accommodate any additional requirements throughout your teacher training year. We’re able to support with conditions such as: \r\n\r\n-\tDyslexia\r\n-\tSpecific learning difficulties\r\n-\tAsperger syndrome/autism\r\n-\tVisual/hearing impairments\r\n-\tPhysical and mobility restrictions\r\n-\tLong-term medical conditions\r\n-\tA mental health condition. \r\n\r\nIf you register with our Disability Service, a member of the team will develop a Learning Support Plan tailored to your specific needs. The support within this plan could include exam adjustments, extended library loans, specialist one-to-one study skills, dyslexia screening and assessments, learning materials provided in alternative formats and alternative assessments.\r\n\r\nWith your permission, they’ll share this plan with your University-based personal tutor so that they know how to best support you during your University-based training. They can also share this plan with the School Partnerships team, who are able to inform the host schools for your placements so they can discuss how to best support you during your school-based training. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.8481606,
+                    "longitude": -1.6459213,
+                    "ukprn": "10003863",
+                    "urn": "133838",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "L24",
+                "changed_at": "2021-08-25T13:25:57.732Z",
+                "uuid": "549aec8b-e79f-4a3e-92ca-5072a1483c33",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "Degree subject should match or be closely related to Modern Languages (French and Spanish).",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-08-25T13:25:57Z",
+                "about_accrediting_body": null,
+                "provider_code": "2C3",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "On successful completion of the course students are awarded QTS, PGCE, comprising 60 credits at Master Level 6. \r\n\r\nStudents are placed in two highly performing schools, mentored by good and outstanding teachers. \r\n\r\nThey will experience all aspects of school life which is invaluable when applying for future teaching positions. \r\n\r\nStudents will spend more than 120 days in schools on placement. \r\n\r\nWe arrange for students visit provision to increase their awareness of where children transition from and to (pre and post secondary), providing a holistic understanding of childrens progression. \r\n\r\nStudents will also have the opportunity to view best practice for SEN and EAL children. \r\n\r\nPlease note that during the Covid-19 pandemic we are conducting Selection Events remotely via Zoom.",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "The course begins with an induction at Horizon CC before commencing the first placement in an alternative school. After Christmas the remainder of the school year is spent at Horizon CC in their Modern Foreign Languages department.\r\n\r\nDedicated to providing all students with a broad and exciting language curriculum, the Modern Foreign Language Department at Horizon is committed to designing and delivering lessons covering a range of cultural topics and linguistic structures to the highest level. We believe in nurturing a love of both the language studied and the world that surrounds this, enabling our students to benefit from the transferable skills that language learning offers. Our team offers a unique opportunity for passionate aspiring teachers to develop their teaching craft through a breadth of experience and teaching styles. We provide excellent mentoring and CPD to our Early Career Teachers whilst offering opportunities for individuals to lead their own initiatives. So, if you have the same drive and enthusiasm as us, come and join this fantastic team.\r\n\r\n ",
+                "interview_process": "We invite applicants who successfully meet the application criteria to attend a Selection Event at Horizon Community College.  \r\n\r\nThe event will be led by staff from our partnership schools along with a staff member from Tykes Teaching Alliance. The event will last approximately two to three hours and will include:\r\n\r\nA meet \u0026 greet – an introductory talk about the course and Tykes   Teaching School Alliance \r\nA learning walk – where you will be shown around school by a group of pupils\r\nAn individual interview\r\nA teaching task \r\n\r\nAt this stage we assess your;\r\n•         ability to communicate clearly, both orally and on paper\r\n•         knowledge of the area of education you are interested in\r\n•         interest in, and commitment to, a career in teaching\r\n•         ability to work effectively with children in an educational setting (for primary education courses you will need to bring the reference from the educational setting you attended)\r\n \r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12959882",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "3D4P",
+                "name": "Drama",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17801,
+                    "address4": "Greater Manchester",
+                    "provider_name": "The Manchester Metropolitan University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Manchester Metropolitan University",
+                    "year_code": "2019",
+                    "provider_code": "M40",
+                    "provider_type": "university",
+                    "postcode": "M15 6GX",
+                    "website": "https://www.mmu.ac.uk/education/pgce/",
+                    "address1": "Brooks Building",
+                    "address2": "Bonsall Street",
+                    "address3": "Manchester",
+                    "email": "courses@mmu.ac.uk",
+                    "telephone": "0161 247 6969",
+                    "region_code": "north_west",
+                    "created_at": "2021-07-06T10:54:41.761Z",
+                    "updated_at": "2021-09-13T10:36:47.838Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:01:15.423Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "COULD YOU BECOME AN ORIGINAL INFLUENCER?\r\n\r\nAs one of the city’s most established providers – with almost 150 years training education professionals under our belts – we know teaching inside out.\r\n\r\nIn many ways, we think teachers are the original influencers. They inspire. They engage. They explain. And they have a lasting impact on the pupils they teach.\r\n\r\nWe’ve been educating teachers, practitioners and professionals since 1878. We’re proud of our history. We’re proud of our present. And we’re proud to be one of the largest teacher training establishments in the country. Each year, we welcome over 700 trainee teachers onto our PGCE courses. We have a partnership of over 1,500 regional schools, colleges and educational organisations. We adopt leading research into our teaching through our Education and Social Research Institute (ESRI). \r\n\r\nSHARING SELFIES TO SHARING KNOWLEDGE\r\n\r\nSharing selfies is fun, but there is real joy in sharing knowledge. It’s finding new ways to explain complex theories to students and inspiring a love of learning. Discovering innovative global teaching methods. Using research to make a difference in the classroom.\r\n\r\nYou might debate how pupils learn when they live below the poverty line or explore the effect of the growth mind-set. You might research ways to include bilingual students in your lessons or global methods of teaching maths and how this could help your class.\r\n\r\nWhichever subject you’re hoping to teach, we’ll help you to develop the practical skills you need to teach, to inspire and to engage your class.",
+                    "train_with_disability": "From study skills to dyslexia screenings - we've got it covered - https://www.mmu.ac.uk/student-life/wellbeing/disability/.\r\n\r\nIf you are a care leaver, estranged from your family, a carer, under 18 or pregnant, we have a dedicated Inclusion Service to help you through your studies - https://www.mmu.ac.uk/student-life/wellbeing/inclusion/.\r\n\r\nCome and visit our Open or Visit Days and speak to a member of staff from Disability Service - https://www.mmu.ac.uk/study/open-days.\r\n\r\nOr simply contact the Disability Service on 0161 247 3491 or (disability.service@mmu.ac.uk)",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.4666748,
+                    "longitude": -2.2465299,
+                    "ukprn": "10004180",
+                    "urn": "133844",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "M40",
+                "changed_at": "2021-07-20T11:35:11.812Z",
+                "uuid": "9925f65e-0aeb-4724-b99e-250e2218fb18",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-07-20T11:35:11Z",
+                "about_accrediting_body": "The Manchester Trusts and Schools Alliance have worked closely with MMU for many years and have forged excellent relationships to ensure our students benefit from our truly collaborative work in partnership.\r\n\r\nOur leaders actively participate on the steering groups set up by the university and this ensures we work effectively together for the benefit of all our students.",
+                "provider_code": "1JR",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Drama Departments at our partnership schools are outstanding and an excellent base to begin your training and teaching career. There is a mix of recently qualified and extremely experienced staff within the department. The subject mentors for Drama are outstanding practitioners.\r\n\r\nHow will the course be assessed?\r\nAssociate Teachers currently have three assignments to complete, along with several shorter ‘reflection points’. In addition to this, when you are on teaching placements, you will need to complete planning, evaluations, marking and self-assessment against the teaching standards. These will be monitored and/or assessed by your mentor and University link tutor.\r\n\r\nYour teaching will also be observed weekly by your school-based mentor. During each placement you will also have at least one joint observation with your professional mentor and one joint observation with your University link tutor. These are the people who will be available to support and mentor you throughout your training.\r\n\r\nCan I refresh my subject knowledge?\r\nNot everyone feels confident in teaching every subject from the outset, for example, your degree might not be in your chosen subject but is closely related. As an Associate Teacher, you should identify parts of your subject knowledge you need to refresh or deepen. Subject Knowledge Enhancement (SKE) courses are available, with a bursary, for English, Maths, Physics, Languages, Chemistry, Computing, Biology, Geography and Design and Technology. Your training sessions at School and University will also assist here, but you are also expected to fill in gaps in your subject knowledge autonomously in order to be confident and competent in teaching accurately. \r\n\r\nWhat proportion of time is spent in school and at University?\r\nAcross the training year, Associate Teachers spend 28 days in University, for subject knowledge and assignment support. 18 days on school-based training and have 120 days teaching experience in two contrasting schools.\r\n\r\nHow do I become a qualified teacher?\r\nThe award of Qualified Teacher Status (QTS) is given based on how well you have met each of the Teacher Standards. Evidence gathered to substantiate each of the standards comes from all assignments, teaching files, reflections and observations completed during your training. A PGCE is awarded from Manchester Metropolitan University.",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "Where will I be placed for secondary training?\r\nMTSA does their best to place Associate Teachers in Chorlton High School, as the lead secondary school in the alliance, and another contrasting placement. Chorlton High School is a designated Teaching School, recognised for the training it provides at all levels, which has recently opened a free school, CHS South. Contrasting placements are provided from schools across Manchester, that CHS works closely with for initial teacher training. For example, Manchester Enterprise Academy, MEA Central, The Manchester Grammar School, The Kingsway School, Fallibroome Academy, Cheadle Hulme High School  and Loreto 6th Form College. \r\n\r\nWhich year groups will I be placed in?\r\nAssociate Teachers complete placements in 11-16 schools. You will also have experience of KS2 transition, in a local primary school, and post 16 teaching. \r\n\r\nYou will then be qualified to teach the secondary age range. You will have your specialism but may offer to teach a second subject also. \r\n\r\n(http://www.chorltonhigh.manchester.sch.uk/)\r\n",
+                "interview_process": "Applicants are interviewed by MTSA, this will include a member of the training team and a subject specialist. The interview for secondary admission has three elements consisting of a teaching task, a written task, and a panel interview.  ",
+                "other_requirements": "All applicants will need to have an Enhanced DBS check done, prior to working with young people. This will be completed through the Disclosure and Baring Service and MTSA.",
+                "personal_qualities": "We are looking to recruit Associate Teachers who are dedicated to pursuing success for children across Manchester. Our placement schools are truly comprehensive and reflect the diverse makeup of the city. We want lifelong learners who will fulfil their potential in the classroom and in their professional development.\r\n\r\nOur current cohort and alumni have varied background experiences. Some have worked in a school before starting training, some come straight from university and others have been career-changers. We have applications from mature students, from those who have worked overseas, parents and applicants currently living or looking to relocate to south Manchester.\r\n",
+                "required_qualifications": "What are the entry requirements for School Direct?\r\nAssociate Teachers must have a minimum of a 2:2 undergraduate honours degree awarded by a UK university, or an equivalent higher education qualification. Your degree needs to support the subject knowledge requirements of the National Curriculum for Drama. \r\n\r\nFor exceptional candidates, particularly those with substantial relevant work experience in schools or relevant occupations, we will consider applications from those who hold a 3rd class degree.\r\n\r\nGood standards of written and spoken English are also essential. You will also need GCSEs at grade C/4 or above in English language and Mathematics.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12960595",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "AT50",
+                "name": "Art \u0026 Design",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17637,
+                    "address4": "Middlesex",
+                    "provider_name": "Hillingdon SCITT",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "David Poole",
+                    "year_code": "2019",
+                    "provider_code": "2B5",
+                    "provider_type": "scitt",
+                    "postcode": "HA4 8EE",
+                    "website": "https://hillingdonteachingschoolalliance.org/Welcome-to-Hillingdon-SCITT/",
+                    "address1": "c/o Bishop Ramsey CE School",
+                    "address2": "Hume Way",
+                    "address3": "Ruislip",
+                    "email": "hillingdonscitt@bishopramseyschool.org",
+                    "telephone": "01895671062",
+                    "region_code": "london",
+                    "created_at": "2021-07-06T10:53:01.289Z",
+                    "updated_at": "2021-09-20T12:42:33.474Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-28T07:19:01.306Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Hillingdon SCITT, an Ofsted recognised Outstanding ITT Provider, located in North-West London, is looking to train exceptional graduates to become teachers.  \r\n\r\nWe are seeking people who are not only passionate about education, have an excellent academic background, and are committed to working with children and young people to make a difference in their lives. \r\n\r\nTrainees who join Hillingdon SCITT will be fully supported and challenged to become reflective, resilient and resourceful practitioners. All Primary and Secondary Schools who are in partnership with Hillingdon SCITT have extensive experience of training teachers and we fully recognise how much vibrancy, enthusiasm and drive they can offer to a school community. We provide a unique opportunity to experience a diverse and contrasting range of teaching and training experiences in at least two schools.  Children and young people across the partnership are happy, friendly and well-behaved and are at the heart of everything we do. \r\n\r\nThe teachers in our Partner Schools are excellent practitioners with exemplary behaviour management skills.  They are supportive and eager to share their skills, knowledge and practice with the next generation of teachers.\r\n\r\nHillingdon SCITT has successfully trained 5 cohorts of Primary and Secondary teachers.  Upon completion of the course Hillingdon SCITT trainees have been graded as Good or Outstanding towards the Teachers' Standards.  As a result, our trainees a highly employable and we have had 100% employment rate upon course completion.  \r\n\r\n",
+                    "train_with_disability": "Candidates who have disabilities or other needs should contact Hillingdon SCITT prior to their application to discussion their needs and the bespoke support that we can provide for them during their initial training year.  \r\n\r\nThe individual Partner Schools have differing disabled access provisions, so if in doubt please contact Hillingdon SCITT for more information.\r\n\r\nBrunel University (Hillingdon SCITT's PGCert provider) has full disabled access and is committed to admitting and supporting students with disabilities.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.5792096,
+                    "longitude": -0.4080951,
+                    "ukprn": "10059208",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B5",
+                "changed_at": "2021-10-05T14:05:26.856Z",
+                "uuid": "5afa4787-e6fc-420f-8713-3600329f737c",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "We do not offer equivalency tests ourselves, but our university partners may do although these may be at a cost to the candidate.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:05:26Z",
+                "about_accrediting_body": null,
+                "provider_code": "1KV",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Ada Lovelace High School is one of four Twyford Trust schools. The Trust's ethos is strongly and distinctively Christian, with an emphasis on developing socially responsible individuals with a sense of their own capacity to do and be good. The Trust prides itself on embracing 'life lived to the full'; a concept that we have developed as our 10:10 ethic.\r\n\r\nAda Lovelace opened as a Free School in September 2018 and last year we moved into our new school site with year groups 7 through to 10. \r\n\r\nThe School Direct Art \u0026 Design programme at Ada Lovelace CE High School begins in September 2022. Upon successful completion of the training programme in summer 2023, you will gain a Postgraduate Certificate in Education (PGCE) as well as Qualified Teacher Status (QTS) .\r\n\r\nAll schools in the Teach West London Ealing secondary partnership are highly supportive and inspirational environments where you will develop the necessary skills and acquire a true appreciation of the practice essential for outstanding teaching and learning. You will learn your craft in a safe environment which allows you to experiment with teaching styles, strategies and ideas.\r\n\r\nYour training will be delivered by expert teachers within the school. You will participate in weekly professional development sessions which will cover a wide range of topics and school policies which will be of use to you in your subject area and in the school as a whole. You will also attend Alliance-wide Golden Day  training events along with fellow ETSA trainees. Your school-led training will be complemented by attendance at Hillingdon SCITT.\r\n\r\nYou will be assigned an experienced mentor from within your subject area at Ada Lovelace CE High School who will support you in your development over the course of what will be a challenging and rewarding year. All mentors are excellent teachers who are well-trained in mentoring, coaching, lesson observations and feedback skills. You will also work closely with a member of the Senior Leadership team who will oversee a great deal of your training and will provide an invaluable perspective on your role as a teacher and the wider issues of education leadership.",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9000,
+                "financial_support": "",
+                "how_school_placements_work": "As well as your main training placement at Ada Lovelace, you will complete a 7-12 week placement in a contrasting context within Ealing. \r\n\r\nThis will afford you the opportunity to experience working with different students, within different structures and with a wider range of colleagues.\r\n",
+                "interview_process": "Shortlisted applicants will be invited to an interview at school and to take part in some or all of the following activities: a presentation; a written task; small group teaching; curriculum discussion and an interview. You will be told in advance if you are required to prepare a presentation or to teach. Hillingdon SCITT will also attend the interview at school, where possible, and be part of the selection panel.\r\n\r\nIt is a rigorous and thorough process designed to ensure successful applicants are well placed to succeed.\r\n\r\nPlease note that we recruit on a rolling basis and usually offer only one position per subject area (unless otherwise stated). We suggest that you apply early as popular subjects are filled quickly.",
+                "other_requirements": "School experience is also essential if you are interested in applying for School Direct at ETSA. We prefer that candidates have up to 10 days of recent experience in a UK school. If you have arranged some classroom experience but it is yet to take place, please make a note of this in your application.\r\n",
+                "personal_qualities": "We seek to appoint applicants who exhibit a passion for and excellent knowledge of their subject and a commitment to the education of all young people. \r\n\r\nIt is anticipated that all successful applicants will participate fully in the life of the school and therefore it is essential that trainees are very well organised, hardworking and enthusiastic. \r\n\r\nWe look to appoint those with the potential to become outstanding teachers, with this in mind, it is crucial that applicants are resilient, reflective and responsive to advice.\r\n",
+                "required_qualifications": "Before the start date of the training programme you must hold a UK degree (or equivalent). You should preferably have a 1st or a 2:1 in a relevant subject area. It is also preferable that you have at least 3 Bs at A level (or equivalent). All applicants must have at least a C in GCSE English, Maths and Science at the time of application.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12958561",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "3DFL",
+                "name": "Primary (3-7)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17647,
+                    "address4": "South Yorkshire",
+                    "provider_name": "Sheffield Hallam University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Office",
+                    "year_code": "2019",
+                    "provider_code": "S21",
+                    "provider_type": "university",
+                    "postcode": "S1 1WB",
+                    "website": "http://www.shu.ac.uk",
+                    "address1": "City Campus",
+                    "address2": "Pond Street",
+                    "address3": "Sheffield",
+                    "email": "admissions@shu.ac.uk",
+                    "telephone": "0114 225 5533",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:53:03.859Z",
+                    "updated_at": "2021-09-09T12:46:21.020Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:27:54.813Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Sheffield Hallam University is one of the UK's largest universities, based in the heart of Sheffield, one of the UK’s biggest student cities.\r\n\r\nSheffield is the fifth biggest city in the UK with over 60,000 students, it has a mix of culture and green spaces. \r\n\r\nWe have invested over £100 million in new buildings and facilities over the last five years, providing innovative, flexible and sustainable spaces to enhance student experience.\r\n\r\nSheffield Hallam University has been awarded The Times and The Sunday Times University of the Year for Teaching Quality 2020. The award recognises our consistently high student satisfaction scores, as measured by the independent National Student Survey (NSS).\r\n\r\nWe pride ourselves on the applied nature of our courses. We offer one of the largest and most diverse range of placements in the region. We’ve built up a network of over 600 partner schools, colleges and other educational establishments, and we work together to our mutual advantage.\r\n\t\r\nYou will study at our centre of education that is recognised for excellence and innovation in teaching and learning. Our academics, researchers and partners in schools work together to ensure you become a committed and professional graduate, with the opportunity to return to us throughout your career to further your professional development.\r\n\t\r\n[Find out more on our website] (https://www.shu.ac.uk/Study-here/options/Teach)",
+                    "train_with_disability": "If you have a disability, including long term medical conditions, specific learning difficulties (such as dyslexia, dyspraxia and A(D)HD) and mental health conditions, you can access additional support for your academic studies whilst at Sheffield Hallam.\r\n\r\nStudents can receive support for a wide variety of conditions. There is extensive support available, including\r\n\r\n•\tLearning contracts- reasonable adjustments to your course such as extensions or extra time in exams\r\n\r\n•\tSupport workers - like a mentor to help with organisation, or a personal assistant to help with mobility\r\n\r\n•\tEquipment/Assistive Technology and software - such as digital recorders or text to speech software\r\n\r\nWe have an on-site assessment Centre, the Sheffield Regional Assessment Centre, where a range of disability specialists can carry out Study Needs Assessments.\r\n\r\nWe run daily drop in sessions - come and talk to us, no appointment needed. You can also register for support online.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.3781046,
+                    "longitude": -1.4665227,
+                    "ukprn": "10005790",
+                    "urn": "133871",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "S21",
+                "changed_at": "2021-07-09T13:29:03.956Z",
+                "uuid": "6d9166a1-0f1f-4c99-a579-e56d8de285bb",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-07-09T13:29:03Z",
+                "about_accrediting_body": null,
+                "provider_code": "2C3",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "On successful completion of the course students are awarded QTS, PGCE, comprising 60 credits at Master Level 6. \r\n\r\nStudents are placed in two highly performing schools, mentored by good and outstanding teachers - wherever possible this will be with a Specialist Leader of Education for the Early Years. \r\n\r\nThey will experience all aspects of school life which is invaluable when applying for future teaching positions. \r\n\r\nStudents will spend more than 120 days in schools on placement. \r\n\r\nWe will also arrange for students to visit provision to increase their awareness of where children transition into the Early Years Foundation Stage from and where they transition to when leaving Key Stage 1. \r\n\r\nStudents will also have the opportunity to view best practice for SEN and EAL children. \r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "You maybe eligible to claim the difference in cost from travelling to your placement school and travelling to Sheffield Hallam University. ",
+                "how_school_placements_work": "Students will be placed in two primary schools within the Barnsley borough, schools placement schools will be selected based on the strength of their Early Years and KS1 provision. \r\n\r\nWherever possible will be place students in placement schools that are located conveniently for their needs, especially if the student has caring responsibilities. Students will not be expected to travel further than 25 miles from their home address to their placement school. \r\n\r\nStudents will be asked their preferred key stage (EYFS or KS1) and will spend the vast majority of the their placement within this key stage.\r\n\r\nStudents will spend September to December in their alternative placement school before spending January through to June in their preferred key stage. This 6 month block allows students to develop a sense of ownership of their class and develop relationships with children, parents and the staff team. \r\n\r\n ",
+                "interview_process": "We invite applicants who successfully meet the application criteria to attend a Selection Event at one of our schools. \r\n\r\nThe event will be led by staff from our partnership schools along with a staff member from Tykes Teaching Alliance. The event will last approximately two to three hours and will include:\r\n\r\nA meet \u0026 greet – an introductory talk about the course and Tykes   Teaching School Alliance \r\nA learning walk – where you will be shown around school by a group of pupils\r\nAn individual interview\r\nA teaching task \r\n\r\nAt this stage we assess your;\r\n•         ability to communicate clearly, both orally and on paper\r\n•         knowledge of the area of education you are interested in\r\n•         interest in, and commitment to, a career in teaching\r\n•         ability to work effectively with children in an educational setting (for primary education courses you will need to bring the reference from the educational setting you attended)\r\n \r\nPlease note that during the Covid-19 pandemic we are conducting Selection Events remotely via Zoom.",
+                "other_requirements": "",
+                "personal_qualities": "We are looking for people to change the lives of children in Barnsley. \r\n\r\nWe are keen to receive applicants from people with a genuine passion for improving the outcome of children and young people in our local area. ",
+                "required_qualifications": "GCSE Maths, English and Science at grade C or above. \r\n\r\n2:2 degree",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12958357",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2VLM",
+                "name": "Modern Languages (French)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17931,
+                    "address4": "Hull",
+                    "provider_name": "Hull SCITT",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Training",
+                    "year_code": "2019",
+                    "provider_code": "25O",
+                    "provider_type": "scitt",
+                    "postcode": "HU7 6AH",
+                    "website": "http://www.hullscitt.com",
+                    "address1": "Hull SCITT",
+                    "address2": "Dorchester Primary School",
+                    "address3": "Dorchester Road",
+                    "email": "training@hullscitt.com",
+                    "telephone": "01482 308650",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:56:14.516Z",
+                    "updated_at": "2021-09-08T20:24:29.559Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-08T20:26:18.907Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Hull SCITT (School Centred Initial Teacher Training) works passionately to train the best teachers for Hull and beyond.  The clue is in the title ‘School Centred’; our trainees are in school on day one learning and developing alongside our experienced mentors and school based coordinators.  School based provision is supported by core training delivered by Specialist Leaders of Education (SLEs). \r\n\r\n“Centre-based training draws effectively on the expertise of SLEs from partnership schools, ensuring that it reflects current educational thinking” Ofsted 2017\r\n\r\nWhen asked to identify the most beneficial aspects of our programmes previous trainees frequently refer to our “hands on approach”.  We deliver a personalised programme that builds upon trainee’s previous experience, strengths and learning styles.  We carefully select and match trainees to the school and mentors with whom they will be working.  \r\n\r\n“Leaders are determined to put trainees first to ensure that they have a successful start to their teaching career” Ofsted 2017 \r\n\r\nEmployment rates for the last 2 years have ben 100%, teachers trained by Hull SCITT are sought-after by employing head teachers.   The nature of our programme ensures a smooth transition into the teaching profession.  Our partnership with Hull Collaborative Teaching School and the University of Hull further support ongoing professional development.  \r\n\r\n“Head teachers are delighted that NQTs (Newly Qualified Teachers) ‘hit the ground running’ and commented that graduates of the SCITT need little support in their transition to employment because of the breadth of their training” Ofsted 2017 \r\n",
+                    "train_with_disability": "We work closely with our Occupational Health partners to ensure support is put into place as needed.   ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7805228,
+                    "longitude": -0.318031,
+                    "ukprn": "10055359",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "25O",
+                "changed_at": "2021-09-28T08:51:27.977Z",
+                "uuid": "dbd1fa82-57c5-4666-ab22-29b84a97def3",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-28T08:51:27Z",
+                "about_accrediting_body": "St Mary’s College School Direct programme is quality assured and accredited by Hull SCITT, an ITE provider that, since its establishment in 2015,  has established a strong reputation “for training high-calibre teachers who are well prepared for the demands of a teaching career.” [Ofsted, 2017] \r\n\r\nLed by the Hull Collaborative Academy Trust, Hull SCITT works in partnership with over 30 schools in the city with an absolute commitment from all partners to its mission to grow future teachers and leaders for Hull’s schools. The SCITT’s success is evident in the high employment rates for its trainees in the region. \r\n",
+                "provider_code": "1RU",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This secondary teacher training programme provides an ideal balance of school-based experience with professional and subject-specific training.  The course leads to Qualified Teacher Status (QTS), with the option to complete a Masters Level Post Graduate Certificate in Education (PGCE) with the University of Hull. \r\n\r\nYou will be fully integrated into the MFL department at your host schools where you will learn from experienced mentors and other host teachers.   You will receive training in how to teach across the 11-16 age range, including techniques for managing classroom behaviour and ensuring pupils of all abilities and needs can learn and make good progress.   You will be trained in all aspects of MFL  teaching including how to help pupils overcome common misconceptions and barriers with learning a new language.  \r\n \r\nYou will not be “thrown in at the deep end”.   Instead the course has a carefully phased approach which allows you to begin by observing lessons and participate in team-teaching before teaching full lessons.  Typically, you would progress to teaching about 6 hours a week by Christmas, and 14 hours by July, as well as taking on increasing responsibility for form time and PSCHE.   This helps to build your confidence within a manageable timetable so that, by the end of the course, you are able to make a smooth transition to the timetable expected in your first teaching year.     \r\n\r\nEach week you will receive high quality one-to-one mentoring from a subject specialist as well as core Professional Studies training delivered by Specialist leaders in Education (SLEs).  There are also regular Subject Knowledge and Pedagogy (SKAP) training sessions, and university-led tuition to support your PGCE assignments.   \r\n\r\nAs well as your two main placements, we also arrange visits for you to spend time in a Primary school, Special School and Free School as part of your programme to enable you to gain further experience of the education sector.    \r\n\r\nYou are assessed at half termly review points throughout the course by your mentor in conjunction with a Link Tutor.  These assessments are based on reviewing the progress of the classes you have been teaching as well as your ‘evidence bundle’ of lesson plans, resources and observations which is kept electronically on a SharePoint Cloud system.   At each review point, personalised targets will be set to help you progress  towards meeting the Teacher Standards by the end of the course.  \r\n",
+                "course_length": "OneYear",
+                "fee_details": "QTS only programme = £8,325\r\nOptional PGCE = £925\r\nTherefore total QTS and PGCE = £9,250\r\n",
+                "fee_international": null,
+                "fee_uk_eu": 8325,
+                "financial_support": null,
+                "how_school_placements_work": "You will spend the majority of the academic year on your main placement in your host school, with a six week second placement in a contrasting secondary school.    You will be fully integrated into your host school, so that you feel truly like a member of staff.  You will be given responsibilities for morning registration time, your own personal academic tutees to mentor, and you will be invited to join in all relevant school events and activities.  \r\n\r\nYour two placements will be in high-achieving departments in successful schools so that you are guaranteed to be working alongside excellent classroom teachers, curriculum and pastoral leaders and learning from the best practice.   You will have at least one placement in St Mary’s College - this could be the main placement or a second placement.   Your other placement will be at one of our partner secondary schools - The Marvell College, Kelvin Hall School or the Boulevard Academy.  \r\n",
+                "interview_process": "All short-listed candidates will be invited to an interview.  The interview panel will seek to gauge your potential, motivation and suitability for the teacher training programme, and will ask about your previous school experience, subject/curriculum knowledge, as well as your understanding about education and the role of the teacher.  \r\n\r\nCandidates are also expected to deliver a mini lesson to some KS3 students and take a short literacy test as part of the interview.  Further details about this will be included in the interview invitation letter.\r\n",
+                "other_requirements": "An informed understanding of the role of a teacher in terms of relevant skills and time commitments required for the profession.\r\n\r\nA commitment to safeguarding young people, equal opportunities and raising standards\r\n\r\nFollowing successful interview, all conditional offers will include:\r\n\r\nHealth and physical capacity to teach standards met (assessed through an occupational health questionnaire)\r\n\r\nSatisfactory Disclosure and Barring Service (DBS) check\r\n\r\nSatisfactory criminal record check for overseas\r\n\r\nSatisfactory check to ensure there is no prohibition order to teach in UK or European Economic Area (EEA)\r\n",
+                "personal_qualities": "A proactive mentality: you show initiative, are self-motivated and seek out useful learning experiences and opportunities. \r\n\r\nA love for learning:   you reflect upon what you have learnt and constantly strive to improve. \r\n\r\nA ‘can do’ attitude:  you are resilient, determined and flexible. \r\n\r\nA collaborative worker:  you work well in a team and engage with others to get the best out of situations. \r\n\r\nExcellent communication skills, especially communicating with young people\r\n\r\nExcellent organisational skills\r\n\r\nHumility, empathy and respect\r\n\r\nProfessional appearance and manner\r\n",
+                "required_qualifications": "Degree of a UK higher education institution or equivalent.  \r\n\r\nGCSE  grade C (grade 4) or equivalent  in Mathematics and English\r\n\r\n\r\n\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12957758",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "T821",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time teaching apprenticeship",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "apprenticeship",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-28T09:38:43.736Z",
+                "uuid": "b74e7c5f-98b4-4d18-abeb-569cd73e7320",
+                "program_type": "pg_teaching_apprenticeship",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "We recommend equivalencytesting.com but may accept tests from other providers by prior arrangement. Equivalency test costs are met by the candidate. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "July 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-28T09:38:43Z",
+                "about_accrediting_body": null,
+                "provider_code": "P85",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Apprenticeships are a salaried training route appropriate for existing school employees, or experienced applicants with a school prepared to employ them for the duration of the course.​\r\n\r\n* A salaried training route lasting for a minimum of 13 months (usually around 4 school terms)\r\n* Apprentices are released for 20% of their working hours (the equivalent of one day a week) for off-the-job training\r\n* Salary costs are met by the employing school\r\n* Training costs are paid through the Apprenticeship Levy Fund\r\n* Central training is provided by PCP SCITT, which is on the Register of Apprenticeship Training Providers\r\n* The programme leads to Qualified Teacher Status (QTS) and the award of an Apprenticeship\r\n* Apprentices are assessed against the Teachers' Standards (2012). They are guided by PCP SCITT staff and their school mentor to prepare a portfolio of evidence to demonstrate that they have met the Teachers' Standards. They will also complete 2 written assignments and undertake an End Point Assessment in Term 4 of the apprenticeship.\r\n\r\nCandidates and their supporting school should contact PCP SCITT prior to submitting an application to discuss apprenticeship levy funding eligibility and requirements.",
+                "course_length": "minimum 13 months",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "Apprentice trainees undertake a main placement in their employing school in addition to a placement of at least six weeks in a contrasting setting and key stage. ",
+                "interview_process": "",
+                "other_requirements": "Applications are invited from existing school employees, or those who have arranged for a school to employ them for the duration of their apprenticeship.​\r\n\r\nThe PCP is committed to safeguarding and promoting the welfare of children and young people. We expect all staff and trainees to share this commitment. All entrants undergo safeguarding and occupational health checks to ascertain that they are suitable to work with children.",
+                "personal_qualities": "The apprenticeship is an exciting, fast-paced year. Candidates are expected to be enthusiastic, well-organised, hard-working and keen to seek their own highest possible standards of achievement. Successful applicants will demonstrate:\r\n\r\n* Appropriate subject knowledge or the capacity to develop it during the course\r\n* A commitment to a career in primary education\r\n* Strong interpersonal and communication skills, including the ability to foster good relationships with children\r\n* An understanding of the demands and expectations of the teaching profession\r\n\r\nCandidates do not need to be a Catholic or from a faith-based background.",
+                "required_qualifications": "Applicants must hold a bachelors degree from a United Kingdom higher education institution (or equivalent as recognised by NARIC), or be currently completing their final year of study. A degree award of 2:2 or above is preferred.\r\n\r\nAll entrants must also have attained a minimum Grade C/4 (or equivalent) at GCSE in English, Mathematics and a Science subject, or will attain these qualifications before the start of the course. Equivalency tests may be accepted on request.",
+                "salary_details": "For the period of their training, all apprentices must be employed by a school as an unqualified teacher and paid in line with their employing school’s pay policy. This includes periods of training spent in other schools.\r\n\r\nMaintained schools and local authorities must abide by school teachers’ pay and conditions, which states that an unqualified teacher must be paid such salary within the minimum and maximum of the unqualified teacher pay range."
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969840",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "F965",
+                "name": "Physics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17626,
+                    "address4": "Leeds",
+                    "provider_name": "Leeds Trinity University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Leeds Trinity University",
+                    "year_code": "2019",
+                    "provider_code": "L24",
+                    "provider_type": "university",
+                    "postcode": "LS18 5HD",
+                    "website": "https://www.leedstrinity.ac.uk",
+                    "address1": "Leeds Trinity University",
+                    "address2": "Brownberrie Lane",
+                    "address3": "Horsforth",
+                    "email": "admissions@leedstrinity.ac.uk",
+                    "telephone": "0113 283 7123",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:52:55.297Z",
+                    "updated_at": "2021-09-22T14:14:08.925Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T13:50:19.392Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Leeds Trinity University has been synonymous with high quality teacher training since 1966, when we were founded as a Catholic teacher training college. \r\n\r\nOver the years, we’ve diversified and expanded to become renowned for teaching excellence and producing highly employable graduates across many subject areas, but an unwavering commitment to outstanding teacher training has remained at the heart of what we do. \r\n\r\nRecognising that people begin PGCE courses with different levels of experience and skills, we train you in three stages to build your confidence and capability with a mix of research-informed practice, school-based training and plenty of one-to-one support. \r\n\r\nWe work with over 600 schools – from small rural schools to large, inner-city high schools. We work with ‘Outstanding’ schools leading innovations in education, as well as schools that may have difficulties in reaching outcome targets at the end of key stages. \r\n\r\nWhen you train with Leeds Trinity, you’ll experience best practice in school improvement, whichever school you train in.\r\n\r\nYou’ll work with expert school mentors while on placement and receive help, advice and support from University-based link tutors. This combination means you’ll get specialist training on teaching the most difficult aspects of subject content, and understanding children and young people at various ages and stages of development.\r\n\r\nAfter you graduate, we offer excellent support for teachers in the early stages of their career, and have a very strong Early Career Teacher (ECT) programme, with CPD, an active online community, and an annual conference.",
+                    "train_with_disability": "We’re committed to ensuring that every student with potential, regardless of their background or circumstances, has the opportunity to benefit from higher education. \r\n\r\nIf you have a disability or additional needs, Leeds Trinity University will endeavour to put in place reasonable adjustments to accommodate any additional requirements throughout your teacher training year. We’re able to support with conditions such as: \r\n\r\n-\tDyslexia\r\n-\tSpecific learning difficulties\r\n-\tAsperger syndrome/autism\r\n-\tVisual/hearing impairments\r\n-\tPhysical and mobility restrictions\r\n-\tLong-term medical conditions\r\n-\tA mental health condition. \r\n\r\nIf you register with our Disability Service, a member of the team will develop a Learning Support Plan tailored to your specific needs. The support within this plan could include exam adjustments, extended library loans, specialist one-to-one study skills, dyslexia screening and assessments, learning materials provided in alternative formats and alternative assessments.\r\n\r\nWith your permission, they’ll share this plan with your University-based personal tutor so that they know how to best support you during your University-based training. They can also share this plan with the School Partnerships team, who are able to inform the host schools for your placements so they can discuss how to best support you during your school-based training. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.8481606,
+                    "longitude": -1.6459213,
+                    "ukprn": "10003863",
+                    "urn": "133838",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "L24",
+                "changed_at": "2021-08-25T13:31:23.258Z",
+                "uuid": "1435f4e9-80f2-42c7-bd62-beaf0b856030",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "Degree subject should match or be closely related to Physics.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-08-25T13:31:23Z",
+                "about_accrediting_body": null,
+                "provider_code": "2C3",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "On successful completion of the course students are awarded QTS, PGCE, comprising 60 credits at Master Level 6. \r\n\r\nStudents are placed in two highly performing schools, mentored by good and outstanding teachers. \r\n\r\nThey will experience all aspects of school life which is invaluable when applying for future teaching positions. \r\n\r\nStudents will spend more than 120 days in schools on placement. \r\n\r\nWe arrange for students visit provision to increase their awareness of where children transition from and to (pre and post secondary), providing a holistic understanding of childrens progression. \r\n\r\nStudents will also have the opportunity to view best practice for SEN and EAL children. \r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "The course begins with an induction at Horizon CC before commencing the first placement in an alternative school. After Christmas the remainder of the school year is spent at Horizon CC in their Science department.\r\n\r\nLocated in a suite of state of the art, fully resourced labs, the Science Department at Horizon offers a fantastic environment in which to begin your teaching journey. In total we have 7 full Science labs, 6 STEM rooms and one electronics room – all of which are maintained and resourced by two experienced lab technicians. Our schemes of learning aim to equip students with the knowledge, skills and mindset that will enable them to succeed to potential in their Science GCSEs and prosper in post-16 opportunities beyond this. We provide many opportunities for students to visit places of significant scientific interest in both Britain and Europe, and our dedicated STEM lead is currently planning a trip to CERN in Geneva for some of our keenest scientists. The Department has a wealth of experience in developing early career teachers, so why not come and join this excellent team!\r\n ",
+                "interview_process": "We invite applicants who successfully meet the application criteria to attend a Selection Event at Horizon Community College.  \r\n\r\nThe event will be led by staff from our partnership schools along with a staff member from Tykes Teaching School Alliance. The event will last approximately two to three hours and will include:\r\n\r\nA meet \u0026 greet – an introductory talk about the course and Tykes   Teaching Alliance \r\nA learning walk – where you will be shown around school by a group of pupils\r\nAn individual interview\r\nA teaching task \r\n\r\nAt this stage we assess your;\r\n•         ability to communicate clearly, both orally and on paper\r\n•         knowledge of the area of education you are interested in\r\n•         interest in, and commitment to, a career in teaching\r\n•         ability to work effectively with children in an educational setting (for primary education courses you will need to bring the reference from the educational setting you attended)\r\n \r\nPlease note that during the Covid-19 pandemic we are conducting Selection Events remotely via Zoom.",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12956672",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "278M",
+                "name": "English",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17457,
+                    "address4": "Cheshire",
+                    "provider_name": "University of Chester",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Undergraduate Admissions",
+                    "year_code": "2019",
+                    "provider_code": "C55",
+                    "provider_type": "university",
+                    "postcode": "CH1 1SL",
+                    "website": "https://www1.chester.ac.uk/education-and-childrens-services/postgraduate-courses",
+                    "address1": "Riverside Campus",
+                    "address2": "Castle Drive",
+                    "address3": "Chester",
+                    "email": "admissions@chester.ac.uk",
+                    "telephone": "01244511000",
+                    "region_code": "north_west",
+                    "created_at": "2021-07-06T10:51:06.330Z",
+                    "updated_at": "2021-09-15T09:33:01.018Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-15T09:38:33.705Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The [University of Chester](https://www1.chester.ac.uk) is an outstanding provider of teacher education, and one of the oldest higher education institutions in the UK. We started teacher training in 1839, and since then the University has developed and evolved to the modern, innovative institution it is today, with a well-deserved reputation for the quality of its education. \r\n\r\nOur [Faculty of Education and Children’s Services](https://www1.chester.ac.uk/education-and-childrens-services) has been awarded 'Outstanding' status in its most recent Ofsted report (Ofsted Report 2016), for its secondary programmes and all 3-7 and 5-11 primary/primary-early years programmes. The Faculty has extensive links to schools within the region, and offer a huge range of undergraduate, postgraduate and professional development courses for those involved or interested in education, teaching and children’s services. \r\n\r\nStudents can benefit from a range of subject specific facilities designed to bring learning to life; high-quality learning facilities and an on-campus library, housing an extensive collection of books and journals, as well as computer suites and multi-media rooms.\r\n\r\nOur experienced team of staff work hard to help you realise your potential through a variety of teaching methods, including practice placements. So whether you’re studying as part of your career development, or retraining towards a new career, our staff and on-campus facilities aim to provide you with a safe and professional environment to hone your skills. ",
+                    "train_with_disability": "[Disability and Inclusion](https://www.chester.ac.uk/campus-life/support-for-students/disability-support) look to fully support all types of disabilities or impairments on a case by case basis to ensure the individual’s needs are reviewed accordingly. We endeavour to provide an inclusive learning and teaching environment, in which all students can achieve their potential. This inclusive environment looks at the way in which courses are run, the accessibility of resources and materials, assessment types and support available with professional placements. Examples of inclusive practice would include accessible buildings, lecture information being made available two days prior to learning, presentations being consistent and easy to follow (colours, text formats etc.) and optional study skills seminars or sessions that students can attend.\r\n\r\nWe are very aware of the complex needs some students may have, such as students with mobility difficulties or visual impairments. We are able to advise these students on the support available through government organisations and specific reasonable adjustments the University are able to put in place, if barriers to learning are still present. Examples could include accessible formats for reading materials, text to speech software, extra time in examinations, alternative seating, ground floor lectures or height adjustment desks.\r\n\r\n[Student Futures Support](https://www.chester.ac.uk/campus-life/support-for-students/section) pride their selves on the quality of the support that they provide students. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.1852087,
+                    "longitude": -2.8916499,
+                    "ukprn": "10007848",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "C55",
+                "changed_at": "2021-10-03T13:12:49.320Z",
+                "uuid": "8f14d575-a6c8-4a98-a936-d36f6c8ff8e5",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_one",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-03T13:12:49Z",
+                "about_accrediting_body": null,
+                "provider_code": "1TR",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Training to be a teacher with Mickle Trafford Village School Alliance of schools allows Associate Teachers (ATs) to gain a realistic understanding of the challenges and rewards of teaching by becoming an integral part of the school staff. From the start, when in school, ATs will be expected to work with students from all year groups, attend department and staff meetings, meet parents, and generally become immersed in school life. Time will also be spent away from the classroom developing professional skills and completing assessments for P.G.C.E. (delivered and assessed by The University of Chester). This approach has proved successful and developed a new generation of teachers who feel optimistic and confident about starting their teaching career.\r\nAssociate teachers will spend the majority of their training at The Bishops’ High School in Chester and a 30 day contrast placement at a partner schools close by.  All our ATs work with an experienced and supportive Subject Mentor to ensure that ATs set high standards for themselves and the pupils they teach.  \r\nIn addition to time in the classroom, days are spent with ATs from local alliances developing and enhancing professional skills.  These sessions include improving Associate Teacher's subject knowledge across the curriculum, the use of different behaviour management strategies, understanding the needs of children with SEND and learning how to use technology to enhance learning. \r\nAssociate Teachers are encouraged, where possible, to participate in residential trips alongside the children. They will gain an understanding the planning process, the need for risk assessment, prepare information for  parents and ensure medical or SEND needs are catered for  - the sort of real life school experiences that enable ATs to feel confident as they enter their NQT year.\r\nIn collaboration with Mickle Trafford Village Primary School, enrichment days help develop an understanding of the challenges facing transition between primary and high school. ATs from primary and secondary work together to create adapted tasks to be delivered in Y5, Y6 and Y7. The aim of the 3 day programme is to inspire pupils of different ages and encourage them to develop empathy and think sensitively about the lives of others.\r\nWe recognise  this training programme is intense and challenging and  endeavour to provide support throughout the year, including with making applications for teaching posts and suggestions for making positive impressions at interview later in the year.\r\nThis programme may need adaptation to meet COVID-19 restrictions.",
+                "course_length": "OneYear",
+                "fee_details": "Please note the above Fees are a guide only. \r\nFees are set by University of Chester - please check on the university website.",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "Please check DFE and University of Chester websites for details on loans and bursaries.\r\nMickle Trafford Village School Alliance have no financial incentives for this course.",
+                "how_school_placements_work": "Associate Teachers will spend the majority of their training at The Bishops’ High School and a 30 day contrast placement at a nearby secondary school.  During the training year, ATs will have experience of working with students from Key Stage 3, 4 and 5 and will also shadow the work of our pastoral team to prepare them for the role of the Form tutor.\r\n \r\nThis may be amended due to COVID-19 restrictions.\r\n",
+                "interview_process": "Candidates will be interviewed at The Bishops’ High School in Chester. \r\n\r\nThe process, which lasts half a day, will include observation of a lesson followed by a formal interview which provides candidates to reflect on the lesson they have observed and make connections to their own experience of working with young people. \r\n\r\nThis process may be amended due to COVID-19 restrictions.\r\n",
+                "other_requirements": "Ideally, candidates are expected to be able to evidence at least two weeks spent working in schools in the secondary age phase or definite placements organised and confirmed prior to starting the course. However, due to COVID-19 restrictions this may not be possible and candidates without two weeks experience in school will be considered. \r\n\r\n",
+                "personal_qualities": "This is a challenging course - resilience, good time management and energy will be needed to complete the year. Candidates are reminded that school hours are no only the ones when the children are present and Associate Teachers will be expected to be in school before and after the children are present. ",
+                "required_qualifications": "Applicants will normally: hold or be expected to gain a minimum 2:1 honours degree ( although lower grades will be considered if candidates have suitable experience in schools or related professions)\r\n\r\nGCSE grade C/grade 4 or above in English Language and Mathematics.\r\n\r\nAll successful candidates who receive an offer of a place for this course will be required to undergo checks with regards to their suitability to practice. This will include completion of Disclosure and Barring Service (DBS) there will be a charge for this.\r\n\r\n\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966466",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "N925",
+                "name": "Primary with mathematics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": {
+                    "id": 17512,
+                    "address4": "Leicestershire",
+                    "provider_name": "Inspiring Leaders with Discovery Schools Trust",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Fossebrook Primary School",
+                    "year_code": "2019",
+                    "provider_code": "1BJ",
+                    "provider_type": "scitt",
+                    "postcode": "1 School Lane",
+                    "website": "http://www.inspiringleadersscitt.com",
+                    "address1": "Discovery Schools NSPCC Training Centre",
+                    "address2": "NSPCC National Training Centre",
+                    "address3": "Leicester",
+                    "email": "jvenables@iltt.org.uk",
+                    "telephone": "01163184066",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:51:32.479Z",
+                    "updated_at": "2021-10-05T14:44:51.060Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T14:44:51.060Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Inspiring Leaders Teacher Training, is an Ofsted 'Outstanding' rated partnership of schools working across Leicestershire, Leicester and Rutland, working together to develop outstanding teachers and leaders of the future. \r\n\r\nAs Discovery Schools Academy Trust  we are committed to helping every child the opportunity to 'Discover their Potential' and believe the best way to achieve this is through outstanding teaching and leadership. \r\n\r\nAll of the schools you will be based within, aspire for our schools to be the best paces for children to learn and develop their full potential. To achieve this we need to recruit, support and invest in teachers with the passion and determination to provide outstanding opportunities and experiences for our children. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience alongside an innovative and inspiring taught programme, leading to the award of QTS and a PGCE, with our partners the University of Leicester.\r\n\r\nWe are passionate, experienced and successful at developing great teachers with 100% of our trainees being successfully employed in the past 3 years.\r\n\r\nWe offer more than just a one year teacher training programme by supporting trainees into employment in our schools and delivering ongoing career opportunities tailored to their needs.\r\n\r\n[For more information visit our websites:]\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n\r\nCall us on 0116 3184066 or email us at info@iltt.org.uk\r\n",
+                    "train_with_disability": "We are an equal opportunities provider and provide support for all our students with their learning requirements. \r\n\r\nOur partner universities provide support for trainees with different needs and learning requirements. \r\n\r\nThis can be discussed at the screening and interview process. ",
+                    "accrediting_provider_enrichments": [
+                        {
+                            "Description": "We work tirelessly to ensure that all of our trainees are supported and become great teachers. In 2018/19 of those who completed the course – 100% of them moved into jobs in local schools and are now accessing high quality support in their first year of teaching.\r\n\r\nWe work with the University of Leicester to award PGCE to all trainees on our programme.",
+                            "UcasProviderCode": "2A5",
+                            "validation_context": null
+                        }
+                    ],
+                    "latitude": 52.6672396,
+                    "longitude": -1.1643891,
+                    "ukprn": "10055365",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1BJ",
+                "changed_at": "2021-10-05T14:06:12.331Z",
+                "uuid": "d867061f-9085-4047-b7c9-ccee7c746ad8",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalencies are offerred to candidates that accept their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:06:12Z",
+                "about_accrediting_body": null,
+                "provider_code": "5W1",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Our General Primary with Maths course will require you working in two contrasting schools across our partnership, depending on the location selected. \r\n\r\nThis programme aims to support you to become an outstanding primary class teacher, whilst developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\nYou will have the opportunity to access specialist training days and experiences to develop your specialism in Maths, overseen by a national mastery specialist teacher. The programme aims to support you to become an outstanding primary class teacher, developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "Financial Support\r\n\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\n\r\n\r\n \r\n[Click here:](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "how_school_placements_work": "General Primary\r\nOur General Primary course will require you working in two contrasting schools across our partnership, depending on the location selected (Don't worry, if you apply to a Leicestershire course, we won't be sending you to Nottingham and visa versa). We call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to cover these 3 age phases: Year 1 and 2; Year 3 and 4; Year 5 and 6, ensuring you gain a variety of experience so you can work out where you would like to be when you qualify as a teacher.\r\n\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "interview_process": "“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)",
+                "other_requirements": "[Call us on 0116 318 4066 or email info@iltt.org.uk. Click here for more info](https://www.inspiringleadersscitt.com)",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\n\r\nWe are looking for candidates that have a good awareness of current educational issues and have a deep understanding and open mind about how they affect children and schools. As well as an ability to act with professionalism and integrity. ",
+                "required_qualifications": "\r\nA UK degree 2:2 and above is required. \r\n\r\nGCSE's or equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nA Level Maths grade B and above is required to be able to access the bursary, but is not an entry requirement for the course.  \r\n\r\nWork experience is recommended. \r\n\r\nILTT has a School Readiness Programme that will help you to gain the right experience in to support your application.\r\n\r\n[If you we can help you gain this school based experience please get in touch via our email infor@iltt.org.uk\r\n[Click here}(https://www.inspiringleadersscitt.com)",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12960606",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "AT64",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time with salary",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "salary",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17706,
+                    "address4": "London",
+                    "provider_name": "St Mary's University, Twickenham",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Office",
+                    "year_code": "2019",
+                    "provider_code": "S64",
+                    "provider_type": "university",
+                    "postcode": "TW1 4SX",
+                    "website": "https://www.stmarys.ac.uk/teacher-training/about.aspx",
+                    "address1": "Waldegrave Road",
+                    "address2": "Strawberry Hill, Twickenham",
+                    "address3": "Richmond upon Thames",
+                    "email": "Apply@stmarys.ac.uk",
+                    "telephone": "020 8240 2394",
+                    "region_code": "london",
+                    "created_at": "2021-07-06T10:53:48.874Z",
+                    "updated_at": "2021-08-16T14:37:44.557Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T10:40:13.055Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "St. Mary's University is graded \"Outstanding\" by Ofsted for both Primary and Secondary teacher training. \r\n\r\nCome and meet us. The university runs 'Getting into Teaching' open events where you can chat with the tutors. Book via https://www.stmarys.ac.uk/open-events/pgce.aspx\r\n\r\nFor further details: (https://www.stmarys.ac.uk/teacher-training/become-a-teacher.aspx )\r\n \r\nWhere to find us:  (https://www.stmarys.ac.uk/contact/overview.aspx)\r\nStudent Life:          (https://www.stmarys.ac.uk/student-life/overview.aspx)\r\n \r\nTrainee teachers at St Mary's have very high employment statistics,  with many securing jobs in in our partnership schools.\r\n \r\nStudent feedback, and our recent OFSTED report (February 2019), highlights the quality of the pastoral care provided through the training programmes and the support offered by partner schools. \r\n \r\nSt. Mary's University is situated in Strawberry Hill, Twickenham - a leafy part of Greater London (5 minute walk from Strawberry Hill mainline from London Waterloo) and good local bus links for other central London connections.\r\n \r\nPublic Transport: https://www.stmarys.ac.uk/contact/overview.aspx\r\n \r\nWe will soon celebrate 170 years in Education in south west London. St Mary's is London's second largest teacher training course provider, with a significant proportion of our 6,000 students training to teach on primary and secondary initial teacher training courses.\r\n \r\nKey Facts\r\nClose partnership between the University and partner schools in all aspects of the course\r\nEducational theory closely related to practical reality of the classroom\r\nBespoke personal tutor support\r\nStrong focus on subject knowledge development\r\nSupport for those with an area of interest in SEND and EAL\r\nHigh employability rates for PGCE Trainee Teachers\r\nOngoing support into your NQT year and your career beyond\r\nOngoing Masters study opportunities at discounted rates",
+                    "train_with_disability": "St. Mary's University has a fully supportive and well-resourced  Student \r\nWellbeing service to support trainees with disabilities and other needs.\r\n\r\nAt interview, we encourage candidates to disclose any additional needs requiring support so that early support can be in place for the PGCE course.\r\n\r\nFor further information on Disability Access: (https://www.stmarys.ac.uk/student-support/wellbeing/dyslexia-and-disability/registering.aspx)",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.437026,
+                    "longitude": -0.3350701,
+                    "ukprn": "10007843",
+                    "urn": "133895",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "S64",
+                "changed_at": "2021-10-05T14:11:52.577Z",
+                "uuid": "a94b2381-86bf-49a5-aaf5-eb4c4f49ab59",
+                "program_type": "school_direct_salaried_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "We do not offer equivalency tests ourselves, but our university partners may do although these may be at a cost to the candidate.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:11:52Z",
+                "about_accrediting_body": null,
+                "provider_code": "1KV",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Ada Lovelace High School is one of four Twyford Trust schools. The Trust's ethos is strongly and distinctively Christian, with an emphasis on developing socially responsible individuals with a sense of their own capacity to do and be good. The Trust prides itself on embracing 'life lived to the full'; a concept that we have developed as our 10:10 ethic.\r\n\r\nAda Lovelace opened as a Free School in September 2018 and last year we moved into our new school site with year groups 7 through to 10. \r\n\r\nThe School Direct Chemistry programme at Ada Lovelace CE High School begins in September 2022. Upon successful completion of the training programme in summer 2023, you will gain  Qualified Teacher Status (QTS) .\r\n\r\nAll schools in the Teach West London Ealing secondary partnership are highly supportive and inspirational environments where you will develop the necessary skills and acquire a true appreciation of the practice essential for outstanding teaching and learning. You will learn your craft in a safe environment which allows you to experiment with teaching styles, strategies and ideas.\r\n\r\nYour training will be delivered by expert teachers within the school. You will participate in weekly professional development sessions which will cover a wide range of topics and school policies which will be of use to you in your subject area and in the school as a whole. You will also attend Alliance-wide Golden Day  training events along with fellow trainees. Your school-led training will be complemented by attendance at St Mary's University.\r\n\r\nYou will be assigned an experienced mentor from within your subject area at Ada Lovelace CE High School who will support you in your development over the course of what will be a challenging and rewarding year. All mentors are excellent teachers who are well-trained in mentoring, coaching, lesson observations and feedback skills. You will also work closely with a member of the Senior Leadership team who will oversee a great deal of your training and will provide an invaluable perspective on your role as a teacher and the wider issues of education leadership.",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "As well as your main training placement at Ada Lovelace CE High School, you will complete a six-week placement in a contrasting context within Ealing; this will afford you the opportunity to experience working with different students, within different structures and with a wider range of colleagues.",
+                "interview_process": "Shortlisted applicants will be invited to an interview at school and to take part in some or all of the following activities: a presentation; a written task; small group teaching; curriculum discussion and an interview. You will be told in advance if you are required to prepare a presentation or to teach.\r\n\r\nIt is a rigorous and thorough process designed to ensure successful applicants are well placed to succeed.\r\n\r\nPlease note that we recruit on a rolling basis and usually offer only one position per subject area (unless otherwise stated). We suggest that you apply early as popular subjects are filled quickly.",
+                "other_requirements": "You must have 3 years full-time (or equivalent) work experience (this does not have to be from an educational setting).\r\n\r\nSchool experience is also essential if you are interested in applying for School Direct at one of the Teach West London Ealing secondary partnership schools. We prefer that candidates have up to 10 days of recent experience in a UK school. If you have arranged some classroom experience but it is yet to take place, please make a note of this in your application.\r\n",
+                "personal_qualities": "We seek to appoint applicants who exhibit a passion for and excellent knowledge of their subject and a commitment to the education of all young people.  \r\n\r\nIt is anticipated that all successful applicants will participate fully in the life of the school and therefore it is essential that trainees are very well organised, hardworking and enthusiastic. \r\n\r\nWe look to appoint those with the potential to become outstanding teachers, with this in mind, it is crucial that applicants are resilient, reflective and responsive to advice.",
+                "required_qualifications": "Before the start date of the training programme you must hold a UK degree (or equivalent). You should preferably have a 1st or a 2:1 in a relevant subject area. It is also preferable that you have at least 3 Bs at A level (or equivalent). All applicants must have at least a C in GCSE English, Maths and Science at the time of application.",
+                "salary_details": "Teach West London Ealing secondary partnership Salaried School Direct trainees will be paid on the Unqualified Teacher Pay Scale (Band A, Inner London) area.\r\n\r\nTeach West London Ealing secondary partnership schools offering Salaried places in Maths, Physics and Computing will pay trainees at least £25,000 as a result of additional funding being offered by the government. \r\n\r\nSalaries for other subjects will vary depending on the subject and salary.\r\n\r\n"
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969243",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "37Z2",
+                "name": "Modern Languages (Spanish)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17408,
+                    "address4": "Newcastle upon Tyne",
+                    "provider_name": "University of Newcastle Upon Tyne",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Dawn Bell",
+                    "year_code": "2019",
+                    "provider_code": "N21",
+                    "provider_type": "university",
+                    "postcode": "NE1 7RU",
+                    "website": "https://www.ncl.ac.uk/ecls/study/postgrad/teacher/",
+                    "address1": "Admissions",
+                    "address2": "Level 3",
+                    "address3": "King's Gate",
+                    "email": "pgce-education@ncl.ac.uk",
+                    "telephone": "0191 208 6017",
+                    "region_code": "north_east",
+                    "created_at": "2021-07-06T10:50:15.994Z",
+                    "updated_at": "2021-08-03T08:26:11.916Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T11:04:10.485Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The PGCE Team pride ourselves on providing our students with an excellent standard of education, training and practical teaching experience and are delighted that Newcastle university achieved A Gold Award, in the Teaching Excellence Framework (TEF), evidencing that Newcastle University consistently delivers outstanding teaching, learning and outcomes, for our students. Similarly, we were given a ‘judgement of Confidence by the The Quality Assurance Agency for Higher Education (QAA). We also pride ourselves personal support we give to our students and you will have full access to the extensive services of the ‘Student Support Service’.\r\n\r\nNewcastle University has a reputation for world-class research (16th in the UK) and the PGCE team work closely with our colleagues to ensure our subject and professional programmes are research led and well informed.\r\n\r\nOur PGCE programme, rated Good by Ofsted in 2017, provides rigorous academic and school training. University and school-based components are integrated so that learning is relevant to your practice and development as a confident and capable teacher.  To support you, you will have access to a wide range of study facilities, including all relevant course materials , a well-stocked Education Resource Centre and the comprehensive facilities of the university. You will also have full access to the extensive services of the ‘Student Support Service’ \r\n",
+                    "train_with_disability": "The PGCE Team welcome applications from students with disabilities.  Advice, information and guidance is available from the university Student Support Services, who liaise with us over students’ support requirements, and may liaise with external agencies where appropriate. Disabled Students' Allowances (DSA) is a non-means tested grant available to U.K. disabled students who are applying for, or are attending, a course of Higher Education. There are specific eligibility conditions related to residence in the UK, which have to be met to qualify for this funding.  DSA allowance covers some additional study-related costs that students will incur because of a disability, ongoing medical condition or mental health condition. Extra costs may include specialist equipment, a non-medical helper or travel costs. If you are invited to an interview for PGCE is often a good opportunity to arrange to meet with one of the Disability Advisers, to talk about your support requirements. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 54.9789749,
+                    "longitude": -1.6135961,
+                    "ukprn": "10007799",
+                    "urn": "133852",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N21",
+                "changed_at": "2021-10-05T14:14:08.894Z",
+                "uuid": "bd7a49a6-5647-416d-81d3-6e9a21a9df69",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:14:08Z",
+                "about_accrediting_body": "",
+                "provider_code": "14U",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This is a one-year full time Initial Teacher Education course leading to the academic award of Postgraduate Certificate of Education (PGCE) and Qualified Teacher Status (QTS). At university, trainees undertake three Masters level modules towards their PGCE: Subject Pedagogy in Practice, Developing Critical Perspectives and Curriculum Development Through Enquiry in Practice. Successful trainees are awarded 60 Masters level credits which they can choose to carry forward to the full Master’s course at a later stage. Our School Direct programme provides a wealth of opportunity for trainees to demonstrate evidence of the Teachers’ Standards required for QTS.\r\n\r\nOur School Direct programme is designed to train teachers in the classroom. Our vision to develop expert teachers and leaders of the future starts with all trainees becoming part of the staff team from the beginning of the academic year. Trainee teachers will learn from experienced colleagues and work closely with the staff in the MFL department. You will be given experience of KS3, KS4 and KS5. The vast majority of the year is spent in the host school that you apply to and you will be allocated a contrasting placement which will include six weeks of teaching elsewhere. Contrasting placements are key to the development of all trainee teachers in order to develop a broader understanding of different educational settings.",
+                "course_length": "OneYear",
+                "fee_details": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/f8x1/#fees-and-funding)",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/3072f/)",
+                "how_school_placements_work": "You will spend the majority of the year and undertake most of your teaching commitments at your host school. A contrasting placement will be arranged for you with consideration given to your location, transport, childcare, etc. By placing you in a contrasting school you will gain invaluable experience which help you to develop a range of teaching skills. We only use schools that we know will give you the help and support you need during your placement, including a professional tutor and subject mentor. Weekly mentor meetings and at least one formal lesson observation will occur each week during your teaching practices.",
+                "interview_process": "Newcastle University’s Admissions Team will conduct an initial eligibility check, to determine whether you meet the eligibility criteria. The school you have applied to will then consider your application and agree whether to invite you to interview. If you are selected for interview, you will be sent information about the interview process, together with guidance on how to prepare. The interview process will take approximately half a day at whichever school you have applied to within the alliance. It is important that you spend some time in the school that you are applying to and you will be given an opportunity to talk to some key staff. You will be required to teach an observed lesson; you will be told in advance about the content and the age group you will be teaching as well as any other relevant information to help you prepare. An interview will be the last part of the day where the professional tutor from the school and an Emmanuel Teacher Training Partnership representative will be present.\r\n\r\n",
+                "other_requirements": "You will be required to undergo an enhanced DBS and fitness to teach check to verify your suitability for working with young people. \r\n\r\nWe recommend you spend at least a few recent working days in a UK secondary classroom before applying. This will inform your application and any later performance in the selection process.\r\n\r\nSubject Knowledge Enhancement (SKE) can be organised where necessary and funding arranged to cover costs. You could get a tax-free SKE bursary of £175 per week.",
+                "personal_qualities": "We are looking for trainee teachers who possess a range of personal qualities including:\r\n\r\n* The ability to communicate in English competently, confidently and clearly to a level that facilitates good quality oral and written communication with pupils, parents and colleagues.\r\n* Self-motivation\r\n* Confidence\r\n* Patience\r\n* Compassion\r\n* Enthusiasm\r\n* Resilience\r\n* Initiative\r\n* Team player\r\n* Good organisational skills\r\n* Effective time management\r\n* Passion\r\n* The desire and drive to transform children through education.\r\n",
+                "required_qualifications": "An honours degree (2:2 or above) or equivalent. At least 50% of your degree should be in the subject that you intend to teach. We may accept closely related degree subjects.\r\n\r\nGCSEs or O Levels (grades A–C/ 4-9) in English language and mathematics, or equivalent.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12970313",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "U840",
+                "name": "Primary",
+                "study_mode": "part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17369,
+                    "address4": "Worcestershire",
+                    "provider_name": "University of Worcester",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions",
+                    "year_code": "2019",
+                    "provider_code": "W80",
+                    "provider_type": "university",
+                    "postcode": "WR2 6AJ",
+                    "website": "https://www.worcester.ac.uk/about/academic-schools/school-of-education/get-into-teaching-at-worcester/home.aspx",
+                    "address1": "Henwick Grove",
+                    "address2": "",
+                    "address3": "Worcester",
+                    "email": "admissionsb@worc.ac.uk",
+                    "telephone": "01905 855111",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:49:48.599Z",
+                    "updated_at": "2021-09-10T14:20:48.294Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T14:38:58.568Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Worcester has a long-standing reputation for training excellent, highly employable teachers. Personalised academic and professional tutoring, from a range of experienced tutors and mentors, ensures that you will be supported throughout your course and in transition from trainee to teacher. With extensive research profiles, your learning is shaped by those helping to shape education itself. \r\n\r\nYou will benefit from our excellent partnerships with schools, in a wide range of locations. With excellent support and dedicated school experience tutors, you will have the opportunity to flourish as an effective teacher.\r\n\r\nOur PGCE courses offer Master's-level credits as well as Qualified Teacher Status, and provide excellent opportunities.\r\n\r\nOur Primary courses include a high quality tailored programme of training in all National Curriculum subjects, in addition to SEND and RE. \r\n\r\nTrainee teachers at Secondary level can choose to add depth to their qualifications by involvement in additional enhancement activities in key areas such: as Special Educational Needs and Disabilities; working with learners who have English as an Additional Language; developing expertise in Citizenship; developing skills in a second STEM subject; preparing to be Education Leaders; developing skills in Technology Enhanced Learning; teenage mental health education; education in climate emergency; research in education.\r\n\r\nAt Secondary level we also offer pre-training Subject Knowledge Enhancement courses in a range of subjects for those who need them.\r\n\r\nOur inclusive courses attract applicants from a range of career and study backgrounds, including career changers and we welcome applications from all who meet our entry requirements. ",
+                    "train_with_disability": "The University of Worcester offers a wide range of support and advice to disabled students and also to parents, staff and those external agencies supporting disabled students.\r\n\r\nOur Disability and Dyslexia Service offers support, advice and guidance to students who have a disability, medical condition or Specific Learning Difficulty (SpLD). This support lasts throughout a student’s studies at the University of Worcester. We also work with and offer support and advice to University staff on how to meet the needs of disabled students.\r\n\r\nWe can provide assistance through:\r\n \r\n* Supporting disabled students with general enquiries\r\n* Implementing special arrangements for lectures, exams and field trips. This might include notes in advance or special arrangements in exams.\r\n* Where appropriate, we can arrange note takers, academic support tutors, library assistance, interpreters and transcribers.\r\n* Help with applying for the Disabled Students Allowance (DSA) which is there to fund these types of support in higher education.\r\n* Limited loans of equipment\r\n* Confidential advice and support for students and staff\r\n* Training and awareness raising workshops\r\n* Assistive technology ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.1970053,
+                    "longitude": -2.2428253,
+                    "ukprn": "10007139",
+                    "urn": "133911",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W80",
+                "changed_at": "2021-10-05T14:29:33.827Z",
+                "uuid": "015f1170-d581-4322-a3c4-c89e82f86753",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalency tests can be arranged through The University of Worcester",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "January 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:29:33Z",
+                "about_accrediting_body": "Our accredited partner, the University of Worcester, offer an immersive and inspiring, school-centred training route into teaching.\r\n\r\nAt Worcester the PGCE: School Direct Primary is tailored to your needs - building on your existing strengths and expertise. Our course is inclusive and innovative in its design and delivery, and places you at the heart of a thriving school community.\r\n\r\n\r\n*Full immersion in the daily life of a school \r\n*Breadth and depth of experience across a range of schools\r\n*Outstanding additional opportunities for enrichment and extension\r\n*A dynamic taught programme, \r\n*Unparalleled personal and academic support throughout the programme and beyond\r\n",
+                "provider_code": "2L6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Arden Forest Teaching Alliance, led by Welford on Avon Primary School is delivering a part time Early Years School Direct Initial Teacher Training course in association with the University of Worcester beginning January 2022.\r\n\r\nAlongside your time in school, learning from experienced and highly skilled teachers, you will attend a number of taught sessions led by both the University of Worcester and lead schools.\r\nYou will be supported, whilst on the programme, by an experienced  school mentor and a University link tutor who will help guide your development, assess your progress and support you to maximise your potential.\r\nThe course is carried out 19 months starting in January 2022 and completes in July 2023\r\nThe course offers:\r\n•\tSchool experience in different primary settings\r\n•\tExcellent preparation to teach all National Curriculum subjects\r\n•\tOpportunity to train as a teacher in the primary phase on a part time basis\r\n•\tA grounding in primary pedagogy across the whole curriculum\r\n•\tResearch-informed teaching\r\nDuring the course, you will:\r\n•\tApply theoretical and practical knowledge and understanding of how children learn and develop in classroom settings\r\n•\tManage different patterns of organisation and styles of teaching to best support effective learning and provide equality of opportunity for all children\r\n•\tDevelop an understanding of SEND through the application of inclusive teaching practices\r\n•\tDevelop and demonstrate the knowledge, skills and teaching competence which will enable you to observe, plan, teach, organise and assess children’s progress and learning across the full primary range\r\n•\tDevelop a clear framework for your own professional values and demonstrate a critical and reflective attitude towards your practice\r\n•\tEvaluate sequences of learning and their impact on pupil progress, linking it to current education research\r\nIndicative course structure (subject to adaptation):\r\n•\tThe Developing Teacher: Covers a wide range of knowledge, skills and understanding required to be an effective, self-evaluating practitioner\r\n•\tThe Learning Child: Covers learning theories, child development and subject pedagogies within the primary curriculum including English, mathematics, science and computing, art, design and technology, geography, history, languages, music, PE, RE and PSHE\r\n•\tLife In School: School Experience with 120-days minimum in school in line with current Department for Education guidance to achieve Qualified Teacher Status\r\n•\tMost weeks will be for three days with a mixture of school placement and university lectures.\r\n\r\n",
+                "course_length": "19 months",
+                "fee_details": "Every course has day-to-day costs for essential books, stationery, printing and photocopying.\r\nTravel costs for placements vary depending on the location of schools and your mode of transport\r\n \r\n",
+                "fee_international": 14100,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will have placements in two schools over the duration of the part time course. Your school placements will be within commuting distance.\r\nWhen choosing school placements we will try to take your journey time into consideration.\r\nWe work with a number of partner schools in the local area. Most will be within range of the Welford Primary School, but sometimes they can cover a wider area.\r\nWe work very closely with our extensive range of partnership schools, to provide you with high quality, carefully chosen placements that, alongside your taught programme, prepare you for your first teaching post and Early Career Teacher (ECT) induction period.\r\n",
+                "interview_process": "Trainees are recruited through a selection process that includes an initial check to ensure that all entry requirements are met. At interview, you may be asked to:\r\n•\tComplete tasks to establish subject knowledge in English and Maths\r\n•\tEngage in observed professional discussions on a current educational topic\r\n•\tEngage in discussion with primary lecturers/school partners on a range of education-related questions\r\n•\tYou will be encouraged to discuss current issues in primary and/or early years education, policy and practice\r\nApplicants invited for interview will receive a comprehensive interview pack with detailed information about the day. We want all our applicants to feel prepared and ready for the interview process.\r\nApplicants will be informed of the interview panel’s decision once all the necessary paperwork has been processed. \r\nReferences: For your application, you will need two references.\r\n",
+                "other_requirements": "All successful applicants will be subject to a full DBS check. ",
+                "personal_qualities": "We are looking to recruit trainee teachers who are excited by the thought of training to teach in a primary school.  Teaching is a challenging profession and trainees need to be enthusiastic about working in a school based setting as well as resilient to the challenges of a demanding course. \r\nYou will inspire, excite and nurture children through a crucial stage of their development and motivate children a providing a safe and secure environment.\r\nYou will motivate and stimulate a child's learning abilities, often encouraging learning through experience preparing them for the start of their primary school years. ",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12960078",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "36N4",
+                "name": "Business Studies",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "14_to_19",
+                "accrediting_provider": {
+                    "id": 17460,
+                    "address4": "London",
+                    "provider_name": "e-Qualitas",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Programme Director",
+                    "year_code": "2019",
+                    "provider_code": "E69",
+                    "provider_type": "scitt",
+                    "postcode": "WC2H 8EE",
+                    "website": "https://www.e-qualitas.co.uk/",
+                    "address1": "Hend House",
+                    "address2": "4th Floor, 233 Shaftesbury Ave",
+                    "address3": "London",
+                    "email": "initialteachertraining@e-qualitas.co.uk",
+                    "telephone": "0208 051 8774",
+                    "region_code": "london",
+                    "created_at": "2021-07-06T10:51:07.850Z",
+                    "updated_at": "2021-09-28T09:56:15.269Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-28T13:39:33.634Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a large SCITT, working with schools of all kinds (primary, secondary, special, independent) in the London area and across southern England. We have rolling recruitment, meaning that trainees can start in September or later in the academic year. \r\n\r\nOur course suits those who are independent, self-motivated learners. An individual training plan guides each trainee; we have an extensive on-line library, and training days in central London complement the in-school training. Trainees are assessed every five weeks, which ensures that they know what they have done well, and what to focus on next. Each trainee has a visiting tutor who is a secondary subject, or primary, specialist. Tutors visit their trainees for a full day each half term. These visits include two lesson observations of the trainee, feedback on strengths and development points, and a check on progress overall.\r\n\r\nOur aim is that all our trainees become excellent teachers. Everything we do is focused on this. In each of the last three years, two-thirds of our trainees have been graded 'excellent' in the final assessment for QTS. Over 90% have been appointed to a teaching post in the school in which they trained or did a placement (a few take teaching posts in other schools).  \r\n",
+                    "train_with_disability": "Our course is designed to be flexible and responsive to individual needs. As a group of full-time trainees starts each term, trainees who aren't able to train on a full-time basis, or who become ill and need time off during the course, don't miss out on any training as they join in with the next group of trainees. Adapted tasks are available for students whose dyslexia makes it hard to write full essays for their assignments. Training day venues have wheelchair access, and cater for all dietary requirements. We ask trainees to let us know of any disability or other need, so that we and the partner schools can make appropriate arrangements.\r\n\r\nTrainees who wish to gain a PGCE as well as QTS can add the academic award through our higher education partner. As we do not have a compulsory integral PGCE we have great flexibility in meeting our trainees' individual training needs eg we can adapt  coursework tasks for those who need individual arrangements, we don't have fixed coursework deadlines during the training, and our trainees can start the course when it suits them  and their school during the academic year.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.5163012,
+                    "longitude": -0.1266746,
+                    "ukprn": "10046623",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "E69",
+                "changed_at": "2021-10-01T06:54:41.367Z",
+                "uuid": "029ffcff-873e-4989-b44b-34d1c67ca893",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_one",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T06:54:41Z",
+                "about_accrediting_body": "",
+                "provider_code": "15O",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "If you are looking for a teacher training course in which you spend most of your time in-school while you study, this course may be for you.\r\nYou work with experienced teachers, first of all observing and team teaching, then teaching independently. This is complemented by a placement of about 6 weeks' teaching in another school plus various other visits. Your study is based on the distance learning resources on the eQ virtual learning environment (VLE). Training sessions are provided by experienced school staff, and you attend some training days run by eQ (up to about 10 days, mostly held in a venue in central London). You also have a subject-specialist visiting tutor from eQ.\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "You will be charged £6,000 + VAT, plus £2,000 which is a disbursement to be paid to the school in which you are based during your training.\r\nApplications for support in the form of tuition fee loans and maintenance loans should be submitted to the Student Loans Company. The maximum student loan is £6,000 for teacher training with e-Qualitas. You may be eligible for a maintenance loan to cover living costs while you undertake initial teacher training.\r\nYou may also be eligible for a tax-free training bursary, payable in monthly instalments during the course. This does not have to be repaid. Further details are available on the Get into Teaching Website.\r\n",
+                "fee_international": null,
+                "fee_uk_eu": 8000,
+                "financial_support": "For up to date information about bursaries and available financial assistance please visit \r\n\r\nhttps://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training",
+                "how_school_placements_work": "Candidates as part of the application process:\r\n* nominate a school to train within \r\n* the age range they wish to teach \r\nCandidates will spend the majority of their time within their nominated school but will also undertake, at least, a six week placement in a second school. The second school must be a contrasting school to their main school. \r\nSt John Southworth Enterprise and Research Alliance consists of some 30 schools which are a mixture of primary and secondary schools. This allows the Alliance to ensure that we are able to meet the needs of the candidates across a wide range of schools. ",
+                "interview_process": "Candidates will normally be interviewed by a member of the Senior Leadership Team and the Head of Department. Interviews are structured into two parts - the first part of the interview will discuss with candidates their motivation for entry into the teaching profession. While the second half of the interview looks at the candidates understanding of the education system in England. As part of the interview candidates may be asked to teach a lesson of about 30 minutes to a class. Candidates may be asked to undertake a written task as part of the interview. ",
+                "other_requirements": "All offers of places are subject to a Disclosure and Barring Service (DBS) enhanced disclosure with list check. If you are offered a place, you will be asked to provide a signed declaration relating to any police record. Contact the SJSERA Office  or the e-Qualitas office if you need guidance on whether an offence or conviction may preclude you from teaching.\r\nAll trainee teachers must also meet the Secretary of State's requirements for physical and mental health. In practice, few health problems preclude applicants from teaching, and so we welcome applications from people with disabilities.\r\n",
+                "personal_qualities": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context. These personal attributes include:\r\n1. Subject knowledge \r\n2. Motivation to become the best teacher possible.\r\n3. Ability to analyse and learn from experience, and to act on feedback.\r\n4. Creativity and imagination.\r\n5. Capacity for hard work.\r\n5. Perseverance.\r\n6. Good organisational skills.\r\n7. Empathy and a liking for young people.\r\n8. Ambition to make a difference by becoming an inspirational teacher.\r\n",
+                "required_qualifications": "We give priority to applicants who have grade B in GCSE English and GCSE maths. We do not accept adult literacy and adult numeracy as equivalent to GCSE. If you do not meet the GCSE requirement, you can do an equivalence test. Applicants should have a good honours degree. If your degree is not in the subject you are applying to teach, you must explain how you have degree-level expertise in the subject.  If your qualifications are from overseas, they must be checked for UK equivalence by NARIC.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12956725",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "24NY",
+                "name": "Mathematics",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17562,
+                    "address4": "Kent",
+                    "provider_name": "Canterbury Christ Church University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "PGCE Admissions",
+                    "year_code": "2019",
+                    "provider_code": "C10",
+                    "provider_type": "university",
+                    "postcode": "CT1 1QU",
+                    "website": "https://www.canterbury.ac.uk/study-here/train-to-teach/train-to-teach.aspx",
+                    "address1": "North Holmes Road",
+                    "address2": "",
+                    "address3": "Canterbury",
+                    "email": "PGadmissions@canterbury.ac.uk",
+                    "telephone": "01227 926699",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:52:05.705Z",
+                    "updated_at": "2021-09-29T09:23:50.439Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T09:23:50.439Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Canterbury Christ Church University (CCCU) is one of the largest and well-respected providers of postgraduate initial teacher education in the country.  We offer a wide range of programmes leading to Qualified Teacher Status (QTS) for those wishing to teach in primary and secondary schools and a variety of qualifications for those wishing to teach in further education sector. Ofsted has praised us for our high employment rates and said that CCCU is making a significant contribution to teaching in the local area.\r\n\r\nOur courses offer a blend of subject knowledge and theory which is directly linked to school-based teaching and learning.  We aim to help you become a confident, high-achieving teacher.  You will develop a wide range of strategies for supporting children and young people’s learning to help them maximise their learning.\r\n\r\nYour learning will be underpinned by the latest research so you will receive up-to-date provision. You will be supported by tutors and mentors who are all qualified teachers. Our students regularly comment on how friendly and supportive the university and course team are.   \r\n\r\nOur range of placements mean that you will gain a wide experience of education and learning in different settings. You will have an excellent support network both in school and at university. \r\n\r\nRead more about our courses at https://www.canterbury.ac.uk/study-here/train-to-teach/train-to-teach.aspx ",
+                    "train_with_disability": "Canterbury Christ Church University is committed to ensuring that you can succeed and reach your full potential.  We have a range of support services to help you both during your application and during your course.  Please see our website at https://www.canterbury.ac.uk/study-here/student-life/supporting-you-to-succeed for more information and contact details.\r\n\r\nDepending on your need, we can offer special arrangements such as accessible interview rooms, access to a hearing loop, use of a laptop to complete written tests and information printed on coloured paper.\r\n\r\nIf you are dyslexic or believe you might be, we can help you with support  which includes screening and learning support. Examples of support we have provided for dyslexic students in the past include extra time for exams and consideration for spelling and grammar.  \r\n\r\nA dedicated team of mental health practitioners can help you with any mental-health related queries. You are able to access support services including resources and techniques to help with anxiety, stress and depression.  They also refer students for counselling both within the University and externally.  If you have been diagnosed with a long-term psychological condition, the team can help you access further support which includes help with accessing funding and tailored.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.277939,
+                    "longitude": 1.090659,
+                    "ukprn": "10001143",
+                    "urn": "133806",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "C10",
+                "changed_at": "2021-10-02T14:47:34.693Z",
+                "uuid": "6df6335b-5490-4807-9ae5-4972715cb3e3",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Third party tests are accepted after agreement with the provider.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-02T14:47:34Z",
+                "about_accrediting_body": null,
+                "provider_code": "19C",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Trainees learn on the job in a supportive environment with a mentor throughout their training.  The majority of the training takes place on the 2 school placements and trainees attend 15 training days at Canterbury Christ Church University.  Trainees are assessed through an ongoing system of internal and external evaluation which leads to a final assessment process.  Trainees will be provided with a timetable within their subject area and work across all the Key Stages.",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 5960,
+                "financial_support": "",
+                "how_school_placements_work": "Secondary trainees spend the majority of their time in 1 base school.  They spend a 1 month block in a comparative school and complete a shorter placement in a primary school.  Primary trainees complete a second placement of 1 month in a different Key Stage or setting and complete a short placement in a secondary school in Key Stage 3.",
+                "interview_process": "Trainees are interviewed by the individual schools that are looking to train future teachers.  Trainees are asked to teach a micro lesson, complete literacy and numeracy tests provided by Canterbury Christ Church University and attend an interview.",
+                "other_requirements": "",
+                "personal_qualities": "Trainees ideally need some experience of life in a school.",
+                "required_qualifications": "A relevant Degree \r\nGrade C/4 in English and Mathematics and C/4 in Science for primary applicants",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964063",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Y351",
+                "name": "Physical education",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-22T13:32:56.257Z",
+                "uuid": "de651849-2b8f-49fa-9a4a-42602faf172a",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "The cost of an equivalency test is £65.00",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-22T13:32:56Z",
+                "about_accrediting_body": null,
+                "provider_code": "2B5",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "During the initial teacher training year Hillingdon SCITT Trainees will not only learn about pedagogy in general but they will also learn about subject specific pedagogy.  Hillingdon SCITT Trainees will be trained to teach 2 consecutive Secondary Key Stages (KS3 and KS4) in their chosen subject.  Trainees will also experience some KS5.  Simultaneously Trainees will also be given the opportunity to improve and expand their subject knowledge. During the training year, Trainees will also have the opportunity to teach a 2nd subject of their choice.\r\n\r\nAll Trainees will spend 4 days a week in school.  This will comprise of teaching, being observed and receiving feedback, observing and learning from experienced colleagues as well as professional development.  The 5th day will be a Professional Learning day with Hillingdon SCITT, which will be held at Bishop Ramsey CE School (which is where Hillingdon SCITT is based) and will be delivered by highly experienced and skilled practitioners.  As part of their Professional Learning, Trainees will undertake an Action Research Project of their choice (which will be the main task for QTS).  \r\n\r\nTrainees will experience teaching in 2 different Partner Schools.  Trainees will also have the opportunity to observe teaching and learning in other educational settings eg. Special Schools, Pupil Referral Unit and Primary Schools. Whilst on placement, the amount of lessons that a School Direct Fee Funded (unsalaried) trainee will be expected to teach is incremental according to each training phase.  A teaching timetable will be created that is bespoke to teach trainee based upon their prior experience and readiness to teach.  \r\n\r\nThroughout the year, Trainees will have a designated Mentor/Coach supporting them as well as, Phase and Subject Leads from Hillingdon SCITT.  In order to achieve QTS, all Trainees at calendared intervals throughout the year will be assessed against their mastery of Hillingdon SCITT's Professional Learning Curriculum followed by the Teachers' Standards at the end of the course.\r\n\r\n\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "£7,050 is the fee for QTS (accredited by Hillingdon SCITT) \r\n\r\n",
+                "fee_international": null,
+                "fee_uk_eu": 7050,
+                "financial_support": "The following types of funding available for teacher training.  The type of funding available will depend upon your circumstances.  \r\n\r\n- Tax free Bursary (only available for certain subjects)\r\n- Tuition Fee Loan \r\n- Maintenance Grant\r\n- Additional financial support if you are a parent or have a disability",
+                "how_school_placements_work": "During the training year Trainees will teach in 2 different Partner Schools. Trainees will be spend the majority of the year in one main placement school (where they were interviewed).  The 2nd placement is for the duration of 6 weeks, whereby Trainees will be placed in a contrasting school. The majority of our Partner Schools are located in Hillingdon, with others in neighbouring boroughs. \r\n\r\nOur Partner Schools have excellent public transport links including buses and the National Rail network (underground and overground).  Full directions to the schools in the Partnership can be found on their websites. Central London is within easy reach. \r\n",
+                "interview_process": "In conjunction with the Lead School, Hillingdon SCITT will co-ordinate the recruitment process.\r\n\r\nThe recruitment process will involve between half a day and a full day being spent at one of the Partner Schools, which is likely to be your main placement school for the duration of the training year.  \r\n\r\nThe recruitment day will include:-\r\n\r\n- Teaching a lesson or working with a group of students which will be observed by a qualified teacher (you will be told in advance about the content of the lesson and the age group you will be teaching).\r\n\r\n- A short presentation (applicants will be given the information prior to the interview for this).\r\n\r\n- English and Maths tests.\r\n\r\n- An interview (the panel will consist of representatives from Hillingdon SCITT and the Partner School).\r\n\r\n- There may also be the opportunity to talk to staff and pupils and possibly a tour of the school.\r\n \r\nIt is a rigorous and thorough process, designed to get the best match of applicant to the places available\r\n\r\n",
+                "other_requirements": "Successful applicants will be subject to:-\r\n\r\nTeachers' and Others Prohibited from the Profession check\r\nSection 128 Barring Directions\r\nEhanced Disclosure Barring Service Checks\r\nChildcare Disqualification Declaration Check\r\nHealth Screening\r\nSafeguarding References\r\nInternational Checks",
+                "personal_qualities": "We are looking for ambitious applicants who are passionate, enthusiastic, committed and have a desire to share that with children and young people of all abilities.",
+                "required_qualifications": "In order to begin the teacher training year, the following qualifications are required:-\r\n\r\n- You should be a graduate. Applicants with a 3rd will only be eligible for the QTS.)\r\n- The majority of the content from your Undergraduate Degree should be in the subject that you wish to teach.\r\n- You will need at least a Grade C or 4 in GCSE/equivalent in English and Maths\r\n\r\nIf you have completed your undergraduate degree or secondary schooling internationally, we will require a NARIC equivalence.\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964969",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2CWC",
+                "name": "Design and Technology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17274,
+                    "address4": "Solihull",
+                    "provider_name": "South Birmingham SCITT",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Administrator",
+                    "year_code": "2019",
+                    "provider_code": "N32",
+                    "provider_type": "scitt",
+                    "postcode": "B91 3WR",
+                    "website": "www.southbirminghamscitt.org.uk",
+                    "address1": "South Birmingham SCITT",
+                    "address2": "Solihull Sixth Form College",
+                    "address3": "Widney Manor Road",
+                    "email": "carol.lewis@southbirminghamscitt.org.uk",
+                    "telephone": "01217042581",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:48:41.866Z",
+                    "updated_at": "2021-10-03T21:52:36.031Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-03T22:47:03.390Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "South Birmingham SCITT …\r\n… is the perfect place for someone who doesn’t just want a job in teaching, they want a career\r\n… is a supportive, encouraging environment and the staff will go out of their way to make you a success\r\n… will help find the teacher in you\r\n\r\n*\tPrimary and Secondary Teacher Training\r\n*\tSchool – Led (SCITT and Schools Direct)\r\n*\tLearn from real teachers in real classrooms\r\n*\t100% employment rates\r\n*\tBespoke programme offering high levels of support to enable you to reach your full potential\r\n*\tQualified Teacher Status and Post Graduate Certificate in Education (MA Level7 x 60)\r\n*\t1 day in training, 4 days in placement\r\n*\t50+ exciting and innovative schools in Birmingham and surrounding areas\r\n*\tStrategic partners of a number of Teaching Schools to secure individuals early career entry and opportunities into leadership\r\n*\t18 years’ experience training new teachers\r\n*\tRecognised locally and nationally for its strong provision\r\n*     The West Midlands provider of Future Scholars and Researchers in Schools Programmes\r\n*\tHighly skilled practitioners to ensure high quality learning for the trainee \r\n*\tNQTs consistently rate us in the top 10 providers via the Good Teacher Training Guide\r\n*\tFantastic partnership of innovative schools who repeatedly employ our trainees\r\n\r\nOur programmes are all the same whether they are through our SCITT or our School Direct Partners. \r\n\tSouth Birmingham SCITT \r\n\tColmore Partnership Training School Alliance\r\n        Summit Learning Trust\r\n        The Augustine Partnership\r\n",
+                    "train_with_disability": "A condition of your offer will be the successful completion of an Occupational Health Check to satisfy the requirements for Fitness to Teach. \r\n\r\nWe endeavour to meet the needs of trainees with disabilities and you are welcome to discuss any needs or disabilities with us at any time during the application process. \r\n\r\nIf you are disabled or have a specific learning difficulty, all reasonable adjustments will be made. \r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.4057217,
+                    "longitude": -1.7728004,
+                    "ukprn": "10052836",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "N32",
+                "changed_at": "2021-10-04T08:42:28.159Z",
+                "uuid": "876e6af8-0aaf-4f7b-9d9d-c51866098094",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-04T08:42:28Z",
+                "about_accrediting_body": null,
+                "provider_code": "19O",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Please visit our website at  (https://www.southbirminghamscitt.org.uk)  for further information and a map of our whole partnership\r\n\r\n* Full time; September to July\r\n* 1 day in Professional Studies training (South Birmingham SCITT site - Our training suite is located at The Sixth Form College, Solihull – 5 minutes from the centre of Solihull and 20 minutes from Birmingham City Centre\r\n* 4 days a week in school placement working with your assigned Daily Trainer and Lead Trainer\r\n* Placement schools allocated primarily upon the location of trainee\r\n* Professional Studies includes research and reflective practice, routines \u0026 behaviour, teaching \u0026 learning strategies, meeting all children’s needs, the importance of assessment, understanding of the wider educational context\r\n* subject specific pedagogy days - (Secondary held at Birmingham City University Campus on Mondays, Primary held at South Birmingham SCITT site)\r\n* Trainees become reflective practitioners with specific targets to move their practice forwards\r\n* Weekly reflection of teaching practice collates evidence and will culminate in a final assessment against the Teachers Standards to be awarded Qualified Teachers Status (QTS)\r\n* 3 research assignments (3000 words each - Nov, Feb and May submission)\r\n* 60 Level 7 Credits towards a Masters in Teaching and Learning \r\n* Ongoing early career development.  Birmingham City University offer  the opportunity to continue and complete your full Masters in subsequent years\r\n* One-to-one support in securing your teaching career\r\n* Expert support via School Based Trainers, Professional Tutors, Subject Tutors, Ex-Trainees and BCU Tutors – and cohort peers! \r\n\r\nOur programmes are all the same whether they are through our SCITT or our School Direct Partners. \r\n\tSouth Birmingham SCITT \r\n\tColmore Partnership Training School Alliance\r\n        Summit Learning Trust\r\n        The Augustine Partnership\r\n\t",
+                "course_length": "OneYear",
+                "fee_details": "£9250 tuition fee – you may be eligible for a student loan\r\nSubject dependent training bursaries may be available \r\n\r\n",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "School placements are based on two factors. The first is the home address of the trainee. We want to ensure that your travel time is accessible and not too time constraining. The second is the availability of a Partnership school in your location. We always limit travel time to no more than 1 hour from home. We will let you know your placement as soon as possible.\r\nWe have a map of all our Primary and Secondary schools on our website \r\n -  (https://www.southbirminghamscitt.org.uk)   We have a wide selection of Primary  and Secondary Schools to choose placements from -  new schools ask to join us all the time!\r\n\r\nThe majority of our trainees will complete a short placement in the Autumn term and will then be placed in their main school for the Spring and Summer Terms.  We need to ensure that the short placement will give you a contrasting experience - this may mean different size, socio-economic catchment, faith/non-faith for example. This will mean a slightly different journey for you, but we will always ensure that it is accessible, for example if you don’t drive. \r\n",
+                "interview_process": "Apply through 'Apply'  (https://www.gov.uk/apply-for-teacher-training) \r\n\r\nInterview day\r\n\r\n* 5 minute presentation about yourself \r\n* Formal panel interview\r\n* Talk through a pre-prepared 20 minute learning activity showing the intended impact on students\r\n* Group discussion activity\r\n* Subject Knowledge Baseline (to enable us to identify any specific gaps in knowledge) \r\n* Literacy and Numeracy assessments  (to inform us of support needed to ensure fundamental skills are in place)\r\n* Written reflection on the learning activity\r\n\r\nYou will have the opportunity to meet School Direct Leads, the SCITT Course Manager / Director and colleagues from the partnership. \r\nWe will inform you of our decision within 48 hours\r\nCheck out our website –  (https://www.southbirminghamscitt.org.uk)\r\n\r\n",
+                "other_requirements": "If you studied outside of the UK, you will need to visit ENIC (https://www.enic.org.uk/) as a certificate of proof for equivalence will need to be obtained. \r\n\r\nWe do not expect you to have school experience upon application. But if you would like to gain some please get in touch and we will arrange this for you. \r\n\r\nA condition of your offer will be the successful completion of all Safeguarding procedures.\r\nYou will be asked to complete an Occupational Health Questionnaire \r\n",
+                "personal_qualities": "* Enthusiasm \r\n* Dedication \r\n* Sense of humour\r\n* Passion\r\n* Resilience\r\n* Organisation\r\n* Patience\r\n* Professionalism\r\n* Reflective practice\r\n\r\nCheck out our website –  www.southbirminghamscitt.org.uk\r\n",
+                "required_qualifications": "\r\nSecondary - \r\n\r\n* GCSE Mathematics  – or equivalent – Grade C/4 or above\r\n* GCSE English Language – or equivalent – Grade C/4 or above \r\n* Degree (1st, 2:1, 2:2, 3rd)  \r\n* As a guide we would expect to see 50% of your degree and / or the ALevels that you took to be relevant to the subject in which you’re applying\r\n\r\nPlease note all applications are individually assessed. Please contact us if you would like to discuss your entry qualifications. \r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12967528",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "3BCC",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": {
+                    "id": 17369,
+                    "address4": "Worcestershire",
+                    "provider_name": "University of Worcester",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions",
+                    "year_code": "2019",
+                    "provider_code": "W80",
+                    "provider_type": "university",
+                    "postcode": "WR2 6AJ",
+                    "website": "https://www.worcester.ac.uk/about/academic-schools/school-of-education/get-into-teaching-at-worcester/home.aspx",
+                    "address1": "Henwick Grove",
+                    "address2": "",
+                    "address3": "Worcester",
+                    "email": "admissionsb@worc.ac.uk",
+                    "telephone": "01905 855111",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:49:48.599Z",
+                    "updated_at": "2021-09-10T14:20:48.294Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T14:38:58.568Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Worcester has a long-standing reputation for training excellent, highly employable teachers. Personalised academic and professional tutoring, from a range of experienced tutors and mentors, ensures that you will be supported throughout your course and in transition from trainee to teacher. With extensive research profiles, your learning is shaped by those helping to shape education itself. \r\n\r\nYou will benefit from our excellent partnerships with schools, in a wide range of locations. With excellent support and dedicated school experience tutors, you will have the opportunity to flourish as an effective teacher.\r\n\r\nOur PGCE courses offer Master's-level credits as well as Qualified Teacher Status, and provide excellent opportunities.\r\n\r\nOur Primary courses include a high quality tailored programme of training in all National Curriculum subjects, in addition to SEND and RE. \r\n\r\nTrainee teachers at Secondary level can choose to add depth to their qualifications by involvement in additional enhancement activities in key areas such: as Special Educational Needs and Disabilities; working with learners who have English as an Additional Language; developing expertise in Citizenship; developing skills in a second STEM subject; preparing to be Education Leaders; developing skills in Technology Enhanced Learning; teenage mental health education; education in climate emergency; research in education.\r\n\r\nAt Secondary level we also offer pre-training Subject Knowledge Enhancement courses in a range of subjects for those who need them.\r\n\r\nOur inclusive courses attract applicants from a range of career and study backgrounds, including career changers and we welcome applications from all who meet our entry requirements. ",
+                    "train_with_disability": "The University of Worcester offers a wide range of support and advice to disabled students and also to parents, staff and those external agencies supporting disabled students.\r\n\r\nOur Disability and Dyslexia Service offers support, advice and guidance to students who have a disability, medical condition or Specific Learning Difficulty (SpLD). This support lasts throughout a student’s studies at the University of Worcester. We also work with and offer support and advice to University staff on how to meet the needs of disabled students.\r\n\r\nWe can provide assistance through:\r\n \r\n* Supporting disabled students with general enquiries\r\n* Implementing special arrangements for lectures, exams and field trips. This might include notes in advance or special arrangements in exams.\r\n* Where appropriate, we can arrange note takers, academic support tutors, library assistance, interpreters and transcribers.\r\n* Help with applying for the Disabled Students Allowance (DSA) which is there to fund these types of support in higher education.\r\n* Limited loans of equipment\r\n* Confidential advice and support for students and staff\r\n* Training and awareness raising workshops\r\n* Assistive technology ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.1970053,
+                    "longitude": -2.2428253,
+                    "ukprn": "10007139",
+                    "urn": "133911",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W80",
+                "changed_at": "2021-10-05T14:06:13.280Z",
+                "uuid": "e244a81b-0720-494f-8b46-c06825c85a23",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalency Tests can be arranged through the University of Worcester",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:12:44Z",
+                "about_accrediting_body": "Our accredited partner, the University of Worcester, offer an immersive and inspiring, school-centred training route into teaching.\r\n\r\nAt Worcester the PGCE: School Direct Primary is tailored to your needs - building on your existing strengths and expertise. Our course is inclusive and innovative in its design and delivery, and places you at the heart of a thriving school community.\r\n\r\n\r\n*Full immersion in the daily life of a school \r\n*Breadth and depth of experience across a range of schools\r\n*Outstanding additional opportunities for enrichment and extension\r\n*A dynamic taught programme, \r\n*Unparalleled personal and academic support throughout the programme and beyond\r\n",
+                "provider_code": "2L6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Arden Forest Teaching Alliance, led by Welford-on-Avon Primary School, is running a School Direct Initial Teacher Training course beginning September 2020. \r\n\r\nThe programme is delivered in association with the University of Worcester, with trainees spending one day a week in University learning the theory and developing the subject knowledge that underpins successful teaching.  The remainder of the time will be spent in school. \r\n\r\nAssessment will come in the form of essays set and marked by the university as well as regular, ongoing assessment of teaching in school.  Lesson observations take place regularly to give trainees constructive feedback about strengths and areas for development.  Every half term there will be a visit from a university based link tutor who will observe with the school based mentor to agree grades and set appropriate future targets. \r\n\r\nSchool based training will take place largely at Welford on Avon Primary School, although other partner schools may be used for specific parts of the training programme. All our partner schools are local and within easy travelling distance of Welford on Avon.\r\n",
+                "course_length": "OneYear",
+                "fee_details": " Current Fees:\r\n\r\nUK / EU £9,250 (subject to change for 21/22)\r\nInternational £13,700 \r\n\r\n",
+                "fee_international": 13700,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "Successful trainees will be based at either Welford-on-Avon Primary School or another of our partner schools, based in and around South Warwickshire. \r\n\r\nTrainees will be based at their main school throughout the Autumn and Summer term. In the Spring term they will spend a period of several weeks on a complementary placement at another of our partner schools to broaden their experience and work in a contrasting setting.  \r\n\r\nThroughout their training we aim to give trainees a broad experience of working in both of the primary school phases - Key Stage 1 (5-7) and Key Stage 2 (7-11). ",
+                "interview_process": "Further details of the interview process will be given to successful applicants. ",
+                "other_requirements": "All successful applicants will be subject to a full DBS check. ",
+                "personal_qualities": "We are looking to recruit trainee teachers who are excited by the thought of training to teach in a primary school.  \r\n\r\nTeaching is a challenging profession but one that can be very rewarding.  Trainees need to be enthusiastic about working in a school based setting as well as resilient to the challenges of a demanding course. ",
+                "required_qualifications": "Details of qualifications are available through the University of Worcester. \r\n\r\nAn undergraduate degree\r\nGCSE passes in English, Maths and Science (or equivalencies)\r\n\r\nEquivalencies in Maths, English \u0026 Science are accepted from some providers \u0026 this will be checked on application.  The University of Worcester do hold their own equivalency tests and therefore we do accept applications without these relevant qualifications in place.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12967714",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2P7T",
+                "name": "Music",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time with salary",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "salary",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 18066,
+                    "address4": "",
+                    "provider_name": "NELTA",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "NELTA manager",
+                    "year_code": "2019",
+                    "provider_code": "251",
+                    "provider_type": "scitt",
+                    "postcode": "IG45LP",
+                    "website": "http://nelta.co.uk/programmes/initial-teacher-training-programme/",
+                    "address1": "Beal High School Upper Site",
+                    "address2": "Woodford Bridge Road",
+                    "address3": "Ilford",
+                    "email": "admin@nelta.co.uk",
+                    "telephone": "02085514954",
+                    "region_code": "london",
+                    "created_at": "2021-07-06T10:57:20.895Z",
+                    "updated_at": "2021-07-06T10:57:20.895Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-07-12T13:49:42.880Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "North East London Teaching Alliance (NELTA) is a large teaching school alliance of 20 schools. Beal High School is the lead school.\r\n\r\nWe are passionate about developing the next generation of teachers and school leaders. Teachers and leaders who will ensure an outstanding educational future for all pupils irrespective of background or ability. \r\n\r\nThe Ofsted inspection of our initial teacher training provision on 2017 said:\r\n“Leaders’ ambitious vision for excellence and their aspirations for trainees are of the highest order”\r\n“The quality of training is outstanding”\r\n“Trainees are overwhelmingly positive about the quality of mentoring”\r\n\r\n\r\nWorking with our alliance you can expect:\r\n* Guidance from an experienced school based mentor and \r\nNELTA  tutor\r\n* Very well established support programmes\r\n* Access to a wide network of schools including community secondary, primary, independent, grammar and special education\r\n* Professional development opportunities beyond your training year focused on outstanding teaching and leadership\r\n\r\nNELTA, which spans Barking and Dagenham, Waltham Forest, Redbridge, Newham and beyond, offer opportunities to work in a range of different socio-economic areas. Working in a partnership which includes independent schools, boys' and girls' grammar schools, faith schools, comprehensive schools and special schools means you will have access to a broad range of training experiences which will give you the opportunity to you develop your practice in a variety of different settings.\r\nWe offer teacher training places for both the tuition fee and salaried routes to Qualified Teacher Status. \r\n\r\n\r\n",
+                    "train_with_disability": "We are committed to supporting equal opportunities and disability access. NELTA has the full support of our  Multi-Academy Trust Human Resources department and every person is treated as an individual.\r\n\r\nWe offer information, advice and guidance to current and prospective disabled students about support that may help them to engage with their studies. When we refer to the term “disability” we also include long-term medical or mental health conditions and Specific Learning Difficulties (SpLDs).  \r\n\r\nWe have accommodated trainees in the past with a range of disabilities including mental health conditions, dyslexia and physical impairments.\r\n\r\nDisability access in schools varies according to the specific training location. Please  email us to discuss your needs [NELTA](admin@nelta.co.uk).\r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.5860169,
+                    "longitude": 0.0517167,
+                    "ukprn": "10046736",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": null,
+                    "can_sponsor_student_visa": null
+                },
+                "accredited_body_code": "251",
+                "changed_at": "2021-10-04T11:27:37.872Z",
+                "uuid": "d4c8da6b-ee33-4b6b-9268-1df3ba732c21",
+                "program_type": "school_direct_salaried_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-04T11:27:37Z",
+                "about_accrediting_body": "We are committed to working in partnership with trainees and partner schools to provide highly trained teachers for the local community and beyond.\r\n\r\nWeekly contact with other trainees and our programme tutors means that you will always feel fully supported.\r\n\r\nThe Ofsted inspection of our initial teacher training provision on 2017 said:\r\n“Leaders’ ambitious vision for excellence and their aspirations for trainees are of the highest order”\r\n“The quality of training is outstanding”\r\n“Trainees are overwhelmingly positive about the quality of mentoring”\r\n",
+                "provider_code": "1NA",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "NELTA is committed to delivering a comprehensive and bespoke training experience and supporting the development of the next generation of teachers and school leaders.\r\n\r\nThis is an innovative approach to teacher training delivered and supported by outstanding teachers and school leaders with current and relevant experience. This programme is highly supportive of the realities of the modern classroom. \r\n\r\nThis course has been designed for those who would prefer a more hands-on approach to teacher training. You may have school experience as an instructor, cover supervisor, teaching assistant or overseas trained teacher.\r\n\r\nYou will spend the majority of your training working in a local school, where you will be employed as an unqualified teacher. You will be paid at least Point 1 on the unqualified teachers’ pay scale. You will normally be allocated approximately a 50% timetable of classes that you will teach from the first day of term. The timetable allocation will increase as you gain more experience. There is a comprehensive programme of mentoring, training and support delivered by the school and NELTA. You will complete a short placement (minimum 4 weeks) at a contrasting school to allow you to meaningfully experience teaching in another context. This is an 11-16 training programme although there will be pre and post phase experience as part of the training. There will be a three day primary school placement.\r\n\r\nAs well as the school-based support from your subject mentor there is also a team of dedicated tutors who will deliver training and fully support your school placement experience. You will have small group subject tutorials every Thursday afternoon followed by a facilitated teaching and learning workshop (with all trainees) from 4.15 to 5.15. There is also a programme of five ‘extended study days’ during the year which will focus on teacher training priorities such as behaviour for learning, SEND and EAL. All training sessions are held centrally at Beal High School in our bespoke NELTA training facility.\r\n\r\nThis course aims to prepare you to: \r\nBecome outstanding secondary school teachers \r\nBecome knowledgeable subject specialists who can support the leadership of curriculum development \r\nBecome good classroom managers \r\nBecome successful form tutors and collaborative colleagues. \r\n\r\nYou will be assessed through a combination of professional practice reports (written by your subject mentor), tutor visits to see you teach, two written assignments and a portfolio of evidence to demonstrate how you are meeting the Teachers’ Standards.\r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "Most placements will be within our network of 14 secondary schools which includes community schools (maintained and academies), faith schools, boys and girls grammar schools and an independent school. The placement school itself will depend on which schools have identified themselves as willing to employ a salaried trainee. \r\n\r\nAll of our schools are geographically close, with most being within the London Borough of Redbridge which means that trainees can easily engage with more than one school in the partnership. \r\n\r\nThe age range of training is 11-16 although there is a requirement for pre and post phase experience as part of the training programme.\r\n\r\nThe majority of the time will be spent in the employing school with NELTA based training from 2.15 pm every Thursday. There are also five extended study days throughout the year. There is a requirement for a second placement in a contrasting school (minimum 4 weeks) and a three day primary school placement.\r\n",
+                "interview_process": "There is one interview which will be held at whichever school has identified itself as having a vacancy for a salaried trainee. You will be interviewed by representatives of the school (possibly Heads of Department or senior leadership) and a member of the NELTA team.\r\n\r\n\r\nThe interview process may include some or all of the following activities:\r\n \r\n* Subject knowledge activity (set before the day of the interview)\r\n* Delivery of a half hour teaching activity to students \r\n* Written task\r\n* Interview by panel \r\n\r\n\r\nWe do not give automatic feedback to all candidates rejected at interview. This is due to the large numbers of interviews that we carry out and the additional workload involved in feeding back to candidates. \r\n",
+                "other_requirements": "We have a duty to protect children and vulnerable adults, and so\r\nbackground checks will include an Enhanced Disclosure certificate from the DBS as a requirement of a place on the course.\r\n\r\nInitial Teacher Training providers are expected assess a trainee's English and mathematics knowledge before QTS is awarded. This will be done during the NELTA ITT programme. \r\n\r\nTeaching is physically and mentally demanding, and there are ‘fitness’ requirements set by the Department for Education for applicants to initial teacher training programmes. This does not however preclude disabled people from pursuing a programme of study or a career in teaching.\r\n",
+                "personal_qualities": "We are looking for ambitious trainee teachers who are passionate and enthusiastic about their subject and have a desire to share that with young people of all abilities in the secondary age range. You need to want to make a real difference to young people’s lives. You should be resilient, have the potential to be able to communicate with an audience and be able to develop positive professional relationships with young people and colleagues. We want you to be able to continually reflect on their practice and respond positively to feedback. The best teachers are learners themselves.",
+                "required_qualifications": "Usually a minimum 2:2 degree (usually including at least 50% of the content in the subject you wish to teach) or a qualification recognised as equivalent. Candidates with other classifications may be considered if it is judged that your experience in other areas compensates.\r\n\r\nMinimum GCSE grade C (4) in Mathematics and English Language or equivalent. Where you do not have these qualifications, you will have to sit a GCSE equivalency test which NELTA can administer and mark.\r\n\r\nIf English is not your first language you will have to demonstrate a satisfactory level of English language proficiency. \r\n",
+                "salary_details": "All trainees will be paid at least point one on the unqualified teachers' pay scale. This is currently (2020/2021) £21,582 for Outer London where most of our schools are based.  Pay scales are revised annually.\r\n\r\nThere are no other fees or costs for this programme."
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12959037",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": false,
+                "course_code": "329R",
+                "name": "English",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time with salary",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "salary",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17446,
+                    "address4": "Hertfordshire",
+                    "provider_name": "University of Hertfordshire",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "School of Education",
+                    "year_code": "2019",
+                    "provider_code": "H36",
+                    "provider_type": "university",
+                    "postcode": "AL10 9AB",
+                    "website": "https://go.herts.ac.uk/teachertraining",
+                    "address1": "University of Hertfordshire",
+                    "address2": null,
+                    "address3": "Hatfield",
+                    "email": "admcom@herts.ac.uk",
+                    "telephone": "01707 284800",
+                    "region_code": "eastern",
+                    "created_at": "2021-07-06T10:50:56.422Z",
+                    "updated_at": "2021-09-29T07:53:45.803Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-30T14:17:19.435Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Hertfordshire is a leading regional provider of [Initial Teacher Education](https://www.herts.ac.uk/study/schools-of-study/education/initial-teacher-education).  Consistently high achieving in its Ofsted inspections and in the Guardian and Times League tables, it is rightly proud of its excellent reputation with local and regional schools who often employ our student teachers.\r\n\r\nThe School of Education has an excellent record of employment for trainees on their Initial Teacher Education programmes, and those who actively seek a teaching post at the end of their programme are successful in joining the profession.\r\n\r\nAfter completing Initial Teacher Education there are opportunities to continue your studies with the University through the [MA Education Framework](https://www.herts.ac.uk/study/schools-of-study/education/postgraduate-courses-education/ma-education-framework).",
+                    "train_with_disability": "The University of Hertfordshire is committed to promoting equality of opportunity to ensure that it meets the needs of disabled people and has policies that are intended to support all students both in their studies and in developing their professional practice.\r\n\r\nIf you have a disability or other need we encourage you to disclose this and any other relevant information that could support your studies.\r\nThe School of Education at the University of Hertfordshire provides both academic and practice placement support for teachers in training with disabilities and other needs.\r\n\r\nOne key aspect of the PGCE course is to raise awareness of mental health and well-being and to support the removal of unnecessary workload. \r\n[University of Hertfordshire disability support](https://www.herts.ac.uk/life/student-support/disability-services)\r\n[University of Hertfordshire statement on disability disclosure by students](https://www.herts.ac.uk/life/student-support/disability-services/statement-on-disability-disclosure-by-students)\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.7518204,
+                    "longitude": -0.2387957,
+                    "ukprn": "10007147",
+                    "urn": "133783",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "H36",
+                "changed_at": "2021-10-05T10:00:35.978Z",
+                "uuid": "97cd2aec-74b5-4873-bfca-fb521fa03866",
+                "program_type": "school_direct_salaried_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "IELTS Only",
+                "degree_grade": "two_one",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-08T12:39:15Z",
+                "about_accrediting_body": null,
+                "provider_code": "214",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Harrow First in collaboration with the University of Hertfordshire offer a salaried School Direct training programme for a limited number of top graduates who wish to teach. Trainees spend four days in school and one day at the University of Hertfordshire each week during term time.\r\n\r\nAll courses are run in Harrow and allow teachers to develop their leadership skills whilst training to teach.  Harrow First is a challenging programme which will take a fresh approach to training teachers via the School Direct (salaried route).  Successful applicants will undergo training during July and August with a view to teaching from 10 hours per week in a school from September, supported in the classroom by a Higher Level Teaching Assistant (HLTA).  Training will continue through the year, both in school and at the University of Hertfordshire.  The course leads to the award of Qualified Teacher Status (QTS) plus 30 MA credits.  There will be opportunities to complete further MA modules in subsequent years in order to achieve the MA in Education.  \r\n\r\nThere are three assessment point throughout the year and trainees are assessed through a combination of lesson observations and an evidence bundle include lesson plans and evaluations. Trainees will benefit from a variety of support: from the University of Hertfordshire, from their mentor in school, from the Higher Level Teaching Assistant, from a Professional Mentor in school and from a Specialist Leader in Education who will ensure the coherence of the course.  Colleagues in all these roles are well trained and experienced.  We are committed to training creative, innovative and reflective practitioners who see themselves as future leaders.  ",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "You main placement school will be one of the schools located in North-West London with good transport links to Central London. You will be teaching either 11 – 16 or 11 – 18 depending on the subject and placement. All trainees will have one main placement school where they will complete the majority of their training. They will train at a second school for a short six week placement in the Spring Term.",
+                "interview_process": "Once your application is submitted shortlisted candidates will be invited for interview at one of the schools in the alliance. The interview process will involve four parts and will include the following: \r\n\r\n* Interview\r\n* Lesson Observation – the topic will be provided prior to interview\r\n* Literacy task\r\n* Document check\r\n\r\nThe interview process will include the opportunity to talk to staff and pupils and is a rigorous and thorough process, designed to allow you to demonstrate a range of qualities and competences.  We seek to get the best match of applicant to the limited places available.  \r\n\r\n",
+                "other_requirements": "We particularly welcome applicants who have worked with young people in a variety of settings.  We expect you to have spent at least five days shadowing in a school or schools; and to have observed lessons in a secondary school before your interview.  You will be required to provide written evidence of this if invited for an interview.  Three years’ work experience (PhD study is acceptable) is required to meet the eligibility requirements of the School Direct (salaried) programme.  ",
+                "personal_qualities": "We are looking for ambitious trainee teachers who are passionate and enthusiastic about learning and have a desire to share this with children and young people of all abilities. This will be demonstrated by meaningful experience of working with children and young people. This does not need to be paid work but might be helping with a sports team, drama group or youth club.  During the last two years we expect you to have carried out at least five days classroom experience, or you may have worked in a school.  ",
+                "required_qualifications": "You should have:\r\n\r\n* 1st or 2nd class honours degree in English or a related subject, or a joint degree with English as the major component (i.e. at least two years of English studies at undergraduate level).  \r\n* GCSE Grade C or above in Mathematics and English \r\n* A level in English at minimum B grade\r\n* Candidates without these qualifications may be accepted if they have acquired knowledge through other routes (e.g. work experience; a subject knowledge enhancement course).  \r\n* Overseas qualifications should be checked by UK NARIC before making an application.  \r\n\r\n",
+                "salary_details": "This is a salaried programme and all training fees and costs are covered by the Canons Park Teaching School Alliance. We pay on the unqualified teachers’ pay scales (for Outer London). There are no other fees or costs for the trainees."
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12958965",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2X8Q",
+                "name": "History",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17627,
+                    "address4": "Reading",
+                    "provider_name": "The University of Reading",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Ms Vanessa Combeer",
+                    "year_code": "2019",
+                    "provider_code": "R12",
+                    "provider_type": "university",
+                    "postcode": "RG6 6AB",
+                    "website": "http://www.reading.ac.uk/education",
+                    "address1": "Admissions Office",
+                    "address2": "Miller Building",
+                    "address3": "Whiteknights",
+                    "email": "teachertraining@reading.ac.uk",
+                    "telephone": "0118 378 5289",
+                    "region_code": "eastern",
+                    "created_at": "2021-07-06T10:52:55.916Z",
+                    "updated_at": "2021-10-04T14:51:04.438Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-04T15:08:52.773Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The Institute of Education (IoE) at the University of Reading is an established provider of high-quality teacher training and research in education. The impact of our research and the breadth of our experience feeds directly into everything we do and the world around us.\r\n\r\nTrain with us and have a direct and positive impact on the lives of young people. In our latest Ofsted inspection in 2016 all our teacher training courses were rated 'Good'. We are currently ranked 10th in the UK for Education in the Guardian University League Tables 2022.\r\n\r\nOur networks and the impact of our work are both local and global. Locally, we have well-established partnerships with over 400 schools, who we work closely with to train the next generation of outstanding teachers. Globally, our research, consultancy and other projects extend to countries as varied as China, Jamaica, the USA and Singapore. \r\n\r\nIn the latest national assessment, the Research Excellence Framework (REF) 2014, 80% of our research outputs were rated world leading or internationally excellent, positively impacting educational policy and practice. \r\n\r\nAt the Institute of Education we have the research, the expertise and the passion to help others grow into engaged and active citizens; individuals with resilience and the confidence to tackle challenges.  \r\n\r\n\r\n \r\n",
+                    "train_with_disability": "The University of Reading welcomes disabled students and has a dedicated Disability Advisory Service. The service offers advice and guidance to students with any disability, mental health condition, or specific learning difficulty (SpLD).\r\n\r\nIf you have not yet told the University about your disability, or have not disclosed it on your application, you can discuss the implications of a disclosure in complete confidence, with one of our disability advisers.\r\n\r\nWe offer support, advice and guidance with:\r\n- physical disabilities e.g. mobility\r\n- sensory disabilities e.g. visual impairments\r\n- mental health difficulties e.g. anxiety\r\n- medical conditions e.g. Irritable Bowel Syndrome, diabetes\r\n- autism/Asperger Syndrome\r\n- SpLDs e.g. dyslexia, dyspraxia \r\n\r\nDAS may be able to assist in study related support in the following ways:\r\n- Disability Advisory Service (DAS) may assess the impact of your disability  on your studies and recommend any reasonable adjustments required\r\n- Provide information on funding for study support, including the Disabled Students Allowance and how to apply.\r\n- Liaise with your Department/Schools/Hubs including Senior Tutors and Disability Representative on reasonable adjustments, including extensions to deadlines and alternative modes of assessment where appropriate.\r\n- Flag students (with permission) in order that tutors are made aware of individual requirements.\r\n- The Disability Advisory Service can provide assistance on arranging non- medical helpers e.g. one to one support arrangements such as mentors and specialist study skills. \r\n- Liaising with the exams office re special exam arrangements\r\n- Referral and signposting to other services\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.4414205,
+                    "longitude": -0.9418157,
+                    "ukprn": "10007802",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "R12",
+                "changed_at": "2021-09-27T09:22:14.315Z",
+                "uuid": "2a8ce623-1f9c-42a8-8c3f-09a7ba5956fd",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-22T10:29:15Z",
+                "about_accrediting_body": "The University of Reading’s Institute of Education is an established provider of high-quality training and research. It is ranked 10th in the UK for Education (The Guardian University League Table 2022).\r\n \r\nCommitted to developing caring, reflective, professional teachers, it has well-established partnerships with over 400 schools in Berkshire and the surrounding area.\r\n \r\nOfsted report that the “effective relationships with partner schools support the development of high quality teaching and trainees that are well-prepared to work in the region’s schools.” (ITE inspection report, September 2016).\r\n",
+                "provider_code": "1UH",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Your training will lead to the award of a PGCE by the University of Reading as well as a recommendation for the award of Qualified Teacher Status (QTS) by the Department for Education (DfE). The PGCE includes 60 credits at Masters level, the equivalent of one third of an MA that you can add to subsequently.\r\n\r\nThe course content has been developed in collaboration between the University and partnership schools so that you can explore issues raised in the University through your work with pupils in school. You will have opportunities to consider issues raised in school against a wide range of educational principles to which you will be introduced.\r\n\r\nPeriods of school experience are integrated into all aspects of the course, and you work in schools throughout the year. Your work in school takes a variety of forms including observing experienced teachers, team teaching, working with small groups, taking responsibility for the learning of whole classes and getting involved in all aspects of school life. You will be well supported in school by a range of experienced and well-trained people including a subject and a professional mentor and university-based tutors.\r\n\r\nThe university-based programme comprises two main aspects: Professional Studies and Subject Studies.\r\n\r\nProfessional Studies develops insights into general aspects of education essential for entrants to the teaching profession. It gives consideration to whole-school issues, such as behaviour management, special educational needs and educational theories that contextualise the teaching of your subject. It is taught in small, mixed-subject seminar groups.\r\n\r\nSubject Studies enables you to study the teaching of your chosen subject. This includes consideration of aspects such as: the nature of the subject in the secondary school; its place in The National Curriculum; what is taught; how it is taught; how it is assessed; providing for young people with different backgrounds and abilities; teaching in accordance with examination specification requirements; and using ICT effectively to facilitate learning.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "£7,710 for QTS",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "This placement is at Yateley School. Yateley School is a popular 11-18 comprehensive school with approximately 1500 students. We pride ourselves on high standards, which are achieved through a friendly and caring atmosphere and a dedicated team of well-qualified teachers. At Yateley, we believe we offer the chance for every child to fulfill potential and achieve success. We have had specialist status in performing arts since 2002.\r\n\r\nAs part of the Calthorpe Park Consortium and in partnership with Reading University, we offer a full range of initial teacher training. Trainees are supported by highly successful teaching mentors and a full professional studies programme.\r\n\r\nwww.yateleyschool.net\r\n\r\nYour second placement is after Christmas for 8 weeks at another school – either a school in our consortium or a school of your choice.\r\n",
+                "interview_process": "If your application is shortlisted, you will be invited for an interview and assessment day at Calthorpe Park School or at one of our consortium partner schools.\r\n\r\nIf you are successful at interview, a conditional offer of a place will be made. The conditions will include providing proof that you have met the eligibility conditions for Initial Teacher Training, including a criminal record check and an occupational health assessment. Further conditions may be discussed with you at interview.\r\n\r\nIf you accept the offer of a place, you will be required to attend an Induction and Needs Assessment Afternoon at the University of Reading. This will be an opportunity to meet the University subject tutor, who will help you identify pre-course targets to prepare you for your training. If you are offered a salaried place, you will be asked to attend an induction day at school, on which you will agree an Individual Training Plan and the details of your contract with the school.\r\n",
+                "other_requirements": "",
+                "personal_qualities": "All candidates must show proficiency in fundamental numeracy and literacy skills.\r\n\r\nAll applicants are expected to have gained some experience in a state secondary school prior to interview.\r\n",
+                "required_qualifications": "Candidates should normally have a 1st, 2:1 or 2:2 honours degree in a subject that is closely related to the subject they intend to teach. All candidates must have at least a C grade (or equivalent) for GCSE  Maths and English.\r\n\r\nSubject Knowledge Enhancement (SKE) courses are offered in Maths, Chemistry, Physics, and Computer Science. These courses are for candidates whose degree included an element of the subject they intend to teach or who have extensive experience in the subject. They are designed to enable candidates to develop the level of specialist knowledge required to teach their chosen subject.\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12968978",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Y020",
+                "name": "Primary (3-7) Full time",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17828,
+                    "address4": "North Yorkshire",
+                    "provider_name": "Red Kite Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Kathy Murdie",
+                    "year_code": "2019",
+                    "provider_code": "2B9",
+                    "provider_type": "scitt",
+                    "postcode": "HG2 0DZ",
+                    "website": "https://redkiteteachertraining.co.uk/",
+                    "address1": "Harrogate Grammar School",
+                    "address2": "Arthurs Avenue",
+                    "address3": "Harrogate",
+                    "email": "TeacherTraining@redkitealliance.co.uk",
+                    "telephone": "01423 535646",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:55:08.222Z",
+                    "updated_at": "2021-09-30T14:46:58.640Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-04T12:59:42.790Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "By becoming part of the Red Kite family, you’ll be choosing some of the highest quality training around and giving yourself the strongest possible chance of landing your dream teaching job.\r\n\r\nOur collective mission is to train evidence-informed, professional and inclusive teachers who can lead learning in today’s rich and varied educational landscape.\r\n\r\nWhether you apply for school-centred training (SCITT) or School Direct with Red Kite, you’ll follow a bespoke programme that’s designed nationally but delivered locally. You’ll spend over 24 weeks in your placement schools, meaning you’ll get to properly immerse yourself in school life with both pupils and colleagues.\r\n\r\nOur training network consists of primary, secondary and special schools spread across West and North Yorkshire, meaning there will always be a location and school type that fits with your own personal characteristics and circumstances.\r\n\r\nThe Red Kite approach is geared towards providing each of our trainees with the help and guidance they need at each stage of their journey into teaching, with a dedicated support structure in place from day one which includes experienced mentors and a dedicated Early Career Leader. Our courses are designed to give you the skills and experience most sought after by employers – evidenced by the number of trainees securing a teaching post.\r\n\r\nAll of our courses lead to Qualified Teacher Status (QTS) and a PGCE (worth 60 masters credits) awarded by the prestigious School of Education at the University of Leeds. \r\n",
+                    "train_with_disability": "At Red Kite we believe the teachers we train are important role models – both in their schools and in the wider community – and that they should reflect the diversity around them and help create a culture that promotes and celebrates inclusion in all its forms.\r\n\r\nIn response to this, we have built up a network of ‘Diversity Champions’, whose role it is to promote conscious inclusion and ensure that every one of our trainees, whatever their personal circumstances, feel welcomed, supported and valued.\r\n\r\nOver years we have worked with a number of individual trainees to tackle specific barriers they have faced, including:\r\n\r\n•\tWorking with a trainee with mobility issues to ensure their placement schools were able to arrange accessible parking, ground floor classrooms, bespoke pupil seating plans and a timetable that allowed them sufficient time to reach other areas of the school if required.\r\n•\tSupporting trainees with autism to clarify expectations with their schools and oversee any necessary modifications to classroom layouts, lighting and sounds.\r\n•\tMaking course adjustments for trainees with dyslexia, such as sending PowerPoint presentations in advance of the training and working with them to develop strategies to help turn any particular perceived weaknesses such as spelling and short-term memory into a strength.\r\n•\tEnsuring that all trainees learn about adult mental health awareness as part of their course.\r\n\r\nOur commitment to diversity in all its forms is evidenced by the fact that 15% of our trainees report having some form of disability.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.9828212,
+                    "longitude": -1.5468081,
+                    "ukprn": "10054307",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B9",
+                "changed_at": "2021-10-04T12:33:36.019Z",
+                "uuid": "58756a51-9dc7-405b-81fa-2efe0ffba7e7",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": null,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "We will accept an equivalency test for Science but require full GCSE certificate at grade C or above for Maths and English.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-30T09:16:52Z",
+                "about_accrediting_body": "Red Kite's ‘Train Where You Live’ concept is aimed at bringing teacher training to you, wherever you live in our region.\r\n\r\nPartnerships with providers across the region mean that wherever you train, you’ll be part of the same Red Kite programme and receive the same high-class teacher training. The only provider working with the University of Leeds, and from September 2021 your learning experience with them will be blended to allow you to work remotely wherever you live.\r\n\r\nWith our wide range of courses, which now includes Part-Time options, there’s something for everyone regardless of where you live.",
+                "provider_code": "1FG",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "\r\n The Primary SCITT 3-7 course specialises in Early Years and Key Stage 1, teaching you how to give children the best possible start to learning in a fun and creative way, with a focus on early maths and phonics.\r\nYou’ll also develop all the skills you need to teach children in any Primary year group, which gives you the flexibility to teach older year groups once you’re qualified.\r\nDuring your course, you’ll work with many inspirational teachers from across our partnership, demonstrating how they continuously strive to improve practice in the classroom, and enable progression across the full range of Primary year groups.\r\nBeing school-based gives us the opportunity to adapt the course to suit each individual. Training is provided by practicing teachers and delivered in small groups.\r\nThanks to our partnerships across the region, our trainees can also benefit from the placements our partners can offer.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "We are unable to sponsor Tier Two visas",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Many Trainees apply for student finance in order to pay their fees with a Tuition Fee Loan and have access to Maintenance Loan. Additional financial support is available if you’re a parent or have a disability.\r\n\r\nRed Kite offers a monthly payment schedule for those planning to self-finance.\r\n\r\n ",
+                "how_school_placements_work": "We have a big partnership of schools, meaning our trainees have flexibility when it comes to placements. Our trainees can also benefit from the placements our partners can offer, which can vary from rural settings to the buzz of the city.\r\n\r\nWhen allocating main placements, we consider trainee preferences, transport and location. Our dedicated team work hard to organise placements early, giving you as much time as possible to make arrangements.\r\n\r\nAll trainees undertake two main placements. The first placement runs from the first day of the Autumn Term until December. The second placement, in a contrasting school environment, runs from January until late June.\r\n\r\nTrainees will also take part in mini placements across the year, which give trainees a unique opportunity to broaden their experience in a range of schools and contexts.",
+                "interview_process": "For the foreseeable future, interviews will be held virtually on Microsoft Teams. Interviews are conducted by representatives from Red Kite Teacher Training and partnership schools.\r\n\r\nPreparation for the interview will include to plan for a pupil activity.\r\n\r\nYou will be given the opportunity to meet current trainees and course leaders. \r\n\r\nWhen it is possible to access schools freely, we shall ask that you conduct a pupil activity and complete a written English test.\r\n\r\n ",
+                "other_requirements": "Experience of being in a school and/or working with young people is not essential, however, it will be beneficial during the application process. You can contact us to arrange experience within a school.\r\n\r\nAdmission is dependent upon satisfactory medical examination conducted by Red Kite's preferred supplier.\r\n\r\nCandidates who are offered a place on the course are required to complete a declaration regarding any criminal convictions.\r\n\r\nCandidates are required to obtain clearance from the Disclosure and Barring Service (DBS) regarding their suitability for work involving children. Successful candidates will have these checks conducted at the expense of Red Kite.\r\n",
+                "personal_qualities": "* Passionate about making a difference to the lives and development of young people\r\n\r\n* Independent, resilient and adaptable\r\n\r\n* Friendly and approachable, with the ability to engage young people\r\n\r\n* Enthusiastic about their subject and are continuing to develop their subject knowledge\r\n\r\n* Creative and imaginative\r\n\r\n* Good organisational skills and excellent time management skills\r\n\r\n* Reflective and strive to improve their own practice\r\n\r\n* High standards of spoken and written English\r\n\r\n* Demonstrate a professional attitude\r\n\r\n* Have made a considered and informed decision to train to teach",
+                "required_qualifications": "Applicants should be qualified to degree level, 2:2 or above (or in their final year of University with a predicated 2:2 or above).\r\n\r\nAll applicants are required to have a GCSE/O'level/iGCSE* at grade C/4 or above in Maths, English and Science.\r\n\r\n*or international equivalent",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        }
+    ],
+    "meta": {
+        "count": 9916
+    },
+    "jsonapi": {
+        "version": "1.0"
+    }
+}

--- a/spec/fixtures/api_responses/ten_courses.json
+++ b/spec/fixtures/api_responses/ten_courses.json
@@ -2870,9 +2870,9 @@
     }
   ],
   "links": {
-    "next": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=7\u0026page%5Bper_page%5D=10\u0026sort=distance",
-    "prev": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=5\u0026page%5Bper_page%5D=10\u0026sort=distance",
-    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=73\u0026page%5Bper_page%5D=10\u0026sort=distance"
+    "next": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=7\u0026page%5Bper_page%5D=30\u0026sort=distance",
+    "prev": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=5\u0026page%5Bper_page%5D=30\u0026sort=distance",
+    "last": "/api/v3/recruitment_cycles/2020/courses?filter%5Blatitude%5D=50.82253000000001\u0026filter%5Blongitude%5D=-0.137163\u0026filter%5Bqualifications%5D=QtsOnly%2CPgdePgceWithQts%2COther\u0026filter%5Bradius%5D=20\u0026filter%5Bvacancies%5D=true\u0026include=site_statuses.site%2Cprovider.sites\u0026page%5Bpage%5D=73\u0026page%5Bper_page%5D=30\u0026sort=distance"
   },
   "meta": {
     "count": 10

--- a/spec/fixtures/api_responses/thirty_courses.json
+++ b/spec/fixtures/api_responses/thirty_courses.json
@@ -1,0 +1,3176 @@
+{
+    "data": [
+        {
+            "id": "12964529",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "29SS",
+                "name": "History",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-29T14:11:54.165Z",
+                "uuid": "f107f809-a984-4ded-961f-08f75cd8122b",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "We do not offer Equivalency Tests.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-29T14:11:54Z",
+                "about_accrediting_body": null,
+                "provider_code": "N42",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "On the NTTP History course, students will train towards a professional teaching qualification, achieving Qualified Teacher Status. The course requires a study of academic literature and completion of professional assignments, alongside two school based placements. The course is designed to show that trainee teachers demonstrate that they have met the standards for Qualified Teacher Status. \r\nYou will explore a wide ranging content, and be expected to convey the subject with passion and enthusiasm to students. The material taught will be in line with Placement School curriculum, but you can assume to have a spread of modern, medieval and ancient history lessons.\r\nThe development of core history skills is a key focus in both KS3 and KS4, and you will be taught how best to convey complex historical events, as well as embed both sourcework and historiography to lessons. Through support of excellent mentors, in supportive schools, we will ensure you have the best opportunity to develop into an outstanding History Teacher.\r\nYou will receive a practice-led, hands on experience. Trainees are supported by a Subject Based Tutor within school, the Professional Tutor of the school, the Lead Subject Mentor from the NTTP SCITT, the Programme Facilitators. Subject Studies and General Professional Study sessions enhance your knowledge of teaching and learning and help to develop your pedagogy. Constant self-reflection allows trainees to assess their strengths and development potential, which should allow progression and confidence.\r\nYou will spend the majority of your course in the classroom; working with dedicated professionals. This is the best place to learn the art of teaching.   During your placements you will teach pupils in the 11 to 16 age range. \r\n\r\nSubject Studies are delivered as twilight sessions and take place in the first half of the year so that you have the tools to succeed in your school placements. Sessions are delivered by your Lead Subject Mentor and other experienced teachers.\r\nA selection of subject studies sessions are as follows: \r\nWhat is Humanities? – Understanding why students need to study Humanities subjects\r\nChallenging mis/preconceptions in Humanities – how to tackle stereotyping in History\r\nDifferentiation within Humanities – How do you stretch students in a content heavy subject?\r\nAssessment for learning in Humanities – Measuring learning within humanities\r\nUse of sourcework in lesson – How to make sourcework engaging for students\r\nTeaching outside the classroom – making Humanities an outdoor subject\r\nApproaches and Methodologies towards KS5 Humanities – ",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9000,
+                "financial_support": null,
+                "how_school_placements_work": "We have long-established partnerships and rewarding connections with a wide variety of secondary schools across the county.  Ideally, you will be required to spend a minimum of 12 weeks in two of our placement schools whilst on the course.  You will work closely with our trained school based tutors receiving weekly one-to-one meetings to monitor your progress throughout your first and second placement.\r\nTo qualify for QTS we will provide trainees with enough time in schools to demonstrate that they have achieved all the Teachers’ Standards.\r\nYou will train with pupils in the 11 to 16 age range, however in many of our partnership schools there will be the opportunity to experience Post 16 Education too.\r\nYou will be allocated to your placement school as a result of an initial induction and skills audit conducted early in the course.  Your placement school will be identified to meet your needs and therefore may not be your nearest school.\r\n\r\n",
+                "interview_process": "As with any interview, the key to success is preparation. Make sure you do your research into the course, as well as the issues surrounding education and teaching in general. Policies and practices change quickly, so your knowledge needs to be up to date.\r\nThe Interview process will entail: \r\n•\tAdministrative Questions \t\t\t\t-\t10 minutes\r\n•\tPresentation - “Why I want to become a teacher”\t-\t5 minutes\r\n•\tPresenting a ‘Starter’ of your choice\t\t\t-\t5 minutes\r\n•\tInterview \t\t\t\t\t\t-\t40 minutes\r\n•\tLiteracy written task\t\t\t\t- \t20 minutes\r\n•\tSubject Knowledge Task\t\t\t\t- \t30 minutes\r\n•\tPortfolio of work/video for Art and Performing Art subjects\r\n\r\nYour interviewers will be looking for you to demonstrate a number of qualities. You should therefore try to tailor your answers and contributions to reflect these qualities. They are:\r\n-\tA commitment to and understanding of secondary education and the role of the teacher\r\n-\tGood personal, intellectual and communication skills\r\n-\tA positive attitude towards children and working with children\r\n-\tAn enthusiasm for and understanding of your subject (s) and teaching in general.  \r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "You must have an Honours Degree at class 1 or 2, relevant to the subject you wish to train for and preferably a minimum of 50% of your degree being in that subject. Your A-Level grades will also be taken into consideration.  \r\n\r\nIt is preferable to have had some experience of working with secondary aged young people\r\nIf you hold a non UK degree and/or other qualifications, you should check its validation with NARIC (www.naric.co.uk) who will inform you of its UK equivalence.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12958448",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2H6W",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17801,
+                    "address4": "Greater Manchester",
+                    "provider_name": "The Manchester Metropolitan University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Manchester Metropolitan University",
+                    "year_code": "2019",
+                    "provider_code": "M40",
+                    "provider_type": "university",
+                    "postcode": "M15 6GX",
+                    "website": "https://www.mmu.ac.uk/education/pgce/",
+                    "address1": "Brooks Building",
+                    "address2": "Bonsall Street",
+                    "address3": "Manchester",
+                    "email": "courses@mmu.ac.uk",
+                    "telephone": "0161 247 6969",
+                    "region_code": "north_west",
+                    "created_at": "2021-07-06T10:54:41.761Z",
+                    "updated_at": "2021-09-13T10:36:47.838Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:01:15.423Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "COULD YOU BECOME AN ORIGINAL INFLUENCER?\r\n\r\nAs one of the city’s most established providers – with almost 150 years training education professionals under our belts – we know teaching inside out.\r\n\r\nIn many ways, we think teachers are the original influencers. They inspire. They engage. They explain. And they have a lasting impact on the pupils they teach.\r\n\r\nWe’ve been educating teachers, practitioners and professionals since 1878. We’re proud of our history. We’re proud of our present. And we’re proud to be one of the largest teacher training establishments in the country. Each year, we welcome over 700 trainee teachers onto our PGCE courses. We have a partnership of over 1,500 regional schools, colleges and educational organisations. We adopt leading research into our teaching through our Education and Social Research Institute (ESRI). \r\n\r\nSHARING SELFIES TO SHARING KNOWLEDGE\r\n\r\nSharing selfies is fun, but there is real joy in sharing knowledge. It’s finding new ways to explain complex theories to students and inspiring a love of learning. Discovering innovative global teaching methods. Using research to make a difference in the classroom.\r\n\r\nYou might debate how pupils learn when they live below the poverty line or explore the effect of the growth mind-set. You might research ways to include bilingual students in your lessons or global methods of teaching maths and how this could help your class.\r\n\r\nWhichever subject you’re hoping to teach, we’ll help you to develop the practical skills you need to teach, to inspire and to engage your class.",
+                    "train_with_disability": "From study skills to dyslexia screenings - we've got it covered - https://www.mmu.ac.uk/student-life/wellbeing/disability/.\r\n\r\nIf you are a care leaver, estranged from your family, a carer, under 18 or pregnant, we have a dedicated Inclusion Service to help you through your studies - https://www.mmu.ac.uk/student-life/wellbeing/inclusion/.\r\n\r\nCome and visit our Open or Visit Days and speak to a member of staff from Disability Service - https://www.mmu.ac.uk/study/open-days.\r\n\r\nOr simply contact the Disability Service on 0161 247 3491 or (disability.service@mmu.ac.uk)",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.4666748,
+                    "longitude": -2.2465299,
+                    "ukprn": "10004180",
+                    "urn": "133844",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "M40",
+                "changed_at": "2021-09-21T09:23:05.928Z",
+                "uuid": "374fe87e-8e6b-40d4-8d47-5304658c0d27",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-21T09:23:05Z",
+                "about_accrediting_body": null,
+                "provider_code": "1HJ",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Our School Direct course consists of a variety of learning experiences, focused on practical training in teaching and learning related skills. This practical training is underpinned by the development of participant’s knowledge and understanding of education theories, ideas and concepts and by enhancing their awareness of current educational issues and developments. \r\n\r\nThis course will be delivered in partnership with Manchester Metropolitan University, who will award both Qualified Teacher Status and 60 Masters level credits as a PGCE on successful completion.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 20000,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will become part of your main placement school team from September, this is earlier than University led programmes.  You will receive intensive support from our experienced team of teachers and mentors from the beginning of your placement.  You will build your skills through observation, reflection, and attendance at both alliance training sessions and university led sessions.  This will support you in building your skill set towards teaching whole class lessons, and then onto a significant timetable by the end of the year.",
+                "interview_process": "All programmes include a panel interview where we are looking to find our more about your skills, knowledge, experience and passion.  \r\n\r\nThe interview process takes place over a half-day at our lead School St Peter's RC High School.\r\n- an introductory talk\r\n- a personal interview designed to identify your suitability and commitment to teaching\r\n- a short presentation \r\n- a subject knowledge assessment\r\n- identity and qualification checks (please provide photographic ID, proof of address and copies of your academic qualifications)\r\n\r\nAll offers we make after interview will be conditional on; clearance through the Disclosure and Barring service, validation of any declared qualification and the acquisition of any pending qualifications.  Individual offers may have additional conditions and you are advised to carefully read these.\r\n",
+                "other_requirements": "We also recommend you check the Department of Education website at (www.education.gov.uk/get-into-teaching) for the latest updates.\r\n\r\n A Disclosure and Barring Service Check and satisfactory DfE Fitness to Teach health form are required",
+                "personal_qualities": "Our strongest applicants have undertaken some observation in a school and reflected on their experiences and the role of the teacher.",
+                "required_qualifications": "- Degree classification minimum of a 2:2 undergraduate honours degree awarded by a UK university, or an equivalent higher education qualification. Your degree needs to support the subject knowledge requirements of the National Curriculum for Geography.\r\n\r\n- Appropriate post-16 qualifications, A-level Geography is desirable.\r\n\r\n- GCSEs at grade C/4 or above in English Language and Mathematics. \r\n\r\n\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963544",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "V577",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:04:58.964Z",
+                "uuid": "0feede99-f95d-4d1f-8e34-a01444d15555",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "The degree needs to have a scientific content.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:04:58Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above do NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2020)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963548",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X210",
+                "name": "English",
+                "study_mode": "part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:56:55.514Z",
+                "uuid": "5a499a83-16df-448e-90a2-a89a365f85e4",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": null,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\nWe will consider accepting equivalency tests in lieu of GCSE English \u0026 Maths ( grade 4 (C) or above ) on an individual basis.\r\n",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:56:55Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September 2022 until June 2024. Carefully designed, delivered by experienced practising teachers  to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid- September. \r\n\r\nYou will undertake most of the remaining cohort training alongside full time trainees during your first year, whilst also spending two days in school. You therefore need to commit to three days per week in year one. In year two you will generally spend three days in school and will undertake bespoke training as appropriate either as part of the part time cohort or individually. \r\n\r\nAdditionally, our programme offers: \r\n\r\n* A minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\n* Weekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\n\r\nOur schools comprise predominantly of comprehensive schools including schools. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through: \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are four formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term of Year 2. \r\n\r\nWritten submissions are evenly spread throughout the programme. The wellbeing of our trainees is of the utmost importance to us, we provide various options to support you. \r\n\r\nPGCE (Post Graduate Certificate in Education – 60 Master credits)  lectures are held locally. Trainees undertake 3 additional assignments. Award is validated by University of Buckingham. ",
+                "course_length": "TwoYears",
+                "fee_details": "The fees above include the PGCE element of the programme in addition to the QTS.\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. The QTS only part time programme will be £10500 in total ( correct as at 01/10/2020)",
+                "fee_international": 11500,
+                "fee_uk_eu": 11500,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements are carefully selected to ensure they give excellent but contrasting experiences whilst considering a reasonable travelling distance from your home.  \r\n\r\nWe know many of our Professional Tutors and School Mentors well and try to match our trainees with their mentor to build that strong professional relationship. \r\n\r\nAs a part-time trainee, you'll have two placement schools. Effectively, you will have 6 terms, 3 per year.  Terms 1, 4, 5, 6 will be in School A and terms 2 \u0026 3  in School B. The two schools will provide a contrasting learning environment. \r\n\r\nEvery Thursday during the first year of training you will receive general professional and subject knowledge sessions, complimented by specific bespoke training as appropriate in your second year.  \r\n\r\nYou will start undertaking structured observations of teachers followed by team teaching, part lesson then full lesson teaching. \r\n \r\n Our schools comprise predominantly of comprehensive schools but include a Church of England school. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings.  \r\n\r\n Schools play such an important part in the programme, and that’s why we can provide you with an outstanding foundation on which to build your future career. You will have an expert school-based Mentor and a designated Senior Link (Professional Tutor) in each placement school and they will be trained by, and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. \r\n\r\n“You all, along with everyone at school, made my first term of training to teach the best experience ever. I was able to learn so much from everyone and you were all incredibly supportive in the process! I honestly can’t sing your praises highly enough!” \r\n\r\n“The support provided at each school was outstanding, both the support from my mentor and regular training sessions allowed me to start my NQT year feeling confident and equipped with the correct knowledge to start my career. I would highly recommend both schools as fantastic places to start your career as a teacher”.   \r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools.  \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\n* Welcome by a member of the SCITT team\r\n\r\n* Document check \u0026 hand in of your pre completed subject audit form\r\n\r\n* Tour of the school in which the interview takes place\r\n\r\n* A 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking SKE \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other safer recruitment processes to verify their suitability to work with young people. \r\n\r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS) - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training. Arrangements for completing DBS check applications will be explained as part of the selection and induction process.\r\n\r\nChecking the Prohibited Teachers List\r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent  communication, time-management, planning and organisation skills\r\n\r\n* A positive engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": "ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969238",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "26J6",
+                "name": "Design and Technology (Product Design)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17408,
+                    "address4": "Newcastle upon Tyne",
+                    "provider_name": "University of Newcastle Upon Tyne",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Dawn Bell",
+                    "year_code": "2019",
+                    "provider_code": "N21",
+                    "provider_type": "university",
+                    "postcode": "NE1 7RU",
+                    "website": "https://www.ncl.ac.uk/ecls/study/postgrad/teacher/",
+                    "address1": "Admissions",
+                    "address2": "Level 3",
+                    "address3": "King's Gate",
+                    "email": "pgce-education@ncl.ac.uk",
+                    "telephone": "0191 208 6017",
+                    "region_code": "north_east",
+                    "created_at": "2021-07-06T10:50:15.994Z",
+                    "updated_at": "2021-08-03T08:26:11.916Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T11:04:10.485Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The PGCE Team pride ourselves on providing our students with an excellent standard of education, training and practical teaching experience and are delighted that Newcastle university achieved A Gold Award, in the Teaching Excellence Framework (TEF), evidencing that Newcastle University consistently delivers outstanding teaching, learning and outcomes, for our students. Similarly, we were given a ‘judgement of Confidence by the The Quality Assurance Agency for Higher Education (QAA). We also pride ourselves personal support we give to our students and you will have full access to the extensive services of the ‘Student Support Service’.\r\n\r\nNewcastle University has a reputation for world-class research (16th in the UK) and the PGCE team work closely with our colleagues to ensure our subject and professional programmes are research led and well informed.\r\n\r\nOur PGCE programme, rated Good by Ofsted in 2017, provides rigorous academic and school training. University and school-based components are integrated so that learning is relevant to your practice and development as a confident and capable teacher.  To support you, you will have access to a wide range of study facilities, including all relevant course materials , a well-stocked Education Resource Centre and the comprehensive facilities of the university. You will also have full access to the extensive services of the ‘Student Support Service’ \r\n",
+                    "train_with_disability": "The PGCE Team welcome applications from students with disabilities.  Advice, information and guidance is available from the university Student Support Services, who liaise with us over students’ support requirements, and may liaise with external agencies where appropriate. Disabled Students' Allowances (DSA) is a non-means tested grant available to U.K. disabled students who are applying for, or are attending, a course of Higher Education. There are specific eligibility conditions related to residence in the UK, which have to be met to qualify for this funding.  DSA allowance covers some additional study-related costs that students will incur because of a disability, ongoing medical condition or mental health condition. Extra costs may include specialist equipment, a non-medical helper or travel costs. If you are invited to an interview for PGCE is often a good opportunity to arrange to meet with one of the Disability Advisers, to talk about your support requirements. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 54.9789749,
+                    "longitude": -1.6135961,
+                    "ukprn": "10007799",
+                    "urn": "133852",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N21",
+                "changed_at": "2021-10-05T13:57:27.198Z",
+                "uuid": "c3a4de06-2b55-4d26-872f-e00bb0c4039c",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:57:27Z",
+                "about_accrediting_body": "",
+                "provider_code": "14U",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This is a one-year full time Initial Teacher Education course leading to the academic award of Postgraduate Certificate of Education (PGCE) and Qualified Teacher Status (QTS). At university, trainees undertake three Masters level modules towards their PGCE: Subject Pedagogy in Practice, Developing Critical Perspectives and Curriculum Development Through Enquiry in Practice. Successful trainees are awarded 60 Masters level credits which they can choose to carry forward to the full Master’s course at a later stage. Our School Direct programme provides a wealth of opportunity for trainees to demonstrate evidence of the Teachers’ Standards required for QTS.\r\n\r\nOur School Direct programme is designed to train teachers in the classroom. Our vision to develop expert teachers and leaders of the future starts with all trainees becoming part of the staff team from the beginning of the academic year. Trainee teachers will learn from experienced colleagues and work closely with the staff in the Design and Technology department. You will be given experience of KS3, KS4 and KS5. The vast majority of the year is spent in the host school that you apply to and you will be allocated a contrasting placement which will include six weeks of teaching elsewhere. Contrasting placements are key to the development of all trainee teachers in order to develop a broader understanding of different educational settings.",
+                "course_length": "OneYear",
+                "fee_details": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/f8x1/#fees-and-funding)",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Click here [here] (https://www.ncl.ac.uk/postgraduate/2022/degrees/3072f/)",
+                "how_school_placements_work": "You will spend the majority of the year and undertake most of your teaching commitments at your host school. A contrasting placement will be arranged for you with consideration given to your location, transport, childcare, etc. By placing you in a contrasting school you will gain invaluable experience which help you to develop a range of teaching skills. We only use schools that we know will give you the help and support you need during your placement, including a professional tutor and subject mentor. Weekly mentor meetings and at least one formal lesson observation will occur each week during your teaching practices.",
+                "interview_process": "Newcastle University’s Admissions Team will conduct an initial eligibility check, to determine whether you meet the eligibility criteria. The school you have applied to will then consider your application and agree whether to invite you to interview. If you are selected for interview, you will be sent information about the interview process, together with guidance on how to prepare. The interview process will take approximately half a day at whichever school you have applied to within the alliance. It is important that you spend some time in the school that you are applying to and you will be given an opportunity to talk to some key staff. You will be required to teach an observed lesson; you will be told in advance about the content and the age group you will be teaching as well as any other relevant information to help you prepare. An interview will be the last part of the day where the professional tutor from the school and an Emmanuel Teacher Training Partnership representative will be present.\r\n\r\n",
+                "other_requirements": "You will be required to undergo an enhanced DBS and fitness to teach check to verify your suitability for working with young people. \r\n\r\nWe recommend you spend at least a few recent working days in a UK secondary classroom before applying. This will inform your application and any later performance in the selection process.\r\n\r\nSubject Knowledge Enhancement (SKE) can be organised where necessary and funding arranged to cover costs. You could get a tax-free SKE bursary of £175 per week.",
+                "personal_qualities": "We are looking for trainee teachers who possess a range of personal qualities including:\r\n\r\n* The ability to communicate in English competently, confidently and clearly to a level that facilitates good quality oral and written communication with pupils, parents and colleagues.\r\n* Self-motivation\r\n* Confidence\r\n* Patience\r\n* Compassion\r\n* Enthusiasm\r\n* Resilience\r\n* Initiative\r\n* Team player\r\n* Good organisational skills\r\n* Effective time management\r\n* Passion\r\n* The desire and drive to transform children through education.\r\n",
+                "required_qualifications": "An honours degree (2:2 or above) or equivalent. At least 50% of your degree should be in the subject that you intend to teach. We may accept closely related degree subjects.\r\n\r\nGCSEs or O Levels (grades A–C/ 4-9) in English language and mathematics, or equivalent.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12970122",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "D658",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17445,
+                    "address4": "Worcestershire",
+                    "provider_name": "Haybridge Alliance SCITT",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Sally Koyuncu",
+                    "year_code": "2019",
+                    "provider_code": "2B3",
+                    "provider_type": "scitt",
+                    "postcode": "DY8 2XS",
+                    "website": "http://www.teachwithhaybridge.co.uk",
+                    "address1": "Haybridge High School \u0026 Sixth Form",
+                    "address2": "Brake Lane",
+                    "address3": "Hagley",
+                    "email": "abarker@haybridge.worcs.sch.uk",
+                    "telephone": "01562 881110",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:50:52.983Z",
+                    "updated_at": "2021-09-20T12:57:54.382Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-28T17:50:57.160Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Haybridge Alliance School Centred Initial Teacher Training (SCITT) is based at Haybridge High School and Sixth Form and is recognised as providing exceptional teaching and learning with vast experience in delivering and supporting Initial Teacher training (ITT) courses and placements.\r\n\r\nHaybridge High School is a well-regarded 11-18 comprehensive school with a track record for excellence including four consecutive Ofsted ratings of ‘Outstanding’.  Our Alliance schools are from a range of phases operating within diverse catchment areas with different challenges.\r\nHaybridge Alliance SCITT is the lead provider coordinating the SCITT programme and overall training experience.  All secondary and primary schools in the Alliance will provide school-based placements for the training year recruited.\r\n\r\nThe quality of the programmes together with the support received by our trainees ensures that a high calibre of newly qualified teachers enter the profession.\r\n\r\nThroughout the duration of the course a weekly programme of professional studies workshops are delivered by practising teachers from across the schools in the partnership.  The focus of the programme is to address the development needs of the next cohort of teachers who will teach in our schools.  A programme of subject studies is  provided by local Specialist Leaders in Education.  These sessions are designed to develop the understanding and delivery of a subject pedagogy, reviewing topics such as lesson planning and assessment.  This stimulating programme of professional and subject studies explores the philosophy of education and the pedagogy associated with the teaching of a subject.\r\n",
+                    "train_with_disability": "\r\nWe strive to promote equal opportunities within Haybridge Alliance SCITT and Haybridge High School and Sixth Form has full access for people with all types of disabilities. \r\n\r\nWe offer bespoke support to cater for any physical, mental or learning disabilities dependent upon the needs of each trainee.\r\n\r\nAccommodation is not available through the Haybridge Alliance SCITT and trainees will be expected to find their own accommodation for the duration of the course. \r\n\r\nThe Haybridge Alliance SCITT does not have child care facilities. \r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.4234721,
+                    "longitude": -2.1488906,
+                    "ukprn": "10034167",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B3",
+                "changed_at": "2021-09-30T12:22:20.417Z",
+                "uuid": "9dee9f9e-fc69-46ee-af5f-85af37fdcbac",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-30T12:22:20Z",
+                "about_accrediting_body": null,
+                "provider_code": "18E",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The course will begin in September 2022 and last for one academic year with a trainees time being divided between school based placements (approximately 80%) and structured training days (approximately 20%) which will take place at either Hales Valley Teaching Hub or at one of our partner organisations (Haybridge Teaching School Alliance) and focus upon key educational theory and practice. \r\n\r\nOn the 44 week programme a trainee’s time is divided between Teaching Experiences and structured training sessions looking at subject delivery and wider professional issues. The teaching commitment will build up over the year: 30-40% in the Autumn term, 50% in the Spring and 80% in the Summer term. During the course trainees will be supported by their school-based practitioner who will be a good or outstanding teacher and leader within the school.\r\n\r\nTrainees will be assessed on a combination of evidence gathered during the teaching experiences, a range of tasks linked to Hales Valley/partnership workshops as well as three formal assignments that focus on key areas of teaching and learning.",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Once individuals have accepted a place, they can then make applications for tuition fee loans through Student Finance England, to cover the cost of their training. ",
+                "how_school_placements_work": "SCITT is a school-led training course which gives you the chance to learn ‘on the job’ in a school. You work as part of the teaching team from day one, learning from experienced, highly-skilled colleagues and you immediately put your new skills into practice.\r\nYou spend on average 80% of the week in one of our 20 primary partnership schools teaching in Early Years and Key Stage 1. \r\nWe have worked very closely with our partnership schools over the last eight years and have excellent relationships with them. They share our ethos, understanding the importance and value of school led teacher training.\r\nYou will have two school experiences throughout the year ensuring you gain experience in both Early Years and Key Stage 1 enabling you to teach 3-7 year olds.  You spend your first and last school experience in the same class, in the same school. Your second school placement is in different school ensuring you gain a wider experience in your training. \r\nYou also spend time in Key Stage 2 in order to gain further experience.",
+                "interview_process": "",
+                "other_requirements": "Successful candidates will be required to carry out an enhanced DBS check before commencing the programme. ",
+                "personal_qualities": "",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12957745",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2PPK",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:58:25.622Z",
+                "uuid": "7bfb3bd2-46b5-45ed-9fb1-c33d65c311d9",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:58:25Z",
+                "about_accrediting_body": null,
+                "provider_code": "R23",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Our SCITT curriculum begins early in September and involves teaching practice in school each week from Monday to Thursday, with Friday as a training  day. Training will be hosted and delivered by experienced ITT specialists, subject experts and classroom practitioners who currently teach in our partner schools. \r\n\r\nIn addition, there will be subject pedagogy days during the year where trainees will focus on teaching science specifically. These will be delivered by the Science Learning Centre at Ashton Community Science College. Biology, Chemistry and Physics trainees study together on these days and this is really useful because you will find that in most schools you will teach combined science at KS3. Learning together really helps you develop your subject knowledge across the three sciences and we can also organise additional courses for you via the Science Learning Centre to meet your individual needs.\r\n\r\nYou will audit your subject knowledge for the topics you will need to teach at KS3 and 4. Lead Subject Mentors will guide you towards great resources for this and you will be encouraged to join a professional subject association. A shared drive enables you to share resources with each other and school mentors. \r\n\r\nLeeds Beckett University provide the PGCE for our SCITT and this is all online. The modules perfectly compliment the training we deliver and you will gain 60 Master's level credits (https://courses.leedsbeckett.ac.uk/PGCE_distancelearning/)\r\n\r\nOur programme documentation has been described by Ofsted: \"Documentation is very well designed and contributes significantly to trainees' success on the course\" \r\n\r\nAssessment of trainees for QTS is based on all of the following:\r\n- Regular observations of practice with development discussion and \r\n action steps\r\n- Progress towards meeting the expectations of the curriculum\r\n- A final assessment against the requirements of the Teachers Standards at the end of the programme.\r\n\r\nWe have been highly praised by Ofsted for our approach to trainee workload, keeping our requirements concise yet effective.",
+                "course_length": "OneYear",
+                "fee_details": "£9250 PGCE and QTS\r\n£7000 QTS only",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will complete placements in two partner schools. The first placement will begin in September, an excellent time to see how rules and routines are established at the start of the academic year. You will start with focused lesson observations across the whole school before you join your subject department and begin to plan teach parts of lessons. After a few weeks you will be planning and delivering whole lessons, building up to approximately 7 hours per week by Christmas. \r\n\r\nThe second placement begins after Christmas in a different school which will give you a contrasting experience and broaden your professional development. Again, you will gradually increase your teaching timetable and for the last few weeks will be full time in school, teaching up to 12 hours per week at that point in May and June.\r\n\r\nPlacements are selected for you on the basis of high quality mentoring, strong subject departments, contrasting schools and reasonable commuting distance. We work with approximately 15 schools in Lancashire. \r\n\r\nOn both placements you will teach the 11-16 age range in your subject. \r\nThere may also be opportunities to spend some time in other partner schools and settings as training needs arise. There will normally be additional opportunities to experience primary education and sixth form education on the programme. \r\n",
+                "interview_process": "We  currently have a blended approach to conducting interviews. Typically, the interview will take place via remote access with assessment tasks completed at a training centre. You will be asked to prepare a lesson plan beforehand and we will ask you about your ideas in the interview. There will also be a subject task and a written task which are normally completed at a named venue.\r\n\r\nWe are looking for the potential to be an excellent trainee, someone who is ready to start training in a school setting from early September. We are also looking for potential employees in our schools.\r\n\r\nThe admissions team are Safer Recruitment trained and we are committed to safeguarding children",
+                "other_requirements": "Applicants who are successful at interview will need the following before they can start the programme:\r\n-\tDBS and barred list check\r\n-\tMedical check\r\n\r\nIt is important that you have a good awareness of what the role of a teacher involves so that you can be sure it is the right career choice for you. We offer school experience for people at all stages of this career decision, including after interview, in order to support you with this.\r\n\r\nWe welcome applicants of all ages, from university graduation to mature career changers.\r\n",
+                "personal_qualities": "We are looking for people who are keen to learn in a school setting and this model suits trainees who are able to learn as they go along and incorporate their own experience into this learning process. Successful applicants will have an understanding of the professionalism and resilience needed to become a teacher and to be reflective learners. A real commitment to a career in teaching, a love of their subject and positive attitude towards young people are essential qualities. ",
+                "required_qualifications": "UK Bachelors degree or equivalent\r\nGCSE Maths and English at grade C/4 or above\r\n\r\nIdeally your degree would be a class 2:2 or above and in a subject relevant to the secondary subject you wish to teach, but there are Subject Knowledge Enhancement courses available for shortage subjects such as Maths, Science, English, and Geography.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964174",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "38RW",
+                "name": "Primary with Mathematics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:58:52.562Z",
+                "uuid": "fbdeca0e-f70b-4535-b6ea-cff8ad7f845a",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Candidates are offerred equivalencies where they have accepted their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:58:52Z",
+                "about_accrediting_body": null,
+                "provider_code": "24H",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "“The quality of training across the partnership is outstanding. A fully comprehensive training programme is in place and ensures complete coverage of the primary curriculum.” Ofsted 2017\r\n\r\n\r\nThis programme aims to support you to become an outstanding primary class teacher, whilst developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\nYou will have the opportunity to access specialist training days and experiences to develop your specialism in Maths, overseen by a national mastery specialist teacher. The programme aims to support you to become an outstanding primary class teacher, developing your knowledge in maths, with the view that you will use this specialism to impact on our schools as you progress through your career. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience underpinned by an innovative and thorough taught programme, leading to the award of QTS and a PGCE, with our partners Nottingham Trent University. \r\n\r\nTrainees spend the greatest proportion of their time in school – please see ‘how placements work’.\r\n\r\nThe taught programme is delivered by outstanding practitioners, who work as teachers in our schools and as leaders of their subjects. This includes English, Maths, Science, Teaching \u0026 Learning, Inclusion and the Foundation Subjects – all up to date theory and practice that is being used with high impact in our schools now. As practising teachers who also guide other schools, our trainers have a wealth of current experience and ideas that you can use. The taught days, alongside a range of fun and immersive opportunities, including our residential, will ensure that you remain motivated throughout the programme and driven to become an exceptional teacher:\r\n\r\n“Laura, Tom and Cath inspired us throughout the programme, kept us going when things got hard and gave us new and innovative ideas to try in the classroom”- ILTT Trainee \r\n\r\nNottingham Trent University provide the PGCE qualification, which brings 60 masters credits. Sessions on campus give you academic underpinning to your teaching practice, with two assignments that weave into your experience in school. The first module takes place with the general primary course and covers Learning Theory, the second module and research project focuses on Maths.\r\n \r\n\r\n [For more information about our course, click here] (https://www.inspiringleadersscitt.com/the-course)\r\nRead comments from our trainees about how our training course inspired them via twitter page @ilscitt\r\n\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\n\r\nFor more information visit our websites:\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n\r\n0116 3184066 or email us at info@iltt.org.uk\r\n",
+                "how_school_placements_work": "“The highly practical, school-based nature of the training which is valued by the trainees because it means they learn from the very best teachers’ practice and are given the time to apply their learning, academic research and training in their own classroom situations.” Ofsted 2017\r\n\r\nYour time in school is the largest part of the training and that in which you apply learning from different strands. It is in school where your teaching is shaped and your individual development needs addressed.\r\nSchool placements are not just about being in class – you will be part of the school team, taking a full part in the life of the school and making a real difference to the experiences for the children.\r\nOur General Primary course will require you working in two contrasting schools across our partnership.\r\nWe call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to gain experience over three age phases: Year 1 or 2; Year 3 or 4; Year 5 or 6.\r\nHost placements are decided based on your home location, your access to transport and other needs. \r\nAlternative placements are still arranged considering your travel, but are also selected to give you a contrasting experience and meet your emerging needs.\r\n\r\nIn each placement you will work in partnership with a Class Mentor, to the advantage of the children, planning and reviewing together. Your class mentor will give you on-going advice and model good practice.\r\nYour professional progress will be supported by an experienced teacher in school – your Learning Coach, who will observe and meet with you weekly.\r\n“I am in no doubt that the support I received from my in-school learning coach enabled me to complete this course and secure my first job as a teacher”- trainee 2017/18\r\n\r\nYour Professional Tutor will work closely with your host school and make visits during the placements.\r\n\r\n\r\n[For more information about our course, click here](https://www.inspiringleadersscitt.com/the-course)\r\n",
+                "interview_process": "\r\n\r\n“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)\r\n",
+                "other_requirements": "\r\nPlease be aware that the welfare of our children is our highest priority, and all offers of training places are subject to DBS, identity and reference checks.\r\n\r\n\r\nCall us on 0116 318 4066 or email (info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\nWe are looking for candidates that are determined to change the lives of children and will put relationships at the heart of everything you do. If you are determined to make an impact on children’s lives, we will support and develop you to be a successful teacher. \r\n",
+                "required_qualifications": "A UK degree is required. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's/equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nA commitment to preparing for teacher training is desirable. This can be through virtual means or via prior school experience. *Talk to us about our Readiness for Teaching programme. (Free virtual sessions to support you in preparing for teaching.) \r\n\r\nILTT has a Self-Assessment Document that will help you to gain the right experience in school to support your application.\r\n\r\nIf you would like to find out more,  please get in touch via our email\r\n(info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966086",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "W541",
+                "name": "Media studies",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "qts",
+                "description": "QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T13:59:01.206Z",
+                "uuid": "b3ef2bbc-8232-4055-a88f-01afa4c7c01e",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:01Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS). \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12965473",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2PFF",
+                "name": "Mathematics",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17977,
+                    "address4": "Hampshire",
+                    "provider_name": "Wildern Partnership",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Gina Farmer",
+                    "year_code": "2019",
+                    "provider_code": "1WH",
+                    "provider_type": "scitt",
+                    "postcode": "SO304EJ",
+                    "website": "http://wildernpartnership.co.uk/",
+                    "address1": "Wildern Partnership, Wildern School",
+                    "address2": "Wildern Lane",
+                    "address3": "Hedge End",
+                    "email": "scitt@wildernpartnership.co.uk",
+                    "telephone": "01489779458",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:56:35.286Z",
+                    "updated_at": "2021-09-29T14:21:16.671Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T14:41:26.603Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The Wildern Partnership SCITT is an outstanding local teacher training provider, developed through years of collaboration with a diverse range of partnership schools, colleges and universities.\r\n\r\nWe offer a school based, collaborative, quality and cross phase training programme which is adapted to your individual needs.\r\n\r\nThe full time one-year training programme in both Primary and Secondary commences in September. Successful completion of your training with us will result in QTS, along with a Postgraduate Certificate of Education (PGCE) at Masters level.\r\n\r\nIn addition to the academic support available we support your wellbeing through; professional coaching; a high level of pastoral care; subsidised gym membership.\r\n\r\n\r\n",
+                    "train_with_disability": "We pride ourselves on supporting those trainees with specific learning difficulties and disabilities, offering bespoke individualised provision.\r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.9188716,
+                    "longitude": -1.3007123,
+                    "ukprn": "10033371",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1WH",
+                "changed_at": "2021-10-01T10:29:27.160Z",
+                "uuid": "2a18c226-c384-4522-a744-a636daed6783",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Candidates will be required to use a third party. Please see our website for details.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T10:29:27Z",
+                "about_accrediting_body": "",
+                "provider_code": "1LC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Wildern Partnership SCITT aims to develop resourceful and reflective early career teachers who are able to motivate learners to engage, achieve and develop. \r\n\r\nOur curriculum is underpinned by four principal strands:\r\n\r\nBehaviours and Relationships; Diversity and Inclusion; Subject Pedagogy and Assessment. \r\n\r\nTeaching timetables build up at an individual rate fully supported by a mentor.\r\n\r\nCurriculum related expectations drive formative and summative assessment through bespoke target setting.\r\n\r\nPhase 1 – Scaffold (Lead School)\r\n\r\n-       Outstanding practice modelled, theory and practice analysed.\r\n-\t Integrated learning experience for general professional studies and \r\nsubject knowledge for teaching.\r\n- \tCore group training where Secondary and Primary trainees received \r\nphased and combined training by Wildern Partnership Specialists.\r\n\r\nPhase 2 – Scaffold and Develop\r\n\r\n-\tTeaching Groups, micro teaching and working with individual children building to whole class planning, teaching and assessment. Individual support from outstanding school based subject leaders and highly trained school based mentors.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study.\r\n \r\nPhase 3 – Develop (Contrasting Setting)\r\n\r\n-\tCurriculum related expectations consolidated and developed in a contrasting setting.\r\n-\tTeaching classes, groups and individual children, supported and assessed by highly trained school based mentors. Embedding subject knowledge for teaching and supporting pupil progress.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n\r\nPhase 4 - Develop and Refine \r\n\r\n-\tReturn to lead school.\r\n-\tBegin to embed practice from second school experience.   \r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-      Time spent in alternative settings/school as part of an enrichment programme.\r\n-      Optional start of second subject or SEND enrichment programme.\r\n\r\nPhase 5/6 – Refine and Enrich\r\n\r\n-\tRefine teaching practice to develop autonomy in the classroom.\r\n- \tSCITT support for local Early Career Teachers, School CPD in mentoring / subject knowledge / MA level study / diverse bespoke needs.\r\n-\tPreparing for Employment in Education.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-\tFurther completion of teaching time, should any long periods of absence arise throughout the year.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "This is a school direct course, therefore the school placement is already determined when you apply.\r\n",
+                "interview_process": "Secondary SCITT  and School Direct Tuition Fee applicants – \r\nIf shortlisted for an interview you will be invited to Wildern School or a partnership school where you will; plan and facilitate, a teaching activity, undertake a Subject Knowledge Audit, English and Maths skills audit, complete a written task,take part in an organisational group activity and have an individual formal interview.\r\n\r\nAs this is a School Direct placement, should you be successful in the initial interview, you will be required to attend a second interview with the relevant school.\r\n\r\nPLEASE NOTE: Due to the Covid-19 pandemic the interview process is subject to change. Should this be the case, the SCITT Administration Team will inform applicants. ",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "Applicants must hold a degree of a UK university, higher education institution or an acceptable equivalent at 2:2 or above. Their degree should include a minimum content of 50% which is directly related to the subject which they are training to teach. \r\n\r\nApplicants must be in possession of appropriate prior qualifications including GCSE grade C or above in English (or English Language) and Mathematics.\r\n\r\nApplicants are required to have passed the professional skills tests before the start of the course.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964172",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2VPH",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:59:44.031Z",
+                "uuid": "a48edf67-b66f-4236-84b9-afd87c0a53ec",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalencies are offerred to trainees that accept their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:44Z",
+                "about_accrediting_body": null,
+                "provider_code": "24H",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "\r\n“The quality of training across the partnership is outstanding. A fully comprehensive training programme is in place and ensures complete coverage of the primary curriculum.” Ofsted 2017\r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience underpinned by an innovative and thorough taught programme, leading to the award of QTS and a PGCE, with our partners Nottingham Trent University. \r\n\r\nTrainees spend the greatest proportion of their time in school – please see ‘how placements work’.\r\n\r\nThe taught programme is delivered by outstanding practitioners, who work as teachers in our schools and as leaders of their subjects for the partnership. This includes English, Maths, Science, Teaching \u0026 Learning, Inclusion and the Foundation Subjects – all up to date theory and practice that is being used with high impact in our schools now. As practising teachers who also guide other schools, our trainers have a wealth of current experience and ideas that you can use. The taught days, alongside a range of fun and immersive opportunities, including our residential, will ensure that you remain motivated throughout the programme and driven to become an exceptional teacher:\r\n“Laura, Tom and Cath inspired us throughout the programme, kept us going when things got hard and gave us new and innovative ideas to try in the classroom”- ILTT Trainee\r\n\r\nNottingham Trent University provide the PGCE qualification, which brings 60 masters credits. Sessions on campus give you academic underpinning to your teaching practice, with two assignments that weave into your experience in school. \r\n\r\nYour progress across the course is supported and monitored by our highly experienced Professional Tutor team, who will give both pastoral and developmental support over the year, ensuring that you are able to make the most of all elements of the course. \r\n\r\n [For more information about our course, click here] (https://www.inspiringleadersscitt.com/the-course)\r\nRead comments from our trainees about how our training course inspired and supported them on our twitter page @ilscitt\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\nFor more information visit our websites:\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n\r\n0116 3184066 or email us at info@iltt.org.uk\r\n",
+                "how_school_placements_work": "\r\n“The highly practical, school-based nature of the training which is valued by the trainees because it means they learn from the very best teachers’ practice and are given the time to apply their learning, academic research and training in their own classroom situations.” Ofsted 2017\r\n\r\nYour time in school is the largest part of the training and that in which you apply learning from the other strands. School placements are not just about being in class – you will be part of the school team, taking a full part in the life of the school and making a real difference to the experiences and outcomes for the children in your care.\r\nOur General Primary course will require you working in two contrasting schools across our partnership.\r\nWe call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to gain experience over three age phases: Year 1 or 2; Year 3 or 4; Year 5 or 6.\r\nHost placements are decided based on your home location, your access to transport and other needs. \r\nAlternative placements are still arranged considering your travel, but are also selected to give you a contrasting experience and meet your emerging needs.\r\n\r\nIn each placement you will work in partnership with a Class Mentor, to the advantage of the children, planning and reviewing together. Your class mentor will give you on-going advice and support as well as modelling good practice.\r\nYour professional progress will be formally supported by an experienced teacher in school – your Learning Coach, who will observe and meet with you weekly.\r\n“I am in no doubt that the support I received from my in-school learning coach enabled me to complete this course and secure my first job as a teacher”- trainee 2017/18\r\n\r\nYour Professional Tutor will work closely with your host school and make visits during the placements.\r\n\r\n\r\n[For more information about our course, click here](https://www.inspiringleadersscitt.com/the-course)\r\n",
+                "interview_process": "“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)\r\n",
+                "other_requirements": "\r\nPlease be aware that the welfare of our children is our highest priority, and all offers of training places are subject to DBS, identity and reference checks.\r\n\r\n\r\nCall us on 0116 318 4066 or email (info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\nWe are looking for candidates that are determined to change the lives of children and will put relationships at the heart of everything you do. If you are determined to make an impact on children’s lives, we will support and develop you to be a successful teacher. \r\n",
+                "required_qualifications": "A UK degree is required. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's/equivalent at grade C/4 or above in English, Mathematics and Science.\r\n\r\nA commitment to preparing for teacher training is desirable. This can be through virtual means or via prior school experience. *Talk to us about our Readiness for Teaching programme. (Free virtual sessions to support you in preparing for teaching.) \r\n\r\nILTT has a Self-Assessment Document that will help you to gain the right experience in school to support your application.\r\n\r\nIf you would like to find out more,  please get in touch via our email\r\n(info@iltt.org.uk)\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.flyinghighpartnership.co.uk)\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963536",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Q358",
+                "name": "Mathematics",
+                "study_mode": "part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T13:59:06.496Z",
+                "uuid": "f6432a74-83d4-4b26-86d5-3f3ebf37bce6",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": null,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\nWe will consider accepting equivalency tests in lieu of GCSE English \u0026 Maths (grade 4 (C) or above ) on an individual basis.\r\n",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:59:06Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September 2022 until June 2024. Carefully designed, delivered by experienced practising teachers  to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid- September. \r\n\r\nYou will undertake most of the remaining cohort training alongside full time trainees during your first year, whilst also spending two days in school. You therefore need to commit to three days per week in year one. In year two you will generally spend three days in school and will undertake bespoke training as appropriate either as part of the part time cohort or individually. \r\n\r\nAdditionally, our programme offers: \r\n\r\n* A minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\n* Weekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\n\r\nOur schools comprise predominantly of comprehensive schools including schools. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through: \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are four formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term of Year 2. \r\n\r\nWritten submissions are evenly spread throughout the programme. The wellbeing of our trainees is of the utmost importance to us, we provide various options to support you. \r\n\r\nPGCE (Post Graduate Certificate in Education – 60 Master credits)  lectures are held locally. Trainees undertake 3 additional assignments. Award is validated by University of Buckingham. ",
+                "course_length": "TwoYears",
+                "fee_details": "The fees above include the PGCE element of the programme in addition to the QTS.\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. The QTS only part time programme will be £10500 in total ( correct as at 01/10/2020)",
+                "fee_international": 11500,
+                "fee_uk_eu": 11500,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements are carefully selected to ensure they give excellent but contrasting experiences whilst considering a reasonable travelling distance from your home.  \r\n\r\nWe know many of our Professional Tutors and School Mentors well and try to match our trainees with their mentor to build that strong professional relationship. \r\n\r\nAs a part-time trainee, you'll have two placement schools. Effectively, you will have 6 terms, 3 per year.  Terms 1, 4, 5, 6 will be in School A and terms 2 \u0026 3  in School B. The two schools will provide a contrasting learning environment. \r\n\r\nEvery Thursday during the first year of training you will receive general professional and subject knowledge sessions, complimented by specific bespoke training as appropriate in your second year.  \r\n\r\nYou will start undertaking structured observations of teachers followed by team teaching, part lesson then full lesson teaching. \r\n \r\n Our schools comprise predominantly of comprehensive schools but include a Church of England school. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings.  \r\n\r\n Schools play such an important part in the programme, and that’s why we can provide you with an outstanding foundation on which to build your future career. You will have an expert school-based Mentor and a designated Senior Link (Professional Tutor) in each placement school and they will be trained by, and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. \r\n\r\n“You all, along with everyone at school, made my first term of training to teach the best experience ever. I was able to learn so much from everyone and you were all incredibly supportive in the process! I honestly can’t sing your praises highly enough!” \r\n\r\n“The support provided at each school was outstanding, both the support from my mentor and regular training sessions allowed me to start my NQT year feeling confident and equipped with the correct knowledge to start my career. I would highly recommend both schools as fantastic places to start your career as a teacher”.   \r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools.  \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\n* Welcome by a member of the SCITT team\r\n\r\n* Document check \u0026 hand in of your pre completed subject audit form\r\n\r\n* Tour of the school in which the interview takes place\r\n\r\n* A 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking SKE \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other safer recruitment processes to verify their suitability to work with young people. \r\n\r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS) - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training. Arrangements for completing DBS check applications will be explained as part of the selection and induction process.\r\n\r\nChecking the Prohibited Teachers List\r\n\r\nChecking references and gaining reassurance where necessary",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": "ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969992",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "S626",
+                "name": "Mathematics",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS, full time or part time with salary",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "salary",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17803,
+                    "address4": "Brighton and Hove",
+                    "provider_name": "University of Sussex",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Coordinator",
+                    "year_code": "2019",
+                    "provider_code": "S90",
+                    "provider_type": "university",
+                    "postcode": "BN1 9QQ",
+                    "website": "http://www.sussex.ac.uk/education/ite",
+                    "address1": "Sussex School of Education",
+                    "address2": "Essex House",
+                    "address3": "Falmer, Brighton",
+                    "email": "iteadmissions@sussex.ac.uk",
+                    "telephone": "01273 873238",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:54:44.013Z",
+                    "updated_at": "2021-09-20T12:03:01.948Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T12:02:30.208Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Sussex Schools Partnership offers high quality professional and academic teaching courses leading to Qualified Teacher Status (QTS), a PGCE of 90 Masters Level Credits and a progression route onto a Masters in Education. \r\n\r\n\r\nWith a history of innovation we pioneered a model of school-based teacher training 50 years ago, now adopted nationally. Schools are involved at every stage of the selection, training and assessment of our beginner teachers. This long standing relationship results in excellent support from experienced teachers mentoring trainees on placement and dedicated University tutors offering models of successful pedagogy. As a small friendly department we offer our trainees a personal approach and  aftercare support and training as Newly Qualified Teachers\r\n\r\n\r\nWe train 'thinking' teachers with a over riding desire to make a difference to the lives of young people.   \r\nA research intensive university, we believe teachers benefit from critical engagement in evidence-based practice, reflection on research and continuing professional development as well as excellent practical classroom skills. \r\n\r\nOur University sits on a leafy campus at the edge of the South Downs National Park, accessible by road or rail from East and West Sussex, Brighton and Hove, Surrey, Kent, Hampshire and South London. The historic seaside city of Brighton is minutes away, with its pebble beaches and vibrant social and cultural opportunities.\r\n\r\n\r\nCourse outcomes are consistently high;  100% achieving QTS on first attempt, \r\n94% completing with Merit or Distinction,  \r\n98% securing a teaching post and \r\n99% of ex-trainees rating the course 'good' or 'very good'.  \r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+                    "train_with_disability": "The University of Sussex welcomes applications from all candidates who have the potential to make excellent teachers regardless of disability and additional needs. \r\n\r\nWe have previously successfully supported trainee teachers with dyslexia, dyspraxia, aspergers, mental wealth conditions and a range of physical, hearing and visual impairments.\r\n\r\nAll trainee teachers  are first screened for mental and physical fitness to teach by the University's Occupational Health Department before admission to the programme.  Following this, if you have a disability or health condition, you will register with the University Student Support service and an assessment is arranged to establish your needs. The team will identify the additional support and adjustments  recommended to help you be as successful as possible on the course.\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.8670895,
+                    "longitude": -0.087914,
+                    "ukprn": "10007806",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "S90",
+                "changed_at": "2021-10-01T10:21:16.592Z",
+                "uuid": "a0a85357-8c8c-4554-8b76-8c5d9952524b",
+                "program_type": "school_direct_salaried_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-24T10:16:42Z",
+                "about_accrediting_body": "Offering a Postgraduate Certificate in Education (PGCE) in Primary (ages 5-11) and Secondary (11-16) with specialisms in over eight subjects.  For the latter, professional practice is focused on Key Stages 3 and 4. \r\n\r\nCommitted to high-quality teacher education built upon genuine partnerships, inspired by best classroom practice, and engaged in teaching as an intellectual and ethical vocation. Our goal is to recognise, support and develop a generation of reflective practitioners who are ready, willing and able to improve the life chances of every young person they teach.",
+                "provider_code": "2CC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Successful applicant(s) for this course are usually placed at Knole Academy Sevenoaks.  \r\nOur well-established and long-running programme provides trainees with the opportunities to undertake a practical and theoretical training programme in a vibrant and dynamic primary or secondary school environment.   \r\nOur School Direct programme is delivered in conjunction with our accrediting training provider, the University of Sussex.  Trainees will undertake four days of training per week in their placement school and attend the University of Sussex on Fridays to undertake sessions that cover the theory and practice of teaching.  Trainees will attend a 3-week induction in September at the University of Sussex, thereafter the main school placements will commence with the first week being comprised of a detailed induction by your school's professional and subject mentors.  Trainees will carry out detailed lesson observations for the first two to three weeks followed by around 5 hours of teaching per week, with the number of hours increasing throughout the year as your professional skills and confidence increases.\r\nTrainees will also continue to have professional development sessions with their relevant mentors throughout the year.  Sessions will focus on the development of your subject knowledge and the craft of teaching through observing other teachers, team-teaching, joint planning sessions, etc.  We will also organise for our trainees a 4-6 weeks placement in a complementary school during the latter part of the academic year.  This will provide trainees with a comprehensive understanding of teaching in different school environments. \r\nAll trainee teachers must demonstrate that they have met the Teachers’ Standards in order to gain Qualified Teacher Status (QTS). You will keep a portfolio of evidence to show that you have done so. \r\nPart-time participants will undertake the programme over a 2-year training programme with hours increasing year-on-year.  During the first year, you will teach two days per week with Fridays at Sussex, and submit the main 6,000 word written assessment comprised of a series of lessons that you will design, teach, evaluate and analyse at Master’s Degree level.  In the second year you will teach for three days per week with a 5-week block of teaching at the end of your course.  \r\nSuccessful School Direct trainees will gain Qualified Teacher Status (QTS) with the option to achieve a Postgraduate Certificate in Education (PGCE) from the University of Sussex worth 60 Masters level credits.\r\n[Kent Oaks Consortium](http://www.kentoaksconsortium.co.uk/)\r\n[University of Sussex Teacher Training](http://www.sussex.ac.uk/education/ite/schooldirect)\r\n",
+                "course_length": "1 year FT, 2 Year PT",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": null,
+                "financial_support": null,
+                "how_school_placements_work": "All primary and secondary schools within the consortium are based in West Kent, including the lead school, Knole Academy, and they undergo continuous quality assurance in order to provide rigorous training standards.  We currently have seven partner school within the consortium.  We have limited availability in each secondary school subject area placements and primary school placements, therefore applicants are advised to apply as early as possible.",
+                "interview_process": "Candidates’ applications will be processed via the university clearing system, UCAS. After an initial screening to check you meet the minimum entry requirements your application will then be read by an expert panel who will invite successful applicants to interview. The interview will take place at the lead school (Knole Academy) or in one of our partnership schools and is likely to include a preliminary interview comprised of:\r\n\r\n * A Short 20 Minutes Teaching Session - potential secondary trainees are required to teach a given task and primary trainees can choose an appropriate activity. Tasks can be found on the Resources page.\r\n * Written Tasks - designed to assess the quality of candidates’ written English and their understanding of current issues in education \r\n * Student Interview - a selection of students across the year groups will conduct an informal interview for secondary applicants\r\n * Formal Interview - panel interview with members of the selection panel \r\n * A Brief (10 Minutes) Presentation – this will be on an aspect of your subject which you feel is misunderstood or difficult to teach.\r\n\r\nCandidates will be advised of the exact format in advance.  There will then be a second interview/meeting with The University of Sussex.\r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": "Trainees will be paid as an unqualified teachers' pay of around £17,700 per annum"
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969830",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "M778",
+                "name": "Primary",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "5_to_11",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-24T10:20:48.544Z",
+                "uuid": "e4d37b9a-0cc3-4f8c-ae1e-e5eaa183041d",
+                "program_type": "higher_education_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-24T10:20:48Z",
+                "about_accrediting_body": null,
+                "provider_code": "N36",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "university",
+                "about_course": "Overview\r\nChoosing to study a PGCE in Primary Education is your first step to inspiring children in learning about their world, and we here at Newman University would love to support you in joining the profession. We understand that the Primary 3-11 age range is a crucial time for children’s development and learning. It is at this formative and particularly receptive stage of development that attitudes towards learning are formed, attitudes that will impact on future life course development. \r\nThe PGCE Primary (3-11) is designed to prepare you for teaching across the Primary age range. There are three modules developed to support your knowledge and understanding of theory, policy and practice, including the Early Years, National Curriculum and SEND frameworks. Two level 7 modules are linked to children’s learning and development as well as curriculum, assessment and pedagogy and you will study these consecutively in the first and second term. The final training module, studied across all three school terms, enables you to observe, reflect on and then undertake the role of the teacher in the Primary phase. The course will enable you to meet the requirements for Qualified Teacher Status (QTS). For those wishing to work within Catholic schools, or who wish to develop their understanding of Religious education, there is also the opportunity to undertake the Catholic Certificate in Religious Studies (CCRS) – see Additional Information for details.\r\nTo ensure that the course content is as up-to-date and relevant to current teaching theory and practice as possible, this course will be re-validated at least every five years or sooner, if external changes require it.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "Unfortunately we are unable to accept international students as we do not hold a Tier 4 Licence,",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "Please refer to our website for further details www.newman.ac.uk ",
+                "how_school_placements_work": "School-based learning is central to the PGCE programme and will be a feature of all three terms of your PGCE year. You undertake placements in at least two primary schools providing opportunities to observe and practise a range of methods and approaches. School-based learning includes observation of experienced teachers, a structured programme of group and whole class teaching and a series of directed activities to explore wider school issues.\r\n\r\n",
+                "interview_process": "Our aim is to make this a two way informative process that is as enjoyable as possible, despite being an interview. We want every candidate to have the opportunity to demonstrate their potential to be a good teacher and to thrive as a teacher in their following career.\r\n\r\nFull details of the interview process will be sent to applicants who have progressed successfully to this stage, further details can also be found on the Newman website.\r\n\r\nInterview candidates will be invited to our Faculty of Education to meet academic staff and tutors. \r\n\r\nThe interview day is made up of 2 main components:\r\n● Micro-teaching session with a small group of other candidates, \r\nInterviewers will be looking for you to include: a brief introduction; a main body, engaging the audience and making good use of the available time; a definitive ending summarizing the learning\r\n● Personal interview. The interviewer will use your personal statement as a starting point, to find out about you and your interests, experiences and skills relevant to becoming a teacher\r\n\r\nWe will be looking for:\r\n● Your passion to become an outstanding teacher\r\n● Good communication skills, including an ability to speak confidently  and communicate effectively with individuals and groups\r\n● A knowledge of the National Curriculum in your subject or age area and current educational developments",
+                "other_requirements": "Obtaining a Disclosure and Barring (DBS) clearance and meeting the requirements for Fitness to Teach are also required.\r\n\r\nSchool experience is desirable, but not an essential requirement prior to interview. However, having experience in a school will:\r\n\r\n * Allow you to add additional information at interview about the experience that you have had when working with children\r\n * Give you an advantage when you start the course as you will be able to make links between your learning and how this relates to school",
+                "personal_qualities": "The quality and variety of your personal statement is an important factor in the decision to call you to interview. Candidates must attend an interview at Newman University.\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12965470",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "26JT",
+                "name": "Modern Languages",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17977,
+                    "address4": "Hampshire",
+                    "provider_name": "Wildern Partnership",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Gina Farmer",
+                    "year_code": "2019",
+                    "provider_code": "1WH",
+                    "provider_type": "scitt",
+                    "postcode": "SO304EJ",
+                    "website": "http://wildernpartnership.co.uk/",
+                    "address1": "Wildern Partnership, Wildern School",
+                    "address2": "Wildern Lane",
+                    "address3": "Hedge End",
+                    "email": "scitt@wildernpartnership.co.uk",
+                    "telephone": "01489779458",
+                    "region_code": "south_east",
+                    "created_at": "2021-07-06T10:56:35.286Z",
+                    "updated_at": "2021-09-29T14:21:16.671Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T14:41:26.603Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The Wildern Partnership SCITT is an outstanding local teacher training provider, developed through years of collaboration with a diverse range of partnership schools, colleges and universities.\r\n\r\nWe offer a school based, collaborative, quality and cross phase training programme which is adapted to your individual needs.\r\n\r\nThe full time one-year training programme in both Primary and Secondary commences in September. Successful completion of your training with us will result in QTS, along with a Postgraduate Certificate of Education (PGCE) at Masters level.\r\n\r\nIn addition to the academic support available we support your wellbeing through; professional coaching; a high level of pastoral care; subsidised gym membership.\r\n\r\n\r\n",
+                    "train_with_disability": "We pride ourselves on supporting those trainees with specific learning difficulties and disabilities, offering bespoke individualised provision.\r\n\r\n\r\n\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 50.9188716,
+                    "longitude": -1.3007123,
+                    "ukprn": "10033371",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1WH",
+                "changed_at": "2021-10-01T10:29:57.137Z",
+                "uuid": "e3c2c028-7902-4b8d-a403-9b0e09aa8449",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "Candidates will be required to use a third party. Please see our website for details.",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-01T10:29:57Z",
+                "about_accrediting_body": "",
+                "provider_code": "1LC",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Wildern Partnership SCITT aims to develop resourceful and reflective early career teachers who are able to motivate learners to engage, achieve and develop. \r\n\r\nOur curriculum is underpinned by four principal strands:\r\n\r\nBehaviours and Relationships; Diversity and Inclusion; Subject Pedagogy and Assessment. \r\n\r\nTeaching timetables build up at an individual rate fully supported by a mentor.\r\n\r\nCurriculum related expectations drive formative and summative assessment through bespoke target setting.\r\n\r\nPhase 1 – Scaffold (Lead School)\r\n\r\n-       Outstanding practice modelled, theory and practice analysed.\r\n-\t Integrated learning experience for general professional studies and \r\nsubject knowledge for teaching.\r\n- \tCore group training where Secondary and Primary trainees received \r\nphased and combined training by Wildern Partnership Specialists.\r\n\r\nPhase 2 – Scaffold and Develop\r\n\r\n-\tTeaching Groups, micro teaching and working with individual children building to whole class planning, teaching and assessment. Individual support from outstanding school based subject leaders and highly trained school based mentors.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study.\r\n \r\nPhase 3 – Develop (Contrasting Setting)\r\n\r\n-\tCurriculum related expectations consolidated and developed in a contrasting setting.\r\n-\tTeaching classes, groups and individual children, supported and assessed by highly trained school based mentors. Embedding subject knowledge for teaching and supporting pupil progress.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n\r\nPhase 4 - Develop and Refine \r\n\r\n-\tReturn to lead school.\r\n-\tBegin to embed practice from second school experience.   \r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-      Time spent in alternative settings/school as part of an enrichment programme.\r\n-      Optional start of second subject or SEND enrichment programme.\r\n\r\nPhase 5/6 – Refine and Enrich\r\n\r\n-\tRefine teaching practice to develop autonomy in the classroom.\r\n- \tSCITT support for local Early Career Teachers, School CPD in mentoring / subject knowledge / MA level study / diverse bespoke needs.\r\n-\tPreparing for Employment in Education.\r\n-\tMost Fridays are based at the training centre and other partner institutions for general professional studies and/or subject specific study. \r\n-\tFurther completion of teaching time, should any long periods of absence arise throughout the year.\r\n\r\n\r\n\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "This is a school direct course, therefore the school placement is already determined when you apply.\r\n",
+                "interview_process": "Secondary SCITT  and School Direct Tuition Fee applicants – \r\nIf shortlisted for an interview you will be invited to Wildern School or a partnership school where you will; plan and facilitate, a teaching activity, undertake a Subject Knowledge Audit, English and Maths skills audit, complete a written task,take part in an organisational group activity and have an individual formal interview.\r\n\r\nAs this is a School Direct placement, should you be successful in the initial interview, you will be required to attend a second interview with the relevant school.\r\n\r\nPLEASE NOTE: Due to the Covid-19 pandemic the interview process is subject to change. Should this be the case, the SCITT Administration Team will inform applicants. ",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": "Applicants must hold a degree of a UK university, higher education institution or an acceptable equivalent at 2:2 or above. Their degree should include a minimum content of 50% which is directly related to the subject which they are training to teach. \r\n\r\nApplicants must be in possession of appropriate prior qualifications including GCSE grade C or above in English (or English Language) and Mathematics.\r\n\r\nApplicants are required to have passed the professional skills tests before the start of the course.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969838",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Y390",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17626,
+                    "address4": "Leeds",
+                    "provider_name": "Leeds Trinity University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Leeds Trinity University",
+                    "year_code": "2019",
+                    "provider_code": "L24",
+                    "provider_type": "university",
+                    "postcode": "LS18 5HD",
+                    "website": "https://www.leedstrinity.ac.uk",
+                    "address1": "Leeds Trinity University",
+                    "address2": "Brownberrie Lane",
+                    "address3": "Horsforth",
+                    "email": "admissions@leedstrinity.ac.uk",
+                    "telephone": "0113 283 7123",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:52:55.297Z",
+                    "updated_at": "2021-09-22T14:14:08.925Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T13:50:19.392Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Leeds Trinity University has been synonymous with high quality teacher training since 1966, when we were founded as a Catholic teacher training college. \r\n\r\nOver the years, we’ve diversified and expanded to become renowned for teaching excellence and producing highly employable graduates across many subject areas, but an unwavering commitment to outstanding teacher training has remained at the heart of what we do. \r\n\r\nRecognising that people begin PGCE courses with different levels of experience and skills, we train you in three stages to build your confidence and capability with a mix of research-informed practice, school-based training and plenty of one-to-one support. \r\n\r\nWe work with over 600 schools – from small rural schools to large, inner-city high schools. We work with ‘Outstanding’ schools leading innovations in education, as well as schools that may have difficulties in reaching outcome targets at the end of key stages. \r\n\r\nWhen you train with Leeds Trinity, you’ll experience best practice in school improvement, whichever school you train in.\r\n\r\nYou’ll work with expert school mentors while on placement and receive help, advice and support from University-based link tutors. This combination means you’ll get specialist training on teaching the most difficult aspects of subject content, and understanding children and young people at various ages and stages of development.\r\n\r\nAfter you graduate, we offer excellent support for teachers in the early stages of their career, and have a very strong Early Career Teacher (ECT) programme, with CPD, an active online community, and an annual conference.",
+                    "train_with_disability": "We’re committed to ensuring that every student with potential, regardless of their background or circumstances, has the opportunity to benefit from higher education. \r\n\r\nIf you have a disability or additional needs, Leeds Trinity University will endeavour to put in place reasonable adjustments to accommodate any additional requirements throughout your teacher training year. We’re able to support with conditions such as: \r\n\r\n-\tDyslexia\r\n-\tSpecific learning difficulties\r\n-\tAsperger syndrome/autism\r\n-\tVisual/hearing impairments\r\n-\tPhysical and mobility restrictions\r\n-\tLong-term medical conditions\r\n-\tA mental health condition. \r\n\r\nIf you register with our Disability Service, a member of the team will develop a Learning Support Plan tailored to your specific needs. The support within this plan could include exam adjustments, extended library loans, specialist one-to-one study skills, dyslexia screening and assessments, learning materials provided in alternative formats and alternative assessments.\r\n\r\nWith your permission, they’ll share this plan with your University-based personal tutor so that they know how to best support you during your University-based training. They can also share this plan with the School Partnerships team, who are able to inform the host schools for your placements so they can discuss how to best support you during your school-based training. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.8481606,
+                    "longitude": -1.6459213,
+                    "ukprn": "10003863",
+                    "urn": "133838",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "L24",
+                "changed_at": "2021-08-25T13:14:39.980Z",
+                "uuid": "1d3f1642-015f-4840-b334-2567637d790b",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "Degree subject should match or be closely related to Biology.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-08-25T13:14:39Z",
+                "about_accrediting_body": null,
+                "provider_code": "2C3",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "On successful completion of the course students are awarded QTS, PGCE, comprising 60 credits at Master Level 6. \r\n\r\nStudents are placed in two highly performing schools, mentored by good and outstanding teachers. \r\n\r\nThey will experience all aspects of school life which is invaluable when applying for future teaching positions. \r\n\r\nStudents will spend more than 120 days in schools on placement. \r\n\r\nWe arrange for students visit provision to increase their awareness of where children transition from and to (pre and post secondary), providing a holistic understanding of childrens progression. \r\n\r\nStudents will also have the opportunity to view best practice for SEN and EAL children. \r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "The course begins with an induction at Horizon CC before commencing the first placement in an alternative school. After Christmas the remainder of the school year is spent at Horizon CC in their Science department.\r\n\r\nLocated in a suite of state of the art, fully resourced labs, the Science Department at Horizon offers a fantastic environment in which to begin your teaching journey. In total we have 7 full Science labs, 6 STEM rooms and one electronics room – all of which are maintained and resourced by two experienced lab technicians. Our schemes of learning aim to equip students with the knowledge, skills and mindset that will enable them to succeed to potential in their Science GCSEs and prosper in post-16 opportunities beyond this. We provide many opportunities for students to visit places of significant scientific interest in both Britain and Europe, and our dedicated STEM lead is currently planning a trip to CERN in Geneva for some of our keenest scientists. The Department has a wealth of experience in developing early career teachers, so why not come and join this excellent team!\r\n\r\n ",
+                "interview_process": "We invite applicants who successfully meet the application criteria to attend a Selection Event at Horizon Community College.  \r\n\r\nThe event will be led by staff from our partnership schools along with a staff member from Tykes Teaching Alliance. The event will last approximately two to three hours and will include:\r\n\r\nA meet \u0026 greet – an introductory talk about the course and Tykes   Teaching School Alliance \r\nA learning walk – where you will be shown around school by a group of pupils\r\nAn individual interview\r\nA teaching task \r\n\r\nAt this stage we assess your;\r\n•         ability to communicate clearly, both orally and on paper\r\n•         knowledge of the area of education you are interested in\r\n•         interest in, and commitment to, a career in teaching\r\n•         ability to work effectively with children in an educational setting (for primary education courses you will need to bring the reference from the educational setting you attended)\r\n \r\nPlease note that during the Covid-19 pandemic we are conducting Selection Events remotely via Zoom. \r\n",
+                "other_requirements": null,
+                "personal_qualities": null,
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966468",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "T805",
+                "name": "Primary (3-7)",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17512,
+                    "address4": "Leicestershire",
+                    "provider_name": "Inspiring Leaders with Discovery Schools Trust",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Fossebrook Primary School",
+                    "year_code": "2019",
+                    "provider_code": "1BJ",
+                    "provider_type": "scitt",
+                    "postcode": "1 School Lane",
+                    "website": "http://www.inspiringleadersscitt.com",
+                    "address1": "Discovery Schools NSPCC Training Centre",
+                    "address2": "NSPCC National Training Centre",
+                    "address3": "Leicester",
+                    "email": "jvenables@iltt.org.uk",
+                    "telephone": "01163184066",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:51:32.479Z",
+                    "updated_at": "2021-10-05T14:44:51.060Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T14:44:51.060Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Inspiring Leaders Teacher Training, is an Ofsted 'Outstanding' rated partnership of schools working across Leicestershire, Leicester and Rutland, working together to develop outstanding teachers and leaders of the future. \r\n\r\nAs Discovery Schools Academy Trust  we are committed to helping every child the opportunity to 'Discover their Potential' and believe the best way to achieve this is through outstanding teaching and leadership. \r\n\r\nAll of the schools you will be based within, aspire for our schools to be the best paces for children to learn and develop their full potential. To achieve this we need to recruit, support and invest in teachers with the passion and determination to provide outstanding opportunities and experiences for our children. \r\n\r\nOur SCITT / School Direct training route provides all trainees with a blend of school experience alongside an innovative and inspiring taught programme, leading to the award of QTS and a PGCE, with our partners the University of Leicester.\r\n\r\nWe are passionate, experienced and successful at developing great teachers with 100% of our trainees being successfully employed in the past 3 years.\r\n\r\nWe offer more than just a one year teacher training programme by supporting trainees into employment in our schools and delivering ongoing career opportunities tailored to their needs.\r\n\r\n[For more information visit our websites:]\r\n(https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)\r\n\r\nCall us on 0116 3184066 or email us at info@iltt.org.uk\r\n",
+                    "train_with_disability": "We are an equal opportunities provider and provide support for all our students with their learning requirements. \r\n\r\nOur partner universities provide support for trainees with different needs and learning requirements. \r\n\r\nThis can be discussed at the screening and interview process. ",
+                    "accrediting_provider_enrichments": [
+                        {
+                            "Description": "We work tirelessly to ensure that all of our trainees are supported and become great teachers. In 2018/19 of those who completed the course – 100% of them moved into jobs in local schools and are now accessing high quality support in their first year of teaching.\r\n\r\nWe work with the University of Leicester to award PGCE to all trainees on our programme.",
+                            "UcasProviderCode": "2A5",
+                            "validation_context": null
+                        }
+                    ],
+                    "latitude": 52.6672396,
+                    "longitude": -1.1643891,
+                    "ukprn": "10055365",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "1BJ",
+                "changed_at": "2021-10-05T14:05:34.199Z",
+                "uuid": "778daece-05ca-4ee5-bfdf-3e630c9fb083",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "We offer equivalencies for those candidates that have accepted their places with ILTT. ",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:05:34Z",
+                "about_accrediting_body": null,
+                "provider_code": "5W1",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Trainees will work alongside others on the 5-11 pathway to ensure that they are also gaining an overview of primary education to recognise their role within the bigger picture of a child’s journey in school. Placements will provide experiences in EYFS and Key Stage 1. The first term will be in KS1 to ensure that knowledge and theory from teaching can be embedded. Trainees will then move into an EYFS setting during their alternative placement. \r\nSchool based training alongside training sessions and high quality tutoring and mentoring will provide opportunities for trainees to plan, teach and manage learning for children aged 3-7 years. Trainees will therefore have the ability to assess and progress learning, build professional relationships and maintain high quality learning environments. \r\nSpecialist sessions will be provided by an SLE in Early Years supported by other relevant personnel to ensure that the trainees have a broad view of the EYFS provision. Additional sessions will allow trainees to experience specialist knowledge at a greater depth and couple it with tasks and experiences in their host schools\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "course_length": "OneYear",
+                "fee_details": "Financial Support\r\n\r\nOn our course, trainees are entitled to the same financial support as other teacher training courses. Those from the UK or EU are eligible for student loans in order to help cover tuition fees and maintenance.\r\n\r\nTo find out more about your a student finance loan please see our website. \r\n\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "\r\n\r\n\r\n \r\n[Click here:](https://www.inspiringleadersscitt.com)\r\n\r\n\r\n0116 3184066 or email us at info@iltt.org.uk",
+                "how_school_placements_work": "\r\nOur EYFS course will require you working in two contrasting schools across our partnership, depending on the location selected. We call these placements your host and your alternative school. You will complete your placement at your host school in the Autumn and Summer term, whilst your alternative placement will be completed in the Spring term. With each placement, you will change year group to cover these 3 age phases: EYFS, Year 1 and Year 2. \r\n\r\n[Click here](https://www.inspiringleadersscitt.com/the-course)",
+                "interview_process": "“Leaders are constantly evaluating the recruitment and selection processes to make sure they attract high-quality candidates with the skills, the moral purpose and the ‘staying power’ to be a successful teacher” – Ofsted 2017\r\n\r\n\r\nSelecting the right people to train with us in our schools is of utmost importance.\r\nOur interviews take place within our schools and  we aim to make you feel relaxed enough to show us who you really are.\r\nThe interview includes includes: \r\n•\tan opportunity to find out more about us\r\n•\ta formal interview in which we find out more about you and establish whether you are suitable to train with us and in our schools;\r\n•\tA  lesson that you will pre-plan and deliver to a small group of children (Full details are provided prior to the interview)\r\n•\tSafeguarding \u0026 identity checks.\r\n\r\n[Applying to our course] (https://www.inspiringleadersscitt.com/applying)",
+                "other_requirements": "Call us on 0116 318 4066 or email info@iltt.org.uk\r\n[Click here](https://www.inspiringleadersscitt.com)\r\n(https://www.discoveryschoolstrust.org.uk/)",
+                "personal_qualities": "At Inspiring Leaders Teacher Training we are looking for 5 key qualities in our trainee teachers. These key qualities are what we think you will need in order to help you become a Qualified Teacher.\r\n*Emotional Intelligence and Resilience\r\n*Knowledge and Professionalism\r\n*Creativity\r\n*Good Communication Skills\r\n*A Capable Reflector\r\n\r\nWe are looking for candidates that have a good awareness of current educational issues and have a deep understanding and open mind about how they affect children and schools. As well as an ability to act with professionalism and integrity. ",
+                "required_qualifications": "\r\nA UK degree is required to join the course. Candidates with a 2:2 will be considered.\r\n\r\nGCSE's or equivalent at grade C/4 or above in English, Mathematics and Science.\r\n Work experience is recommended. \r\n\r\nILTT has a School Readiness Programme that will help you to gain the right pre- course experience to support your application.\r\n\r\n[If you would like us to help you gain this school based experience please get in touch via our email info@iltt.org.uk\r\n\r\n[Click here](https://www.inspiringleadersscitt.com)",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12960407",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "258T",
+                "name": "Modern Languages",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17149,
+                    "address4": "",
+                    "provider_name": "York St John University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions Office",
+                    "year_code": "2019",
+                    "provider_code": "Y75",
+                    "provider_type": "university",
+                    "postcode": "YO31 7EX",
+                    "website": "http://www.yorksj.ac.uk",
+                    "address1": "Lord Mayor's Walk",
+                    "address2": "York",
+                    "address3": "",
+                    "email": "pgce@yorksj.ac.uk",
+                    "telephone": "01904 876598",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:47:24.309Z",
+                    "updated_at": "2021-09-28T10:57:41.367Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T13:20:12.968Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": null,
+                    "train_with_disability": null,
+                    "accrediting_provider_enrichments": null,
+                    "latitude": 53.9649139,
+                    "longitude": -1.0800959,
+                    "ukprn": "10007713",
+                    "urn": "133914",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "Y75",
+                "changed_at": "2021-09-14T08:52:47.888Z",
+                "uuid": "22aeba32-6426-4923-bbaa-62925b179717",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-14T08:52:47Z",
+                "about_accrediting_body": "YSJ supports and trains student teachers who are intelligent risk takers who base their professional decisions on a deep-rooted understanding of pupil’s learning and effective pedagogies.  \r\n\r\nInitial Teacher Education with York St John University in collaboration with the White Rose Alliance will provide you with high quality training that not only responds to the demands of the Teachers' Standards and changes in the wider education landscape but also encompasses and embraces that which criticises and critiques current practice, encouraging, acknowledging and rewarding research-led reflection on pedagogy.",
+                "provider_code": "196",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "This WRA School Direct course leads to a PGCE qualification and Qualified Teacher Status (QTS). The secondary course age range is 11-16 with 16-18 enhancement. Languages trainees will be expected to teach their first language (French) to the full age range and their second language (German or Spanish) to Key Stage 3.\r\n\r\nThe course structure enables trainees to begin their development in school from the start of the course and build their confidence and teaching knowledge through their two school placements. \r\n\r\nTrainees will spend most of the training year based in their placement schools developing their teaching skills at their own pace, underpinned by weekly WRA Professional Studies (PS) sessions held at King James's School , and weekly academic/subject pedagogy training sessions held at York St John University providing specialist support for the PGCE qualification.  Trainees are also able to access and benefit from the full range of university services e.g. writing and academic support, wellbeing services, library and IT, careers, etc.\r\n\r\nThe weekly WRA PS programme covers the core areas of the Initial Teacher Training (ITT) Core Content Framework (CCF) to equip trainees with the essential skills and knowledge they need to develop as professional educators.  Feedback from a former trainee : \"Can't rate these sessions highly enough in terms of how they have helped my progression through the year\".\r\n\r\nTrainee progress is monitored closely throughout the course and assessment made by mentors regarding their achievement of QTS status at the end of the course. Trainees will be required to complete 2 Masters level assignments for their PGCE qualification.\r\n\r\nWRA trainees have access to a comprehensive support structure covering every aspect of their training through staff in their placement schools (subject mentor, department/pastoral staff, ITT coordinator), their university (link tutor, coordinator, subject peers) and the White Rose Alliance (lead teacher, senior mentor, administrator and cohort peers). Feedback from a former trainee:\" Support from all aspects of the course has been excellent and has allowed me to really grow in confidence and competence throughout the year\". \r\n\r\nWhilst the intention is for university and White Rose Alliance sessions to be delivered in person, where this is not possible due to Covid-19 restrictions or exceptional circumstances, alternative arrangements will be made to run university \u0026 White Rose Alliance sessions virtually. \r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "For the majority of the course, trainees are school-based. Trainees will be in their placement school unless attending sessions at their link university (in general terms one day per week), weekly Professional Studies sessions at King James's School on Wednesday mornings or School Experience Days at WRA partner schools.\r\n\r\nWRA partner schools are:\r\n\r\n* King James's School, Knaresborough\r\n* Bradford Grammar School\r\n* Stokesley School\r\n* The Grammar School at Leeds\r\n* Thirsk School and Sixth Form College\r\n* Ripon Grammar School\r\n* Sherburn High School\r\n* Boroughbridge High School\r\n* Ryedale School\r\n* Richmond School \u0026 Sixth Form College\r\n\r\nTrainees undertake 2 school placements: Placement 1 from September to Christmas and Placement 2 from January to June.\r\n\r\nSchool placements provide structured opportunities for trainees to observe experienced teachers and other professionals, and receive support as they progressively build confidence and skills towards independent teaching. During school placements trainees will be expected to cover the 11-16 age range plus obtain experience of some 11-18 teaching during their course. In school you will be given the opportunity to participate in all aspects of school life and the wider school context eg. attending school meetings, extra-curricular activities, school training days and other professional development activities, that will support you in developing your knowledge and understanding of the whole school environment. You will be supported during your school placements by a subject mentor and other school staff who are committed to your education and training.   \r\n\r\nWhen allocating school placements, we consider a number of factors including trainee home location and accessibility to transport (ie. ability to drive, access to own vehicle or reliant on public transport).  Not all WRA partner schools are able to provide placements for all subjects \u0026 therefore on occasions, it may be necessary for trainees to undertake placements in non-WRA schools. Trainees should expect, and be prepared for, some reasonable daily travel at their own cost. We will however, endeavour to  provide the most appropriate placements we can.   \r\n\r\nShould there be any impact on school placements as a result of Covid-19, virtual or alternative educational experiences will be arranged.",
+                "interview_process": "WRA interviews take place remotely. Candidates will generally be given one week's notice of interview whenever possible \u0026 dates/times are flexible. \r\n\r\nCandidates invited to interview will be required:\r\n* to complete an initial subject audit form for each of their 2 languages\r\n* to complete a Prior Achievement Booklet \r\n* to undertake a subject test in French (45 minutes) via email (before the interview if possible)\r\n* to prepare a lesson plan \u0026 resources for an imaginary 15 minute teaching/learning activity (to discuss during the formal interview)\r\n* have a formal interview (45 minutes) via Zoom. The panel for the formal interview will comprise 2 members of a combination of White Rose Alliance staff, partner school staff or university staff. \r\n\r\nThe initial subject audit forms and subject test will be reviewed by a subject specialist who will provide advice to the interview panel.\r\n\r\nCandidates will be advised of the interview outcome as soon as possible after their formal interview, once all information from the interview activities has been collated. ",
+                "other_requirements": "Standard university conditions will apply to all offers made at interview. These include proof of qualifications (candidates will be required to produce degree certificate \u0026 GCSE Maths \u0026 English certificates for verification), obtain Enhanced DBS clearance \u0026 complete a medical check.",
+                "personal_qualities": "\r\n* Strong subject knowledge \u0026 willingness to develop it\r\n* Enthusiasm for subject and a desire to share this\r\n* Passion for both learning and teaching\r\n* Genuine interest in young people and their development\r\n* Strong and committed work ethic\r\n* Ability to build good working relationships with others\r\n* Excellent organisation and time management skills\r\n* Confidence in communicating with young people and adults of all levels\r\n* Resilience to cope under pressure\r\n* Creativity\r\n* Self-motivation\r\n* Resourcefulness and adaptability\r\n* Openness to constructive criticism\r\n* Reflective approach\r\n* Sense of humour\r\n* Patience\r\n ",
+                "required_qualifications": "\r\n* Honours degree in chosen subject at 2.2 or above. If degree subject is not in subject applied for, but applicant holds an A Level in the subject \u0026 can demonstrate subject-related experience, applicant may still be considered; applicant is likely to be required to complete a subject knowledge enhancement (SKE); this would become a condition from any offer made at interview. \r\n* GCSE Grade Cs or above (or equivalent) in English and Mathematics.\r\n* First language must be French and have ability to teach second language (ie. German or Spanish) to Key Stage 3 before course commencement.\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966056",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "G719",
+                "name": "Modern Languages (French, German, Spanish)",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "qts",
+                "description": "QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T14:01:25.962Z",
+                "uuid": "e5ddec7d-e1ab-4d7d-a10c-86427d802269",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:01:25Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS). \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963390",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "27RK",
+                "name": "English",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17773,
+                    "address4": "Coventry",
+                    "provider_name": "The University of Warwick",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Centre for Teacher Education",
+                    "year_code": "2019",
+                    "provider_code": "W20",
+                    "provider_type": "university",
+                    "postcode": "CV4 8EE",
+                    "website": "http://www2.warwick.ac.uk/fac/soc/cte/thinking-about-being-a-teacher/",
+                    "address1": "Westwood Campus",
+                    "address2": "University of Warwick",
+                    "address3": "Kirby Corner Road",
+                    "email": "cte.admissions@warwick.ac.uk",
+                    "telephone": "024 761 50269",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:54:26.825Z",
+                    "updated_at": "2021-10-04T12:47:19.281Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T11:46:03.644Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "WARWICK. HELPING YOU FIND YOUR OWN PATH TO TEACHING SUCCESS.\r\n\r\nWe understand that teaching is more than just a job. We also know that you are more than just another applicant. That’s why our approach is tailored around your needs. We’re focused on getting you prepared to enter the classroom and ready for all the challenges that teaching throws at you. We won’t drop you in at the deep end, but we will help you become accustomed to different school environments.\r\n\r\nWe have a long history of providing students with the best access to the contacts, resources and facilities needed to fulfil teaching promise. You’ll also benefit from our research-informed teaching, delivered at an acclaimed university with a reputation for excellence. That teaching will come from people who truly understand about the journey that you’re taking. We have been training teachers for over 50 years and are part of the Russell Group, whose members represent outstanding teaching and learning experience.  We are rated an \"Outstanding\" provider of teacher training by Ofsted \r\n\r\nWe work in partnership with over 500 schools to deliver the highest quality training. You will be taught and supported by highly experienced tutors, class teachers and school mentors who have national reputations for the quality of their training. Upon completing a PGCE with Warwick you will gain 90 credits at master’s level. \r\n",
+                    "train_with_disability": "All trainees are provided with a named personal tutor and a subject specific mentor in placement. \r\nWarwick provide a range of support for students with disabilities and other needs through the Student Disabilities Team.\r\n\r\nwarwick.ac.uk/services/disability",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.3879174,
+                    "longitude": -1.5613053,
+                    "ukprn": "10007163",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W20",
+                "changed_at": "2021-09-27T11:51:19.066Z",
+                "uuid": "d4fa9f57-6076-46b7-9467-c0f896553c89",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "August 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-27T11:51:19Z",
+                "about_accrediting_body": null,
+                "provider_code": "179",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "School Direct programmes contain a core Professional Studies element and a series of Subject Studies sessions designed for your chosen specialism.  Some of these take place at the placement school and some at the University of Warwick.\r\n\r\nTrainees then take what they have learned in the training room directly into the classroom where they put it into practice under the supervision and guidance of mentors and fellow colleagues who will provide support, feedback and key guidance to ensure that all trainees make the required progress. Professional Studies sessions, based at Caludon Castle School, are facilitated by leading practitioners who have a track record of excellence in teaching.\r\n\r\nTopics covered include:\r\n\r\nUnderstanding learning\r\nBehaviour for learning\r\nOutstanding lesson planning\r\nUsing ICT to enhance learning and teaching\r\nLiteracy and numeracy\r\nQuestioning techniques\r\nDifferentiation\r\n\r\nThe course will include:\r\n\r\n•\tmaintaining subject knowledge in English Language and Literature\r\n•\ttaking the fear out of grammar teaching\r\n•\tpromoting good accuracy\r\n•\treading for pleasure and for comprehension       \r\n•\tdelivering Literature at Key Stage 3, 4 and 5       \r\n•\tdesigning and supporting learning outside the classroom\r\n•\tlinking English to the wider curriculum\r\n•\tsupporting Post-16 English teaching\r\n\r\nTrainees will have experience in at least two secondary or primary schools (depending on phase and potential Covid restrictions) and have the opportunity to immerse themselves in school life, participating in extra-curricular activities, parent meetings, and cross-curricular events.  Trainees, also get the chance to spend some time working with children with special educational needs.\r\n\r\nAll programmes lead to QTS and PGCE status, including the award of 90 CATS credits towards Master’s accreditation, upon meeting the assessment criteria, specified by the University of Warwick.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "Successful School Direct candidates will complete their Post Graduate Certificate of Education (PGCE 11-18) with the University of Warwick, allowing them to achieve Qualified Teacher Status (QTS) as well as gaining 90 CATs points towards their Master’s. Practical, school-based training will take place at the lead school.  The School Direct programme will involve candidates being supported in and engaged with the schools from the beginning of September 2022, developing relevant professional skills and learning from the wealth of experience that exists both within the schools and the university. High quality support will be available at all times from the schools and the university to help candidates on their journey towards becoming outstanding classroom practitioners. ",
+                "interview_process": "If shortlisted for selection, applicants will be invited to an interview day, where they will be involved in a range of activities, including teaching a short lesson to students, undertaking a literacy exercise, and undergoing a panel interview.  All applicants offered a place will subsequently be required to produce a clear enhanced disclosure certificate from the Disclosure and Barring Service and to pass the 'Fitness to Teach' requirements laid down by the Department for Education, before taking up their place on the course.",
+                "other_requirements": "",
+                "personal_qualities": "Applicants need to have a passion for teaching and show a sincere professional interest in working with children.  Applicants need to be in good health.  Applicants are required to show a commitment to their subject, as well as a desire to train in a school-based environment. They are encouraged to highlight in particular any prior teaching experience in their application.",
+                "required_qualifications": "Selection criteria are broad and we welcome applications from all sections of the community.  Candidates must have at least 5 GCSE's at 4 (C) grade or above, including English and Mathematics. Primary school applicants need to have a grade 4 (C) or above in Science as well. We prefer at least a high second-class UK honours degree for all subjects although a 2.2 is acceptable.  Applicants are advised that 50% of their degree should focus on the relevant subject, but if a candidate wishes to teach in a subject different from their degree, then they must undertake a SKE.\r\n\r\n.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963549",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X542",
+                "name": "Biology",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:02:34.736Z",
+                "uuid": "f4094fe9-1f22-4d71-bcc8-228ba60421d4",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": true,
+                "degree_subject_requirements": "It is important that your degree has a science composition.",
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:02:34Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above does NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2021)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12967529",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "V611",
+                "name": "Early Years",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "primary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "equivalence_test",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english",
+                    "science"
+                ],
+                "age_range_in_years": "3_to_7",
+                "accrediting_provider": {
+                    "id": 17369,
+                    "address4": "Worcestershire",
+                    "provider_name": "University of Worcester",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Admissions",
+                    "year_code": "2019",
+                    "provider_code": "W80",
+                    "provider_type": "university",
+                    "postcode": "WR2 6AJ",
+                    "website": "https://www.worcester.ac.uk/about/academic-schools/school-of-education/get-into-teaching-at-worcester/home.aspx",
+                    "address1": "Henwick Grove",
+                    "address2": "",
+                    "address3": "Worcester",
+                    "email": "admissionsb@worc.ac.uk",
+                    "telephone": "01905 855111",
+                    "region_code": "west_midlands",
+                    "created_at": "2021-07-06T10:49:48.599Z",
+                    "updated_at": "2021-09-10T14:20:48.294Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-01T14:38:58.568Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Worcester has a long-standing reputation for training excellent, highly employable teachers. Personalised academic and professional tutoring, from a range of experienced tutors and mentors, ensures that you will be supported throughout your course and in transition from trainee to teacher. With extensive research profiles, your learning is shaped by those helping to shape education itself. \r\n\r\nYou will benefit from our excellent partnerships with schools, in a wide range of locations. With excellent support and dedicated school experience tutors, you will have the opportunity to flourish as an effective teacher.\r\n\r\nOur PGCE courses offer Master's-level credits as well as Qualified Teacher Status, and provide excellent opportunities.\r\n\r\nOur Primary courses include a high quality tailored programme of training in all National Curriculum subjects, in addition to SEND and RE. \r\n\r\nTrainee teachers at Secondary level can choose to add depth to their qualifications by involvement in additional enhancement activities in key areas such: as Special Educational Needs and Disabilities; working with learners who have English as an Additional Language; developing expertise in Citizenship; developing skills in a second STEM subject; preparing to be Education Leaders; developing skills in Technology Enhanced Learning; teenage mental health education; education in climate emergency; research in education.\r\n\r\nAt Secondary level we also offer pre-training Subject Knowledge Enhancement courses in a range of subjects for those who need them.\r\n\r\nOur inclusive courses attract applicants from a range of career and study backgrounds, including career changers and we welcome applications from all who meet our entry requirements. ",
+                    "train_with_disability": "The University of Worcester offers a wide range of support and advice to disabled students and also to parents, staff and those external agencies supporting disabled students.\r\n\r\nOur Disability and Dyslexia Service offers support, advice and guidance to students who have a disability, medical condition or Specific Learning Difficulty (SpLD). This support lasts throughout a student’s studies at the University of Worcester. We also work with and offer support and advice to University staff on how to meet the needs of disabled students.\r\n\r\nWe can provide assistance through:\r\n \r\n* Supporting disabled students with general enquiries\r\n* Implementing special arrangements for lectures, exams and field trips. This might include notes in advance or special arrangements in exams.\r\n* Where appropriate, we can arrange note takers, academic support tutors, library assistance, interpreters and transcribers.\r\n* Help with applying for the Disabled Students Allowance (DSA) which is there to fund these types of support in higher education.\r\n* Limited loans of equipment\r\n* Confidential advice and support for students and staff\r\n* Training and awareness raising workshops\r\n* Assistive technology ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.1970053,
+                    "longitude": -2.2428253,
+                    "ukprn": "10007139",
+                    "urn": "133911",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "W80",
+                "changed_at": "2021-10-05T14:03:00.870Z",
+                "uuid": "10c60456-2efe-4f5b-93a9-6c60996ae448",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": true,
+                "additional_gcse_equivalencies": "Equivalency tests can be accessed through the University of Worcester",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T13:54:19Z",
+                "about_accrediting_body": "Our accredited partner, the University of Worcester, offer an immersive and inspiring, school-centred training route into teaching.\r\n\r\nAt Worcester the PGCE: School Direct Primary is tailored to your needs - building on your existing strengths and expertise. Our course is inclusive and innovative in its design and delivery, and places you at the heart of a thriving school community.\r\n\r\n\r\n*Full immersion in the daily life of a school \r\n*Breadth and depth of experience across a range of schools\r\n*Outstanding additional opportunities for enrichment and extension\r\n*A dynamic taught programme, \r\n*Unparalleled personal and academic support throughout the programme and beyond\r\n",
+                "provider_code": "2L6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The Arden Forest Teaching Alliance, led by Welford on Avon Primary School is delivering an Early Years School Direct Initial Teacher Training course in association with the University of Worcester beginning September 2021.\r\n\r\nFor the majority of the training year you will based at your ‘host school’.\r\nIn addition, you will spend one term on a complementary placement, in a contrasting school setting.\r\n\r\n\"As a partnership of schools, we are fully committed to offering the best possible support and training to grow the next generation of teachers. We have a wealth of experience and expertise in supporting those new to the profession and feel that our school Direct programme will give teachers the best possible start in their career”\r\n\r\nJulie Leeman – Headteacher, Welford on Avon Primary School\r\n\r\nAlongside your time in school, learning from experienced and highly skilled teachers, you will attend a number of taught sessions led by both the University of Worcester and lead schools from with the partnership, to support your academic practice. \r\nYou will complete a number of Masters level assignments which will further your understanding of effective teaching pedagogies and theories.\r\nYou will be supported, whilst on the programme, by an experienced  school mentor and a University link tutor who will help guide your development, assess your progress and support you to maximise your potential.\r\n\r\nThe course is carried out over a full academic year, starting in September 2022",
+                "course_length": "OneYear",
+                "fee_details": "UK/EU £9,250 ( subject to change during 21/22\r\n\r\nInternational Fees £13,700\r\n\r\n",
+                "fee_international": 13700,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "Successful trainees will be based at one of our partner schools, located in and around South Warwickshire.\r\n\r\nYou will have three school experience placements. SE1 and SE3 will take place in your host school and usually in the same year group ( Nursery or Reception). SE2 will be a contrasting setting and in a Key Stage One classroom.  \r\nThroughout their training we aim to give trainees a broad experience in our Early Years and Key Stage 1 settings. In addition, we will provide short experiences observing and working with our KS2 classrooms. ",
+                "interview_process": "Further details of the interview progress will be shared with the successful applicants.",
+                "other_requirements": "All successful applicants will be subject to a full DBS check.",
+                "personal_qualities": "As an Early Years Teacher, you will inspire, excite and nurture children through a crucial stage of their development. Your aim is to motivate children a providing a safe and secure environment for them to develop their social and communication skills.\r\nAs an early years teacher you will motivate and stimulate a child's learning abilities, often encouraging learning through experience preparing them for the start of their primary school years. ",
+                "required_qualifications": "Details of qualifications are available through the University of Worcester. \r\n\r\nAn undergraduate degree\r\n\r\nGSCE passes in English, Maths, and Science (or equivalencies)\r\n\r\nEquivalencies in Maths, English \u0026 Science are accepted from some providers \u0026 this will be checked on application.  The University of Worcester do hold their own equivalency tests and therefore we do accept applications without these relevant qualifications in place.",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969936",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "P947",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-19T15:57:00.385Z",
+                "uuid": "60037c96-ec88-4461-9094-2344510c66be",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-19T15:57:00Z",
+                "about_accrediting_body": null,
+                "provider_code": "1BO",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The School Direct course is a flexible approach to teacher training. The majority of your time will be spent in school, training in the classroom and being supported by experienced teachers and mentors. You will also spend time studying at the University.  Successful completion of the course leads to Qualified Teacher Status (QTS)* and a postgraduate qualification.\r\n  *The title of this award is subject to change due to an ongoing government consultation. For the latest information, please visit www.gov.uk/dfe\r\n\r\nYou will be a registered student with NTU and your qualification will be an NTU award. This means that NTU has responsibility for the quality of your training and you will benefit from the combined expertise of the University and lead placement school. \r\n\r\nThis secondary PGCE teaching degree is based around five modules which are core to all trainees.  The curriculum has been organised so that you will gain substantial support for the study of all modules at the start of the course through front-loaded University-based sessions, before your placements begin. The Learning and Teaching in the Subject module will largely be completed in this period, meaning that you will have clarity about academic expectations and your tutors will have an insight into required support. The other modules will be completed at different stages during the year to ensure both reasonable workload and to allow for the progressive impact of the Learning and Teaching in the Subject and Learning and Teaching in the Wider Context modules (underpinned by the Skills of Enquiry module which is assessed across these two modules) on the Secondary Education Independent Study and Secondary Professional Practice modules which run right until the end of the courses.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "As a School Direct trainee, you will be entitled to the same financial support as trainees on other postgraduate teacher training courses.\r\n\r\nIf you are a UK or EU trainee, you should be eligible for a student loan, maintenance loan or maintenance grant to cover the cost of your study, and will only start paying the loans back when you start earning over £21,000 per annum.\r\n\r\nYou may be eligible to receive a training bursary, dependent on the subject you train for and a degree classification.\r\n",
+                "how_school_placements_work": "Successful candidates will spend the majority of their time at Brunts Academy where they will be assigned a subject specific mentor and undertake the teaching, in their chosen subject area, of students from age 11-18 as appropriate.  Some days will be spent at University - see course content.\r\n\r\nCandidates will spend a minimum of 2 days at a primary school in the first term.  During the primary placement candidates will:\r\n* begin to appreciate the similarities and distinctiveness of learning and teaching in KS2 and the primary phase more generally;\r\n*gain awareness of pupils’ capabilities and prior knowledge in the key stage immediately prior to that for which they are training; \r\n*contribute to their growing knowledge and understanding of standards, progression and transition in their subject/related disciplines. \r\n\r\nCandidates will also undertake a second placement at the beginning of the spring term at another school/academy.  This placement is arranged by the Director of ITT.  This provides candidates with an opportunity to broaden their experience by teaching in a school in a different setting/location/context.",
+                "interview_process": "Following the submission of a successful application form candidates will be invited for an initial interview at NTU prior to being interviewed at the Lead School, Brunts Academy. ",
+                "other_requirements": "Candidates will be subject to an interview with both the training school and NTU as part of the selection process.  Candidates will undertake:\r\n*Disclosure and Barring Service check; \r\n*Prohibition Order check. \r\n\r\nTwo references are required, one academic and one vocational.  Evidence of mainstream UK school experience (paid or voluntary) in their application is desirable, although not essential. ",
+                "personal_qualities": "Every day you'll get the chance to inspire young people and use your skills to give something back – making sure every pupil gets the same access to a quality education and the opportunity to succeed. \r\n\r\nYou will need:\r\n*good communication skills\r\n*good organisational skills\r\n*the ability to develop relationships with others\r\n*to be passionate about your subject \r\n*to be dedicated to teaching\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12968705",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2C9T",
+                "name": "Chemistry",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-09-10T15:13:09.069Z",
+                "uuid": "17ad7cf4-2bd8-4924-8346-01b1f812e2b0",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-10T15:13:09Z",
+                "about_accrediting_body": null,
+                "provider_code": "S95",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "The Stourport SCITT (School Centred Initial Teacher Training) is committed to providing the best school based training experience in the area. The final qualification is for Qualified Teacher Status (QTS), with a PGCE accredited through Birmingham City University. There is extensive subject knowledge support and a strong connection with placement schools, in order to ensure a 'joined up' approach to the course, trainee wellbeing and support. \r\n\r\nThe secondary chemistry teaching programme is based in a school from the very beginning and closely follows the national curriculum. Each successful applicant should be able to teach across all science areas up to Key Stage 4 and be willing to teach the full age range, from 11 to 18. Applicants will be given a full opportunity to demonstrate their knowledge and understanding at the interview and selection stage. Excellent support for trainees is offered by outstanding teachers and science departments committed to providing the best school placement experiences. Trainees will be based at the SCITT Training Rooms and will be offered places at two different secondary schools within the local area during the course.\r\n\r\nPlease contact us direct on 01562 542574 option 3, email jhomer@saet.co.uk or check out our website on www.stourportscitt.com. We will be pleased to answer any questions you may have regarding the course, the support or the final qualification.\r\n",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "As we are very much ‘school centred’ you will spend a large proportion of the year in schools, so you will be immersed in school life from day one. We work with many schools across Worcestershire, Herefordshire and Shropshire.  These are from a range of settings; from urban schools to more rural locations.  We place trainees sensitively and would not normally expect you to have to travel for more than 30 minutes from home to get to your placement school.  \r\n\r\nYou will teach students within secondary age ranges, pertinent to your subject area. The school placements are with two contrasting schools to maximise your teaching experience. Placement one is at the very beginning of the Autumn term, giving you an invaluable insight in to the start of the school year and the expectations surrounding this important time for children.  \r\n\r\nYour development will be supported by five intensive training blocks, delivered by experts and practicing teachers to ensure that you have excellent, current pedagogy.  You will be given a mentor in each of your placements whom you will meet each week to discuss your progress.  You will also be thoroughly immersed in the pastoral role of a teacher; you will be assigned to support a tutor group to gain an excellent understanding of the critical work a tutor does to monitor academic progress as well as caring for students’ welfare.\r\n\r\nYou will also gain first-hand experience of how your placement school delivers spiritual, moral, social and cultural education, as well as sex and relationships education. Your placement school will also offer you experience in the extra-curricular provision offered to students. Past trainees have supported school trips, sporting events, drama productions and many other enrichment activities.\r\n",
+                "interview_process": "If your application is successful you will be called to interview very quickly.  Your interview will normally take place in a school setting appropriate to the age range you wish to teach. You will attend only one interview session, and this will take either a full morning or afternoon. You will be formally interviewed by one of the SCITT team and a subject specialist. In your formal interview we will discuss your application in further detail and your motivation for teaching.  \r\n\r\nWe are looking for applicants with a clear passion for both teaching and their subject; strong candidates will also show that they are at ease with pupils.  As part of this process you will also teach a short episode (30 to 40 minutes) in your subject area to a class.  We are not looking for the 'finished article' at this stage but you should aim to show your enthusiasm for your subject and positive relationships with students. Once the lesson has finished you will have the opportunity to write a reflection on your lesson. We will also ask you to sit a recent external examination paper in your subject.\r\n\r\nOnce the interview process is complete we meet as a panel to discuss all elements of the process. We would then make a decision and inform candidates within three working days of interview.\r\n",
+                "other_requirements": "We will conduct a Data Barring Service (DBS) check for each applicant, at no cost.",
+                "personal_qualities": "We are looking for professional individuals with a genuine passion for teaching children and becoming part of the next generation of teachers. Ideally you will have school experience,  if you need assistance with organising this, we are more than happy to help. ",
+                "required_qualifications": "The minimum academic requirements for this Chemistry course are:\r\n\r\n* English GCSE (or equivalent) at grade 4 or above\r\n* Mathematics GCSE (or equivalent) at grade 4 or above\r\n* Post 16 qualifications with a strong interest in Chemistry\r\n* Relevant degree at classification 2:2 or above\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12966089",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "X322",
+                "name": "Physics",
+                "study_mode": "full_time_or_part_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS, full time or part time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17054,
+                    "address4": "Kingston upon Hull",
+                    "provider_name": "Yorkshire and Humber Teacher Training",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Chris Fletcher",
+                    "year_code": "2019",
+                    "provider_code": "2B2",
+                    "provider_type": "scitt",
+                    "postcode": "HU5 4ET",
+                    "website": "http://yhtt.ac.uk",
+                    "address1": "Yorkshire \u0026 Humber Teacher Training, c/o Bricknell Primary School",
+                    "address2": "Bricknell Avenue",
+                    "address3": "Hull",
+                    "email": "info@yhtt.co.uk",
+                    "telephone": "01482686699",
+                    "region_code": "yorkshire_and_the_humber",
+                    "created_at": "2021-07-06T10:46:24.539Z",
+                    "updated_at": "2021-08-23T19:53:46.926Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-29T16:32:31.764Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "We are a partnership of 20 schools, colleges and educational establishments covering Yorkshire and The Humber.  Our core training programme is delivered by expert trainers at our Hull base in September and January during our core training blocks.  Once on placement you will be treated as a member of staff, being fully immersed in the life of a school and the education of it's pupils.  \r\n\r\nOur training programmes were developed by educational experts to update traditional training routes and equip our trainees for teaching in the 21st century.\r\n\r\nYHTT has a highly successful track record of developing outstanding school teachers. We have excellent rates of employment for our graduates both within our alliance schools and also elsewhere in the region and beyond. Our alliance and partnership is made up of excellent schools.  Additionally, we are delighted to be working with The Constellation Trust and The Yorkshire and the Humber Co-operative Learning Trust.  Their Teacher Training activity has an excellent track record of producing first rate trained teachers and we believe this Alliance allows us to, together, produce a generation of outstanding teachers. \r\n\r\nOur Secondary partnership ranges from Scarborough in the North to Lincoln in the South, whereas our Primary partners are predominantly in Hull.  Whichever phase you wish to train in, we offer extensive enhancement opportunities in all Primary and Secondary, Post-16, EAL, SEND and Alternative Provision settings.\r\n \r\n[What's a SCITT?](yhtt.co.uk)",
+                    "train_with_disability": "Meeting our trainees needs allows them to flourish in the classroom.  We carry out extensive pre-course assessments which allows trainees with additional needs to access the support they require throughout the year.\r\nIn addition, we offer mental health training and a dedicated pastoral tutor to offer emotional support both during the training year and beyond.",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 53.7647974,
+                    "longitude": -0.3864639,
+                    "ukprn": "10058237",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "2B2",
+                "changed_at": "2021-10-05T14:08:11.484Z",
+                "uuid": "d144d9f1-b70c-4564-ad5b-2ed7ba0e1c75",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:08:11Z",
+                "about_accrediting_body": null,
+                "provider_code": "2KL",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "Teaching is a vibrant, fast-paced and exciting career and we’d love you to train with us. We believe that our accredited mentors and support team ensure that we deliver the very best teacher training around.\r\n\r\nIt’s hands on, hard work in the classroom Monday-Thursdays and then on Friday’s it’s professional studies sessions which are delivered in our brand new in-house teacher training suite on site in Cromwell in Chatteris for trainees in Cambridgeshire or for those studying in Suffolk, your base will be either Ipswich or Lowestoft.\r\n \r\nWe provide unique teacher training opportunities in a supportive and forward-thinking environment. We believe that our teachers who work in schools day in, day out with young people are best placed to provide teacher training. When you join our training programme you will work alongside an assigned mentor and subject specialist tutor who will provide you with bespoke experiences and challenges to help you make progress each week.\r\n\r\nCompletion of this course will provide you with Qualified Teacher Status (QTS) \u0026 a PGCE. \r\n\r\nDuring the course, you’ll spend time in two school placements and you’ll be assigned a subject specialist mentor so you’ve always got professional support and guidance.\r\n\r\nAssessment is carried out across both placements against the Teachers' Standards. \r\n\r\nTo date, we have helped 100% of our trainees who have wanted our help to find them a job to secure employment.\r\n\r\nThe teachers in our partnership are outstanding practitioners who share a desire to be at the forefront of curriculum innovation, making learning topical, purposeful and thought-provoking.\r\n\r\nWe look forward to working with you!\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will be based in your placement school Monday to Thursday. At this time, you’ll have the opportunity to teach, plan, observe and research. \r\n\r\nOn Fridays, you’ll be invited into our teacher training centre in Cromwell Community College in Chatteris if you're based in Cambridgeshire or Ipswich or Lowestoft in Suffolk. This is when you’ll have the opportunity to complete our outstanding professional studies programme which draws on exceptional experts from across our network of schools in Cambridgeshire and Suffolk. \r\n\r\nWe always aim to place candidates in schools which match their needs. We will do everything we can to match your ability to travel to the schools we place you in. \r\n\r\nWe operate an A-B-A model. This means that you'll begin and end at one school, and spend time in your second contrasting placement school in the second, middle term.\r\n",
+                "interview_process": "All our trainees who are shortlisted for interview are typically invited to complete some of the following activities: \r\n\r\n•\tSpend some time in school with us to take a tour, meet children and share your views about why you'd like to be a teacher.\r\n\r\n•\tComplete a face to face interview\r\n\r\n•      Complete a classroom based exercise, where you will be observed interacting with children or young people.\r\n\r\nWhen you're shortlisted, we'll tell you exactly what to expect.\r\n",
+                "other_requirements": "You'll need to complete a DBS check and should be in good general health.",
+                "personal_qualities": "We're looking for applications from people who are motivated to work with children in order to help them achieve their very best.\r\n\r\nWe also think it's helpful to be resilient, hard-working, inquisitive and have a good sense of humour.\r\n\r\nYou'll need to be a team player as well as be able to work as part of a group. You will have excellent communication skills and presence.\r\n",
+                "required_qualifications": "• A degree in the subject area you want to teach or a degree with a substantial portion relevant to National Curriculum programmes.\r\n\r\n• GCSE (or equivalent) English and Mathematics at grade 4 or above. You will also need a GCSE (or equivalent) grade C or above in a science subject to teach children aged 3-11.\r\n\r\n• Experience of working with young people is a bonus – but if you don’t have this we can help organise taster days in school. We understand this has been difficult recently due to Covid.\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12957754",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "N503",
+                "name": "Business studies",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "must_have_qualification_at_application_time",
+                "maths": "must_have_qualification_at_application_time",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "14_to_19",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:04:43.771Z",
+                "uuid": "a75095a1-b23c-493e-b998-d1724415191d",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:04:43Z",
+                "about_accrediting_body": null,
+                "provider_code": "R23",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "We are looking for Business graduates who are keen to teach their subject up to A level in a school and sixth form setting. Our SCITT curriculum begins early in September and involves teaching practice in school each week from Monday to Thursday, with Friday as a training day. Training will be hosted and delivered by experienced ITT specialists, subject experts and classroom practitioners who currently teach in our partner schools.  \r\n\r\nIn addition, there will be subject pedagogy days during the year where trainees will focus on teaching your subject and age phase specifically. These will be delivered by a experienced curriculum leaders in the 14-19 age phase. The days incorporate learning walks and lesson experience alongside input from the Lead Subject Mentors and directed tasks for you to consolidate your learning.\r\n\r\nYou will audit your subject knowledge for the topics you will need to teach. Lead Subject Mentors and tutors will guide you towards high quality resources for this and you will be encouraged to join a professional subject association. The learning platform enables you to share resources with each other and school mentors. \r\n\r\nLeeds Beckett University provide the PGCE for our SCITT and this is all online. The modules perfectly compliment the training we deliver and you will gain 60 Master's level credits (https://courses.leedsbeckett.ac.uk/PGCE_distancelearning/)\r\n\r\nOur programme documentation has been described by Ofsted: \"Documentation is very well designed and contributes significantly to trainees' success on the course\" \r\n\r\nAssessment of trainees for QTS is based on all of the following:\r\n- Regular observations of practice with development discussion and action step setting\r\n- Progress towards meeting the expectations of the curriculum\r\n- A final assessment against the requirements of the Teachers Standards at the end of the programme.\r\n\r\nWe have been highly praised by Ofsted for our approach to trainee workload, keeping our requirements concise yet effective.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "PGCE and QTS £9250\r\nQTS only £7000",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "You will normally complete placements in two partner schools. Placement training will begin in September, and you will start with focused lesson observations before you join your subject department and begin to plan and teach parts of lessons. After a few weeks you will be planning and delivering whole lessons, building up to approximately 7 hours per week by Christmas. You will gradually increase your teaching timetable and for the last few weeks will be full time in school, teaching up to 12 hours per week at that point in May and June.\r\n\r\nPlacements are selected for you on the basis of high quality mentoring and strong subject departments. You will teach the 14-19 age range in your subject in two different settings. There may also be opportunities to spend some time in other partner schools and settings as training needs arise. You will gain experience of pastoral care and careers guidance appropriate for 14-19 students alongside subject teaching. There will normally be brief opportunities to experience KS3 as well as 14-19.\r\n",
+                "interview_process": "We currently have a blended approach to conducting interviews. Typically, the interview will take place via remote access with assessment tasks completed at a training centre. You will be asked to prepare a lesson plan beforehand and we will ask you about your ideas in the interview. There will also be a subject task and a written task which are normally completed at a named venue.\r\n\r\nWe are looking for the potential to be an excellent trainee, someone who is ready to start training in a school setting from early September. We are also looking for potential employees in our schools.\r\n\r\nThe admissions team are Safer Recruitment trained and we are committed to safeguarding children",
+                "other_requirements": "Applicants who are successful at interview will need the following before they can start the programme:\r\n-\tDBS and barred list check\r\n-\tMedical check\r\n\r\nIt is important that you have a good awareness of what the role of a teacher involves so that you can be sure it is the right career choice for you. We offer school experience for people at all stages of this career decision, including after interview, in order to support you with this.\r\n\r\nWe welcome applicants of all ages, from university graduation to mature career changers.",
+                "personal_qualities": "We are looking for people who are keen to learn in a school setting and this model suits trainees who are able to learn as they go along and incorporate their own experience into this learning process. Successful applicants will have an understanding of the professionalism and resilience needed to become a teacher and to be reflective learners. A real commitment to a career in teaching, a love of their subject and positive attitude towards young people are essential qualities.\r\n",
+                "required_qualifications": "UK Bachelors degree or equivalent in Business and/or Economics\r\nGCSE Maths and English at grade C/4 or above\r\n\r\nIdeally your degree would be a class 2:2 or above \r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12969938",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "U792",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "not_set",
+                "maths": "not_set",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_18",
+                "accrediting_provider": {
+                    "id": 17838,
+                    "address4": "Nottingham",
+                    "provider_name": "Nottingham Trent University",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "Nottingham Trent University",
+                    "year_code": "2019",
+                    "provider_code": "N91",
+                    "provider_type": "university",
+                    "postcode": "NG1 4FQ",
+                    "website": "http://www.ntu.ac.uk/teach",
+                    "address1": "50 Shakespeare Street",
+                    "address2": "",
+                    "address3": "",
+                    "email": "enquiries@ntu.ac.uk",
+                    "telephone": "0115 848 4200",
+                    "region_code": "east_midlands",
+                    "created_at": "2021-07-06T10:55:18.809Z",
+                    "updated_at": "2021-10-04T15:52:27.749Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-10-05T15:01:41.872Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "Nottingham Trent University's (NTU) reputation is long established. We've been training teachers and educational professionals for well over 50 years. Our greatest strength is our extensive links with schools and educational settings. These relationships enable every student to gain experience through placement in a wide variety of educational environments.\r\n\r\nWhy choose NTU?\r\nWorking with schools\r\nA great strength of our courses is the extensive partnership links that we have with over 600 primary, secondary and post-16 settings across the East Midlands. These relationships enable you to gain a wide experience of teaching in many different educational environments. Experiences vary from city centre to suburban and semi-rural settings, laying a sound foundation for future professional development.\r\n\r\nStudent diversity\r\nWe are committed to promoting a diverse body of teacher trainees. Our students are made up of different backgrounds, nationalities and faiths.\r\n\r\nExperienced lecturers and informed courses\r\nNTU is home to an enthusiastic, expert group of academic staff who are leading researchers and practitioners in the education field. This means that, not only is your course informed by the latest thinking, but also that you will learn from people with a real passion for their subject.",
+                    "train_with_disability": "You will receive lots of support based around your school placements, with planning sessions, mentors and pastoral support from your tutors and colleagues. You can also tap into a range of services at any time, including: Financial Support Services, Counselling, Disability Support, Support, Mature Student Support and Mental Health Support. ",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 52.9580712,
+                    "longitude": -1.1540226,
+                    "ukprn": "10004797",
+                    "urn": null,
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": true
+                },
+                "accredited_body_code": "N91",
+                "changed_at": "2021-09-19T16:01:24.179Z",
+                "uuid": "514e9075-b4df-4c77-b36c-2f52685099bd",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": false,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-19T16:01:24Z",
+                "about_accrediting_body": null,
+                "provider_code": "1BO",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The School Direct course is a flexible approach to teacher training. The majority of your time will be spent in school, training in the classroom and being supported by experienced teachers and mentors. You will also spend time studying at the University.  Successful completion of the course leads to Qualified Teacher Status (QTS)* and a postgraduate qualification.\r\n  *The title of this award is subject to change due to an ongoing government consultation. For the latest information, please visit www.gov.uk/dfe\r\n\r\nYou will be a registered student with NTU and your qualification will be an NTU award. This means that NTU has responsibility for the quality of your training and you will benefit from the combined expertise of the University and lead placement school. \r\n\r\nThis secondary PGCE teaching degree is based around five modules which are core to all trainees.  The curriculum has been organised so that you will gain substantial support for the study of all modules at the start of the course through front-loaded University-based sessions, before your placements begin. The Learning and Teaching in the Subject module will largely be completed in this period, meaning that you will have clarity about academic expectations and your tutors will have an insight into required support. The other modules will be completed at different stages during the year to ensure both reasonable workload and to allow for the progressive impact of the Learning and Teaching in the Subject and Learning and Teaching in the Wider Context modules (underpinned by the Skills of Enquiry module which is assessed across these two modules) on the Secondary Education Independent Study and Secondary Professional Practice modules which run right until the end of the courses.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": null,
+                "fee_uk_eu": 9250,
+                "financial_support": "As a School Direct trainee, you will be entitled to the same financial support as trainees on other postgraduate teacher training courses.\r\n\r\nIf you are a UK or EU trainee, you should be eligible for a student loan, maintenance loan or maintenance grant to cover the cost of your study, and will only start paying the loans back when you start earning over £21,000 per annum.\r\n\r\nYou may be eligible to receive a training bursary, dependent on the subject you train for and a degree classification.",
+                "how_school_placements_work": "Successful candidates will spend the majority of their time at Brunts Academy where they will be assigned a subject specific mentor and undertake the teaching, in their chosen subject area, of students from age 11-18 as appropriate.  Some days will be spent at University - see course content.\r\n\r\nCandidates will spend a minimum of 2 days at a primary school in the first term.  During the primary placement candidates will:\r\n* begin to appreciate the similarities and distinctiveness of learning and teaching in KS2 and the primary phase more generally;\r\n*gain awareness of pupils’ capabilities and prior knowledge in the key stage immediately prior to that for which they are training; \r\n*contribute to their growing knowledge and understanding of standards, progression and transition in their subject/related disciplines. \r\n\r\nCandidates will also undertake a second placement at the beginning of the spring term at another school/academy.  This placement is arranged by the Director of ITT.  This provides candidates with an opportunity to broaden their experience by teaching in a school in a different setting/location/context.",
+                "interview_process": "Following the submission of a successful application form candidates will be invited for an initial interview at NTU prior to being interviewed at the Lead School, Brunts Academy. ",
+                "other_requirements": "Candidates will be subject to an interview with both the training school and NTU as part of the selection process.  Candidates will undertake:\r\n*Disclosure and Barring Service check; \r\n*Prohibition Order check. \r\n\r\nTwo references are required, one academic and one vocational.  Evidence of mainstream UK school experience (paid or voluntary) in their application is desirable, although not essential. ",
+                "personal_qualities": "Every day you'll get the chance to inspire young people and use your skills to give something back – making sure every pupil gets the same access to a quality education and the opportunity to succeed. \r\n\r\nYou will need:\r\n*good communication skills\r\n*good organisational skills\r\n*the ability to develop relationships with others\r\n*to be passionate about your subject \r\n*to be dedicated to teaching\r\n",
+                "required_qualifications": null,
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963535",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "Q208",
+                "name": "Business studies",
+                "study_mode": "full_time",
+                "qualification": "qts",
+                "description": "QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "equivalence_test",
+                "maths": "equivalence_test",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "14_to_19",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-05T14:03:47.979Z",
+                "uuid": "30ebc997-1b46-41b3-8e92-3a4ca0b4ec61",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "There will be costs incurred by yourself to achieve equivalency tests.\r\n\r\nWe will consider accepting equivalency tests in lieu of GCSE English or Maths ( grade 4 (C) or above ) on an individual basis",
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-10-05T14:03:47Z",
+                "about_accrediting_body": null,
+                "provider_code": "3C6",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "Training starts in early September through to June. Carefully designed, delivered by experienced practising teachers and expert trainees to ensure your training prepares you for the needs of the modern classroom and enables you to start your teaching career equipped with the best combination of knowledge and skills. A crucial aspect of this programme is the innovative 10 day induction period which prepares you to commence your first teaching placement in mid - September. \r\n\r\nAdditionally, our programme offers: \r\n\r\nA minimum of 6 subject knowledge sessions with a subject expert who will enable you to develop your pedagogical skills. \r\n\r\nWeekly sessions focusing on: \r\n\r\n* Managing behaviour \r\n\r\n* How pupils learn and cognitive science \r\n\r\n* Assessment for learning \r\n\r\n* Special Educational Needs and disabilities \r\n\r\n* Adaptive teaching and pupil progress \r\n\r\n* Planning for curriculum progression \r\n\r\n* Managing workload and well-being \r\n\r\n* Developing thinking skills \u0026 use of group work \r\n\r\n* Metacognition \r\n\r\n* Literacy across the curriculum \r\n\r\n* Action research \r\n\r\n* Visit to a special school \r\n\r\n* Personal, Social and Health Education \r\n\r\n* Career progression \u0026 applying for your first teaching job \r\n\r\n* Preparing for your ECT years \r\n\r\nFull cohort sessions are based at one of our training centres at Farlingaye High School or Kesgrave High School. \r\n\r\nSchool Placements \r\n\r\nYou will spend 80% of the course in school. Once per week you will receive general professional and subject knowledge sessions. \r\n\r\nYour teaching will build up gradually: you will start by undertaking structured observations of teachers followed by team teaching then full lesson teaching. \r\n\r\nAssessment \r\n\r\nYou will be provided with regular feedback to help you progress in your teaching skills through \r\n\r\n* observation of your lessons \r\n\r\n* assessment tasks \r\n\r\n* your reflections linking theory from training to your practice in the classroom. \r\n\r\nThere are three formal reviews of progress throughout your training, with the final assessment to gain Qualified Teacher Status taking place in the summer term.\r\n\r\nWritten submissions are evenly spread throughout the programme. The well being of our trainees is of the utmost importance to us. We take pride in the personalised provision we offer trainees and have a comprehensive support structure in place to to ensure all aspects of your training are successful.",
+                "course_length": "OneYear",
+                "fee_details": "The fees above do NOT include PGCE . If you wish to apply for a full time  QTS + PGCE  programme this is possible. The QTS + PGCE only full time programme will be £9250 in total ( correct as at 01/10/2020)\r\n\r\nIf you are unsure at the time of applying, we recommend you apply for both programmes with us, and we will discuss these options more fully with you at the interview stage. ",
+                "fee_international": 8250,
+                "fee_uk_eu": 8250,
+                "financial_support": "You don’t have to apply for a Department of Education bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. \r\n\r\nYou may be eligible for a  loan while you study – note that you’ll have to apply for  undergraduate student finance. \r\n\r\nFind out about financial support if you’re from  outside the UK. ",
+                "how_school_placements_work": "Your placements will be carefully selected to ensure that they give excellent but contrasting experiences whilst also considering a reasonable travelling distance from your home. \r\n\r\nIf you wish to nominate a school for one of your placements, we will be pleased to talk to the Headteacher about our programme, but we can never guarantee a request for a specific placement will be fulfilled. \r\n\r\nWe have established excellent working relationships with our Professional Tutors and School Mentors and try to match our trainees with their mentor to build strong professional relationships. \r\n\r\nEach full-time trainee will be placed in the same school for terms 1 and 3, term 2 will be in a different school providing a contrasting school environment.Our schools comprise predominantly of comprehensive schools but include Church of England schools. \r\n\r\nEach of our training programmes is for a specified age range. We strive to provide experiences at special schools, pupil referral units and alternative educational settings. \r\n\r\nSchools experience is at the heart of our training programme. Our expert school-based mentors will provide you with an outstanding foundation on which to build your future career alongside a designated Senior Link (Professional Tutor) who will and work closely with the SCITT team to ensure that you have great input and support which allows you to develop rapidly. You will also be supported by a SCITT tutor who will monitor your progress and provide you with additional support. \r\n\r\n“You have made the start of training to teach a fantastic experience. I have able learned so much from everyone. The organisation has been top drawer!”  \r\n\r\n“The training sessions have been really inspiring. Having the opportunity to learn theory and then go and see it in the classroom has been so useful.”  \r\n\r\n \r\n\r\n ",
+                "interview_process": "Our recruitment and selection process is designed to allow us to make the right decisions for you as an applicant and for our placement schools. \r\n\r\nOnce we receive your application, it will be considered by a subject specialist / SCITT Tutor and the SCITT Director/Strategic Lead. If successful to the next stage, you will be invited to a Selection \u0026 Recruitment day.\r\n\r\nThe day will consist of:\r\n\r\nWelcome by a member of the SCITT team\r\n\r\nDocument check \u0026 hand in of your pre completed subject audit form\r\n\r\nTour of the school in which the interview takes place\r\n\r\nA 20 minute task with pupils\r\n\r\n* Formal Interview \r\n\r\n* Written Task (to display knowledge \u0026 understanding of your subject) \r\n\r\n* English \u0026 Maths diagnostic activities \r\n\r\nWe encourage applicants to find out more about the application and recruitment process details online and also by attending one of our information events. \r\n\r\nSuccessful candidates will be offered a place within days. An offer letter will be issued and may detail some conditions, e.g. passing your degree/ undertaking subject knowledge enhancement. \r\n\r\nAll trainees offered a place must: \r\n\r\n* Pass a Fitness to Teach medical assessment; \r\n\r\n* Undergo an enhanced DBS check and all other mandatory Safer Recruitment activities to verify their suitability to work with young people. \r\n\r\n\r\nCovid 19 restrictions may alter the interview process, if so, you will be notified of arrangements. ",
+                "other_requirements": "EAST SCITT follow the Safer Recruitment procedures as set out in Keeping Children Safe in Education 2021 version.\r\n\r\nThis includes but is not limited to:\r\n\r\nDisclosure and Barring Service (DBS)  - The Disclosure and Barring Service has taken the place of the CRB check and it is a condition of all ITT courses that trainees must have a satisfactory enhanced DBS check before commencing training.  Arrangements for completing DBS check applications will be explained as part of the selection and induction process. \r\n\r\nChecking the Prohibited Teachers List \r\n\r\nChecking references and gaining reassurance where necessary\r\n",
+                "personal_qualities": "\r\n*  Enthusiastic and committed \r\n\r\n* Show humility, respect and empathy \r\n\r\n* Analytical and reflective in order to improve \r\n\r\n* Have high expectations \r\n\r\n*  Sense of humour \r\n\r\n*  Sense of purpose \r\n\r\n* Resilient and adaptable \r\n\r\n* Self-aware\r\n\r\n*  Establish and maintain professional relationships with students and adults \r\n\r\n* A team player\r\n\r\n* Confidence to lead learning and the work of others \r\n\r\n* Evidence of creative thinking and appropriate risk taking to solve problems \r\n\r\n* Excellent communication, time-management, planning and organisation skills\r\n\r\n* A positive  engaging presence \r\n\r\n* Strong literacy and  numeracy skills \r\n\r\n* Potential to develop strong subject knowledge for teaching \r\n",
+                "required_qualifications": " ESSENTIAL: \r\n\r\n* Minimum 2:2 honours degree from a UK university or recognised international equivalent (applicants with non-UK degrees must ensure that they have obtained the relevant equivalency statement from NARIC) \r\n\r\n* GCSE English and Maths, grade C/4 or above or recognised equivalent (evidence of equivalence will be required) \r\n\r\nDESIRABLE \r\n\r\n* 2:1 or above in a relevant degree \r\n\r\n* If teaching a subject different to your degree, an A level at grade C or above in that subject is preferable \r\n\r\n Please note:   To prove that your qualifications are equivalent and you must include a NARIC statement with your application verifying this. ",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12964543",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "2JSC",
+                "name": "Geography",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published_with_unpublished_changes",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": null,
+                "accredited_body_code": null,
+                "changed_at": "2021-10-04T15:20:39.920Z",
+                "uuid": "12874da0-34a3-466d-a92c-93b752c471a5",
+                "program_type": "scitt_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": true,
+                "accept_english_gcse_equivalency": true,
+                "accept_maths_gcse_equivalency": true,
+                "accept_science_gcse_equivalency": null,
+                "additional_gcse_equivalencies": "",
+                "degree_grade": "not_required",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-07-19T19:09:28Z",
+                "about_accrediting_body": null,
+                "provider_code": "T87",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "scitt",
+                "about_course": "The Tudor Grange SCITT geography programme blends theory and practice, helping you to confidently develop your understanding and skills. All aspects of pedagogy will be covered, and you will have opportunities to watch outstanding practitioners demonstrating their skills in the classroom. \r\n\r\nEducational theories are taught and practical application in the classroom is explored. The emphasis is on evaluation and reflection throughout to help you consider the relevance of these concepts, enabling you to discover more about the kind of teacher you want to be. \r\n\r\nTeaching geography allows us to educate children and enrich their lives in order to prepare themselves for future success. This focus on cultural capital is something that separates geography from other subjects by making every topic applicable to real-life and allowing students to acknowledge the world around them. The subject studies sessions include a range of individual and group activities, and often follow on from the professional studies sessions. Although there is scope to become more bespoke by concentrating on areas of concern for individual trainees, for example: focusing on “teaching tricky topics” that are identified as part of the subject knowledge audit, which is completed before the course begins. Your geography specific Subject Leader will work with you directly to develop your teaching style and be another avenue of support during your teacher training year.\r\n\r\nThe course content is wide ranging and you will learn about how to plan lessons specific to your subject to help all the young people in your classrooms make progress; how to enable positive behaviour in classrooms; and how to work with parents. \r\n\r\nFeedback will be both formal and informal and always based around helping you to reflect on your own strengths and next steps. Trainees have regular collaborative progress checks and a scheduled weekly mentor meeting whilst on placement, so you can be sure that you will know how you’re doing at all times. The final recommendation for QTS is based around a combination of reports and your classroom practice.\r\n\r\nAs an accredited provider, we work in partnership with Birmingham City University for the PGCE element of the programme and all of the learning here is aimed at developing your pedagogical understanding. It is a complimentary programme, which enhances your classroom practice.\r\n",
+                "course_length": "OneYear",
+                "fee_details": "",
+                "fee_international": 9250,
+                "fee_uk_eu": 9250,
+                "financial_support": "",
+                "how_school_placements_work": "We strongly believe that the best place for a trainee teacher is in schools, developing your skill set through a cycle of observation, reflection, practise and feedback. Therefore the course is split into 25% Professional Studies sessions and 75% in school placements. Trainees are placed in at least two schools, which are carefully selected in order to provide a range of different experiences, giving you the best chances of developing your practice. For example, you might be placed in a rural school for one of your placements and an urban school for another. This increases your chances of employment and ensures you are a well-rounded practitioner.  \r\n\r\nWhilst on placement, you will be in the role of a teacher, and will therefore be able to take opportunities to learn about how the school day works – thus, you should plan to work full school days, including attending meetings before and after school, as well as preparing for parents’ evenings and after school activities, like awards ceremonies. We are also passionate about protecting our teachers and ensuring work/life balance is achieved. There are specific professional studies sessions related to this. Furthermore, although your timetable will increase so that by the end of the year, your teaching commitment is similar to that of a Newly Qualified Teacher, we gradually build up your timetable, at a rate that is right for you. It is our deep belief that mastering the craft of teaching is more important than arbitrarily increasing the number of lessons that you plan and teach.\r\n\r\nTrainees are assigned a personal subject specific mentor whilst on placement, who will work with you to set achievable targets, to help you to become the very best teacher you can be. You will constantly be working towards the Teachers’ Standards and will be supported and guided by Tudor Grange SCITT throughout the program. \r\n\r\nThe programme is an 11-16 offer, with post 16 enhancement. In reality, this means that when you are confidently mastering KS3 and 4 teaching, we will seek to find opportunities for you at post-16. We find that this helps with employability.",
+                "interview_process": "We sift all UCAS applications following a consistent criteria set out in-house, looking at candidate personal qualities, academic achievements and previous relevant experience in schools/working with young people, or vulnerable groups.\r\n\r\nFollowing a successful sift, candidates will be invited to an interview day, which dependant on applicant numbers, may be ran over one or two days. \r\nThe interview process consists of four parts;\r\nA subject knowledge audit – This is not a pass/fail test of your subject knowledge rather an audit of your strengths and areas for improvement. This allows us to understand your baseline and develop strategies for how we can work with you to fill any subject knowledge gaps prior to the course beginning, and to continue to provide bespoke support.\r\nUnseen task - Information on the task is given on the interview day.\r\nPanel interview – Your education philosophy and values, resilience, and knowledge of National Curriculum will all be explored during the panel interview.\r\n20 minute session delivery to a KS3 class – You will be provided with a topic for the session (set by the class teacher) a week in advance to allow you to prepare. During the session we will be looking at how candidates have demonstrated learner progress, their relationships with young people, and their ability to plan.\r\n\r\nWe aim to share outcomes of the interview process on the day, including detailed and meaningful feedback where applicable. All offers made by us are conditional, and will be explained when the offer is made\r\n",
+                "other_requirements": "All successful candidates will be subject to;\r\nAn enhanced DBS check, candidates must fund this themselves although Tudor Grange SCITT will make the application.\r\nAn occupational health check.\r\nConfirmation of right to work in the UK.",
+                "personal_qualities": "The Tudor Learning Habits;\r\n- Positive self regulation\r\n- Process not product\r\n- Open to failure and feedback\r\n- Courageous and gritty\r\n\r\nThe Tudor Character Habits;\r\n- Honesty and truthfulness\r\n- Kindness and empathy\r\n- Responsibility and integrity \r\n- Generosity and gratitude ",
+                "required_qualifications": "All candidates must hold;\r\n\r\nA Bachelor’s degree (or equivalent).\r\nEnglish GCSE - Minimum Grades C/4 (or equivalent).\r\nMaths GCSE - Minimum Grade C/4  (or equivalent).\r\n\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        },
+        {
+            "id": "12963331",
+            "type": "courses",
+            "attributes": {
+                "findable?": true,
+                "open_for_applications?": false,
+                "has_vacancies?": true,
+                "course_code": "3XXU",
+                "name": "Religious Education",
+                "study_mode": "full_time",
+                "qualification": "pgce_with_qts",
+                "description": "PGCE with QTS full time",
+                "content_status": "published",
+                "ucas_status": "running",
+                "funding_type": "fee",
+                "level": "secondary",
+                "is_send?": false,
+                "english": "expect_to_achieve_before_training_begins",
+                "maths": "expect_to_achieve_before_training_begins",
+                "science": "not_set",
+                "gcse_subjects_required": [
+                    "maths",
+                    "english"
+                ],
+                "age_range_in_years": "11_to_16",
+                "accrediting_provider": {
+                    "id": 17446,
+                    "address4": "Hertfordshire",
+                    "provider_name": "University of Hertfordshire",
+                    "scheme_member": "is_a_UCAS_ITT_member",
+                    "contact_name": "School of Education",
+                    "year_code": "2019",
+                    "provider_code": "H36",
+                    "provider_type": "university",
+                    "postcode": "AL10 9AB",
+                    "website": "https://go.herts.ac.uk/teachertraining",
+                    "address1": "University of Hertfordshire",
+                    "address2": null,
+                    "address3": "Hatfield",
+                    "email": "admcom@herts.ac.uk",
+                    "telephone": "01707 284800",
+                    "region_code": "eastern",
+                    "created_at": "2021-07-06T10:50:56.422Z",
+                    "updated_at": "2021-09-29T07:53:45.803Z",
+                    "accrediting_provider": "accredited_body",
+                    "changed_at": "2021-09-30T14:17:19.435Z",
+                    "recruitment_cycle_id": 4,
+                    "discarded_at": null,
+                    "train_with_us": "The University of Hertfordshire is a leading regional provider of [Initial Teacher Education](https://www.herts.ac.uk/study/schools-of-study/education/initial-teacher-education).  Consistently high achieving in its Ofsted inspections and in the Guardian and Times League tables, it is rightly proud of its excellent reputation with local and regional schools who often employ our student teachers.\r\n\r\nThe School of Education has an excellent record of employment for trainees on their Initial Teacher Education programmes, and those who actively seek a teaching post at the end of their programme are successful in joining the profession.\r\n\r\nAfter completing Initial Teacher Education there are opportunities to continue your studies with the University through the [MA Education Framework](https://www.herts.ac.uk/study/schools-of-study/education/postgraduate-courses-education/ma-education-framework).",
+                    "train_with_disability": "The University of Hertfordshire is committed to promoting equality of opportunity to ensure that it meets the needs of disabled people and has policies that are intended to support all students both in their studies and in developing their professional practice.\r\n\r\nIf you have a disability or other need we encourage you to disclose this and any other relevant information that could support your studies.\r\nThe School of Education at the University of Hertfordshire provides both academic and practice placement support for teachers in training with disabilities and other needs.\r\n\r\nOne key aspect of the PGCE course is to raise awareness of mental health and well-being and to support the removal of unnecessary workload. \r\n[University of Hertfordshire disability support](https://www.herts.ac.uk/life/student-support/disability-services)\r\n[University of Hertfordshire statement on disability disclosure by students](https://www.herts.ac.uk/life/student-support/disability-services/statement-on-disability-disclosure-by-students)\r\n",
+                    "accrediting_provider_enrichments": [],
+                    "latitude": 51.7518204,
+                    "longitude": -0.2387957,
+                    "ukprn": "10007147",
+                    "urn": "133783",
+                    "can_sponsor_skilled_worker_visa": false,
+                    "can_sponsor_student_visa": false
+                },
+                "accredited_body_code": "H36",
+                "changed_at": "2021-09-03T08:32:53.636Z",
+                "uuid": "10510422-f13b-49f0-aff6-cdc0395d883e",
+                "program_type": "school_direct_training_programme",
+                "accept_pending_gcse": true,
+                "accept_gcse_equivalency": false,
+                "accept_english_gcse_equivalency": false,
+                "accept_maths_gcse_equivalency": false,
+                "accept_science_gcse_equivalency": false,
+                "additional_gcse_equivalencies": null,
+                "degree_grade": "two_two",
+                "additional_degree_subject_requirements": null,
+                "degree_subject_requirements": null,
+                "start_date": "September 2022",
+                "applications_open_from": "2021-10-12",
+                "last_published_at": "2021-09-03T08:32:53Z",
+                "about_accrediting_body": null,
+                "provider_code": "1HS",
+                "recruitment_cycle_year": "2022",
+                "provider_type": "lead_school",
+                "about_course": "The PGCE Secondary course is a full time, one year Initial Teacher Education qualification introducing you to the requirements for teaching to the 11 – 16 age range. Where appropriate, opportunities to experience post 16 provision will be available. It has been designed to enable you to demonstrate evidence of having met the Teachers’ Standards that lead to Qualified Teacher Status. Whilst undertaking the University-led PGCE route into teaching you will work towards securing 60 Master’s level credits. This is an integral part of the programme. We strongly believe that innovative and effective teaching and learning is made possible through a teacher’s full engagement with research informed practice and underpinning theories of learning.\r\nThis is fostered in two modules and developed through School Based Training. You will be well supported in becoming a critically reflective teacher capable of inspiring pupils to learn, achieve and flourish. You will be supported and taught by specialist tutors with excellent experience, knowledge and research informed expertise. Partnership schools provide opportunities for you to learn about pedagogical approaches relevant to your subject specialism and the professional responsibilities of all teachers.\r\nYou will have two School Based Training placements, where, with the support of a teacher mentor and a university subject tutor, you will develop your skills to become an excellent classroom teacher. Training to teach is exciting, rewarding and demanding. By the end of the course you will be well prepared for employment as a Newly Qualified Teacher (NQT).",
+                "course_length": "OneYear",
+                "fee_details": null,
+                "fee_international": 14505,
+                "fee_uk_eu": 9250,
+                "financial_support": null,
+                "how_school_placements_work": "Schools in the University of Hertfordshire schools\u0026#39; partnership have a proven track record of strong engagement with Initial Teacher Education. Schools are evaluated and monitored in relation to the quality and effectiveness of school based training provision. School’s commit to enact the terms of the University of Hertfordshire Partnership for Initial Teacher Education.\r\n\r\nDuring the course you will undertake School Based Training in two contrasting secondary schools:\r\n* The first school placement will take place between September and December\r\n* The second school placement will take place between January and June\r\nYour School Based Training will total a minimum of 120 days. In addition to the two main placements you will:\r\n* visit a primary school to consider Year 6 transition\r\n* visit a special school to explore effective differentiation and inclusion for pupils with complex learning needs\r\n* visit a school demonstrating excellent provision for pupils with English as an additional language\r\n\r\nThe University of Hertfordshire partners with a wide and diverse range of schools with whom we have a strong working partnership based upon the vision to work together to develop teachers with the confidence to:\r\n\r\n* make professional judgements to enable the development and learning of all (Agency)\r\n* articulate how research has informed their practice and contribute to new thinking and new ways of working (Professional Voice)\r\n* respond innovatively to a changing educational landscape (Resilience)\r\n* strive to ensure a child\u0026#39;s learning and life chances are not limited by social or economic factors (Social Justice)\r\n\r\nDuring School Based Training you will be teaching students in the 11-16 age range. Where appropriate, you will have the opportunity to experience post 16 provision.",
+                "interview_process": null,
+                "other_requirements": "You are required to pass the [Professional Skills tests (http://sta.education.gov.uk/) in literacy and numeracy before starting the course.\r\nYou are required to complete a Disclosure and Barring Service (DBS) check and a Declaration of Disqualification by Association form. You will also need to respond to targeted and relevant health questions. Guidance will be provided after you have been offered a place.\r\nWe recommend that you undertake observation time in a state secondary school prior to interview but this is not essential. [Activities to support observation in school - either before or after interview - that you may\r\nfind useful](https://www.herts.ac.uk/__data/assets/pdf_file/0006/164436/Secondary-School-experience-\r\ntasks.pdf)",
+                "personal_qualities": "In your application and during the interview process, you will need to demonstrate an ability to train to teach through the following:\r\n\r\n* Genuine care for children’s learning, progress and achievement\r\n* A commitment and passion for your subject specialism\r\n* Your motivation and interest in training to teach\r\n* Excellent interpersonal and communication skills\r\n* A commitment to working with children and adolescents and improving their educational outcomes\r\n* The ability to be organised, adaptable and resilient\r\n* A willingness to work and learn from others and to be responsive to feedback",
+                "required_qualifications": "Qualifications needed You will need to have these UH entry requirements\r\nHonours degree (2.2 or higher) from a UK university. Usually the degree should have a minimum 50% content of the subject applied for.\r\nEnglish language and mathematics GCSE grade 4 or above and Science grade 4 or above for primary teacher training [or a qualification recognised as equivalent by the University]( https://www.herts.ac.uk/study/entry-\r\nrequirements/undergraduate-degrees/gcse-equivalent-entry-requirements ).\r\nEquivalent overseas qualifications are accepted when recognised as comparable by NARIC. We may require demonstration of English language proficiency through IELTS (Academic version) with an overall score of 6.5\r\n(minimum of 6.0 in each band).\r\n",
+                "salary_details": null
+            },
+            "relationships": {
+                "provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "accrediting_provider": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "site_statuses": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "sites": {
+                    "meta": {
+                        "included": false
+                    }
+                },
+                "subjects": {
+                    "meta": {
+                        "included": false
+                    }
+                }
+            }
+        }
+    ],
+    "meta": {
+        "count": 9916
+    },
+    "jsonapi": {
+        "version": "1.0"
+    }
+}

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -3,7 +3,7 @@ def results_page_parameters(parameters = {})
     'filter[has_vacancies]' => 'true',
     'include' => 'site_statuses.site,provider,subjects',
     'page[page]' => 1,
-    'page[per_page]' => 10,
+    'page[per_page]' => 30,
     'sort' => 'provider.provider_name,name',
   }.merge(parameters)
 end

--- a/spec/support/stubbed_requests/courses.rb
+++ b/spec/support/stubbed_requests/courses.rb
@@ -22,6 +22,10 @@ module StubbedRequests
         'four_courses.json'
       when 10
         'ten_courses.json'
+      when 30
+        'thirty_courses.json'
+      when 60
+        'sixty_courses.json'
       end
     end
 

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -852,9 +852,9 @@ describe ResultsView do
       end
     end
 
-    context 'where there are 10 results' do
+    context 'where there are 30 results' do
       before do
-        stub_request_with_meta_count(10)
+        stub_request_with_meta_count(30)
       end
 
       it 'returns 1 page' do
@@ -862,9 +862,9 @@ describe ResultsView do
       end
     end
 
-    context 'where there are 20 results' do
+    context 'where there are 60 results' do
       before do
-        stub_request_with_meta_count(20)
+        stub_request_with_meta_count(60)
       end
 
       it 'returns 2 pages' do


### PR DESCRIPTION
### Context
We are picking only 10 rows of an expensive query.
Could reduce subsequent calls to the API by showing more results per page.

### Changes proposed in this pull request
Show 30 results per page
Could lead to lesser click through to deep pages

### Guidance to review

### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
