### PR TITLE
Toggle the bursaries and scholarships flag on

### DIFF
--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -8,7 +8,9 @@
       <%= render 'shared/hidden_fields', exclude_keys: %w[subject_codes senCourses], form: f %>
       <h1 class="govuk-heading-l" data-qa="heading"><%= I18n.t('page_titles.subjects_filter') %></h1>
 
-      <p class="govuk-body">Some subjects may offer bursaries or scholarships. Funding will be announced later this autumn.</p>
+      <% unless FeatureFlag.active?('bursaries_and_scholarships_announced') %>
+        <p class="govuk-body">Some subjects may offer bursaries or scholarships. Funding will be announced later this autumn.</p>
+      <% end %>
 
       <%= govuk_accordion(id: 'subject-area-accordion') do |accordion| %>
         <% @subject_areas.each_with_index do |subject_area, counter| %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -10,4 +10,4 @@ feature_flags:
   send_web_requests_to_big_query: true
   cache_courses: true
   provider_autocomplete: false
-  bursaries_and_scholarships_announced: false
+  bursaries_and_scholarships_announced: true


### PR DESCRIPTION
### Context

FI has been announced and we need to expose the new data on Find. This PR toggles the `bursaries_and_scholarships_announced` flag on 

### Changes proposed in this pull request

- Switch on the `bursaries_and_scholarships_announced` flag 
