### PR TITLE
Update the banner and maintenance page content and switch banner on

### DIFF
--- a/app/components/maintenance_banner_component.html.erb
+++ b/app/components/maintenance_banner_component.html.erb
@@ -1,4 +1,4 @@
 <%= govuk_notification_banner(title_text: 'Important') do |notification_banner| %>
-  <% notification_banner.heading(text: 'This service will be unavailable on Thursday 23 September from 7.30am to 8am, while we carry out maintenance') %>
+  <% notification_banner.heading(text: 'This service will be unavailable on Monday 11 October for a short period between 8pm and 9pm, while we carry out maintenance') %>
   <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
 <% end %>

--- a/app/views/pages/maintainance.html.erb
+++ b/app/views/pages/maintainance.html.erb
@@ -5,7 +5,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">This service is currently down for maintenance</h1>
 
-      <p class="govuk-body">The service will be available from 8am on 23 September.</p>
+      <p class="govuk-body">The service will be available soon.</p>
       <p class="govuk-body">If you have any questions, contact us at <%= govuk_mail_to bat_contact_email_address %>.</p>
     </div>
   </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,7 @@ feature_flags:
   send_web_requests_to_big_query: false
   new_filters: true
   maintenance_mode: false
-  maintenance_banner: false
+  maintenance_banner: true
   cache_courses: false
   provider_autocomplete: true
   bursaries_and_scholarships_announced: true


### PR DESCRIPTION
### Context

We're upgrading the DB tonight between 8pm and 9pm. During this period Find will go down for a couple of minutes.

We need to let candidates know that the service will be down for a short period of time between 8 & 9pm.

### Changes proposed in this pull request

- Update the content on the maintenance page to reflect tonights DB upgrade.
- Switch the banner on 

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
