### PR TITLE
Send the correct cache provider autocomplete query param to the back end

### DIFF
--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -93,7 +93,7 @@
               id="query-container" data-qa="by-provider-conditional">
               <div class="govuk-form-group <%= 'govuk-form-group--error' if provider_error? %>" data-module="track-no-provider-results">
                 <% if FeatureFlag.active?(:cache_providers) && select_provider_options %>
-                  <%= form.label :query, { class: 'govuk-label', data_qa: 'cached-providers-autocomplete',for: 'provider'  } do %>
+                  <%= form.label :query, { class: 'govuk-label', data_qa: 'cached-providers-autocomplete',for: 'query'  } do %>
                     School, university or other training provider
                   <% end %>
                   <span class="govuk-hint">Enter the name or provider code</span>
@@ -103,7 +103,7 @@
                   <% end %>
                   <% aria_described_by = "provider-hint" %>
                   <% aria_described_by += " provider-error" if provider_error? %>
-                  <%= form.collection_select('provider', select_provider_options, :id, :name, {}, { class: "govuk-input", "aria-describedby" => aria_described_by }) %>
+                  <%= form.collection_select('query', select_provider_options, :id, :name, {}, { class: "govuk-input", "aria-describedby" => aria_described_by,  data: { qa: 'provider-search' } }) %>
                 <% else %>
                   <%= form.label :query, { class: 'govuk-label', for: 'provider' } do %>
                     School, university or other training provider

--- a/app/webpacker/scripts/__snapshots__/cached-providers-autocomplete.spec.js.snap
+++ b/app/webpacker/scripts/__snapshots__/cached-providers-autocomplete.spec.js.snap
@@ -7,7 +7,7 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
   
           
   <label
-    for="provider"
+    for="query"
   >
     Enter something
   </label>
@@ -23,7 +23,7 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
         <div
           aria-atomic="true"
           aria-live="polite"
-          id="provider__status--A"
+          id="query__status--A"
           role="status"
         >
           
@@ -31,7 +31,7 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
         <div
           aria-atomic="true"
           aria-live="polite"
-          id="provider__status--B"
+          id="query__status--B"
           role="status"
         >
           
@@ -40,12 +40,12 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
       
       <input
         aria-autocomplete="list"
-        aria-describedby="provider__assistiveHint"
+        aria-describedby="query__assistiveHint"
         aria-expanded="false"
-        aria-owns="provider__listbox"
+        aria-owns="query__listbox"
         autocomplete="off"
         class="autocomplete__input autocomplete__input--default"
-        id="provider"
+        id="query"
         name=""
         placeholder=""
         role="combobox"
@@ -54,13 +54,13 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
       
       <ul
         class="autocomplete__menu autocomplete__menu--inline autocomplete__menu--hidden"
-        id="provider__listbox"
+        id="query__listbox"
         role="listbox"
       >
         
       </ul>
       <span
-        id="provider__assistiveHint"
+        id="query__assistiveHint"
         style="display: none;"
       >
         When autocomplete results are available use up and down arrows to review and enter to select.  Touch device users, explore by touch or with swipe gestures.
@@ -68,7 +68,7 @@ exports[`initACachedProvidersAutocomplete should instantiate an autocomplete 1`]
     </div>
   </div>
   <select
-    id="provider-select"
+    id="query-select"
     style="display: none;"
   >
     

--- a/app/webpacker/scripts/cached-providers-autocomplete.js
+++ b/app/webpacker/scripts/cached-providers-autocomplete.js
@@ -1,7 +1,7 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
 export const initCachedProvidersAutocomplete = () => {
-  const inputId = 'provider'
+  const inputId = 'query'
   const autocompleteId = 'provider-autocomplete'
 
   try {

--- a/app/webpacker/scripts/cached-providers-autocomplete.spec.js
+++ b/app/webpacker/scripts/cached-providers-autocomplete.spec.js
@@ -8,8 +8,8 @@ describe("initACachedProvidersAutocomplete", () => {
   beforeEach(() => {
     document.body.innerHTML = `
         <div id="outer-container">
-          <label for="provider">Enter something</label>
-          <select id="provider">
+          <label for="query">Enter something</label>
+          <select id="query">
             <option value>Select a option</option>
             <option value="A">A</option>
             <option value="B">B</option>


### PR DESCRIPTION
### Context

The new provider cache autocomplete is currently failing (once the cache is populated) because the wrong query param key is being passed to the back end. This slipped through the net and indicates a spec is missing

### Changes proposed in this pull request
- Send the correct cache provider autocomplete query param to the back end
- Add test coverage

### Guidance to review

Locally, manually populate the providers cache (`SyncAllProviders.call`) and all should be well again

Note this does not fix the other issue where [the background job to populate the cache appears to not be working](https://ukgovernmentdfe.slack.com/archives/CN1MCQCHZ/p1634632593143600) (a separate fix for this is under investigation)


### Trello card

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
