### PR TITLE
Switch provider autocomplete back on in QA and prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -11,6 +11,5 @@ background_jobs: # scheduled jobs run on all environments except prod, dev and t
 feature_flags:
   send_web_requests_to_big_query: true
   cache_courses: true
-  provider_autocomplete: false
   bursaries_and_scholarships_announced: true
   cache_providers: false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -10,5 +10,4 @@ feature_flags:
   send_web_requests_to_big_query: true
   new_filters: true
   cache_courses: true
-  provider_autocomplete: false
   bursaries_and_scholarships_announced: false


### PR DESCRIPTION
With the start of cycle traffic cycle having subsided, we can now
re-enable this autocomplete. It will shortly be replaced by a version
which uses a locally-stored provider list, resulting in far fewer
network calls.

### Context

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
