### PR TITLE
Reject invalid multipart form data in Rack middleware

### DIFF
--- a/app/middleware/handle_bad_multipart_form_data_middleware.rb
+++ b/app/middleware/handle_bad_multipart_form_data_middleware.rb
@@ -1,0 +1,17 @@
+class HandleBadMultipartFormDataMiddleware
+  # Rack panics when calling params on req with invalid multipart form data
+  # but we need to look at params as part of the Csharp param handling middleware
+  # https://github.com/rack/rack/issues/903
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    begin
+      @app.call(env)
+    rescue EOFError
+      [400, { 'Content-Type' => 'text/plain' }, ['Bad Request']]
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'view_component/engine'
 require './app/middleware/csharp_subject_conversion_middleware'
+require './app/middleware/handle_bad_multipart_form_data_middleware'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -32,6 +33,7 @@ module FindTeacherTraining
     # https://thoughtbot.com/blog/content-compression-with-rack-deflater
     config.middleware.use Rack::Deflater
     config.middleware.use CsharpSubjectConversionMiddleware
+    config.middleware.insert_before CsharpSubjectConversionMiddleware, HandleBadMultipartFormDataMiddleware
 
     config.skylight.environments = Settings.skylight_enable ? [Rails.env] : []
 

--- a/spec/requests/bad_form_data_spec.rb
+++ b/spec/requests/bad_form_data_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'handling invalid multipart form data' do
+  it 'returns 400 for malformed form data' do
+    # POST to /cookies (a valid POST path) so we don't get a 404 exception instead
+    post '/cookies', params: 'nonsense', headers: { 'Content-Type' => 'multipart/form-data; boundary=----blah' }
+    expect(response).to have_http_status(400)
+  end
+end


### PR DESCRIPTION
Our Csharp subject param converting middleware needs to look at the request params, but if these are malformed Rack throws an exception. Handle this exception in outer middleware.

Example sentry error:
https://sentry.io/organizations/dfe-bat/issues/2685501784/?referrer=slack
