### PR TITLE
Switch off maintenance banner

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,7 +23,7 @@ feature_flags:
   send_web_requests_to_big_query: false
   new_filters: true
   maintenance_mode: false
-  maintenance_banner: true
+  maintenance_banner: false
   cache_courses: false
   provider_autocomplete: true
   bursaries_and_scholarships_announced: true


### PR DESCRIPTION
### Context

We're done upgrading the db now and can switch the flag off for the banner

### Changes proposed in this pull request

- Switch off maintenance banner

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
