### PR TITLE
Remove load-test references from master

### DIFF
--- a/app/controllers/switcher_controller.rb
+++ b/app/controllers/switcher_controller.rb
@@ -14,8 +14,6 @@ class SwitcherController < ApplicationController
 private
 
   def redirect_to_homepage_if_in_production
-    # rubocop:disable Rails/UnknownEnv
-    redirect_to root_path if Rails.env.production? || Rails.env.loadtest?
-    # rubocop:enable Rails/UnknownEnv
+    redirect_to root_path if Rails.env.production?
   end
 end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -136,9 +136,7 @@ class CycleTimetable
 
   def self.current_cycle_schedule
     # Make sure this setting only has effect on non-production environments
-    # rubocop:disable Rails/UnknownEnv
-    return :real if HostingEnvironment.production? || Rails.env.loadtest?
-    # rubocop:enable Rails/UnknownEnv
+    return :real if HostingEnvironment.production?
 
     SiteSetting.cycle_schedule
   end


### PR DESCRIPTION
### Context

We have taken down the `load-test` and `loadtest` environments. All terraform configuration for `loadtest` seems to live in a branch, but there are some references in the main application.

### Changes proposed in this pull request

Remove references to `loadtest`.

### Guidance to review

Should be easy.

### Trello card

https://trello.com/c/3l4dR0wC/4429-destroy-load-test-environment

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
