### PR TITLE
Use markdown for qualifications freetext fields

### DIFF
--- a/app/components/courses/entry_requirements_component.html.erb
+++ b/app/components/courses/entry_requirements_component.html.erb
@@ -8,7 +8,7 @@
 
     <% if course.degree_subject_requirements.present? %>
       <p class="govuk-body">
-        <%= course.degree_subject_requirements %>
+        <%= helpers.markdown(course.degree_subject_requirements) %>
       </p>
     <% end %>
 
@@ -26,7 +26,7 @@
 
     <% if course.additional_gcse_equivalencies.present? %>
       <p class="govuk-body">
-        <%= course.additional_gcse_equivalencies %>
+        <%= helpers.markdown(course.additional_gcse_equivalencies) %>
       </p>
     <% end %>
   </div>


### PR DESCRIPTION
### Context

We're not using markdown atm on the degree and gcse structured free text fields.

### Changes proposed in this pull request

- Use the markdown helper on the appropriate fields

### Trello card

https://trello.com/c/PHPNfO9B/4024-gcse-equivalency-test-additional-information-should-render-using-markdown-to-match-preview

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
