### PR TITLE
Remove left over binding.pry

### DIFF
--- a/app/views/courses/_entry_requirements_qualifications.html.erb
+++ b/app/views/courses/_entry_requirements_qualifications.html.erb
@@ -1,6 +1,5 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Entry requirements</h2>
-  <% binding.pry %>
   <% if course.required_qualifications.present? %>
     <h3 class="govuk-heading-m">Qualifications needed</h3>
     <div data-qa="course__required_qualifications">


### PR DESCRIPTION
### Context

A `binding.pry` made it into master

### Changes proposed in this pull request

Remove it!

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
