### PR TITLE
Add the 'amazing_print' gem 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -112,6 +112,9 @@ group :development, :test do
   # Debugging
   gem 'pry-byebug'
 
+  # Prettify logs
+  gem 'amazing_print'
+
   # Testing framework
   gem 'rspec-rails', '~> 5.0.2'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
+    amazing_print (1.4.0)
     ast (2.4.2)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -493,6 +494,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  amazing_print
   better_errors
   binding_of_caller
   bootsnap (>= 1.1.0)


### PR DESCRIPTION
### Context

This PR adds the ['amazing_print' gem](https://logger.rocketjob.io/rails.html) and prints lovely logs. Thanks to @saliceti for the recommendation!

<img width="1623" alt="nicer_logging" src="https://user-images.githubusercontent.com/5256922/138061195-b1402481-07ed-49e6-8a8e-f78c4d86b23a.png">

### Guidance to review
- Are people happy with where the config has been placed?
- @gpeng - can we add to TTAPI please?

### Trello card


### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
