### PR TITLE
Don't render the location row on a non location search

### DIFF
--- a/app/components/courses/search_result_component.html.erb
+++ b/app/components/courses/search_result_component.html.erb
@@ -34,12 +34,5 @@
 
     <dt class="app-description-list__label">Visa sponsorship</dt>
     <dd data-qa="course__visa_sponsorship"><%= visa_sponsorship_status %></dd>
-
-    <% unless filtered_by_location? %>
-      <dt class="app-description-list__label">Locations</dt>
-      <dd data-qa="course__main_address">
-        <%= helpers.smart_quotes(course.provider.decorate.short_address) %>
-      </dd>
-    <% end %>
   </dl>
 </li>

--- a/spec/features/courses/results_spec.rb
+++ b/spec/features/courses/results_spec.rb
@@ -46,7 +46,6 @@ describe 'Search results', type: :feature do
         expect(first_course.qualification.text).to include('PGCE with QTS')
         expect(first_course.study_mode.text).to eq('Full time')
         expect(first_course.funding_options.text).to eq('Student finance if you’re eligible')
-        expect(first_course.main_address.text).to eq('Poole SCITT, Ad Astra Infant School, Sherborn Crescent, Poole, Dorset, BH17 8AP')
         expect(first_course).not_to have_show_vacancies
       end
     end

--- a/spec/features/result_filters/location_and_provider_spec.rb
+++ b/spec/features/result_filters/location_and_provider_spec.rb
@@ -48,11 +48,6 @@ RSpec.feature 'Results page new area and provider filter' do
         subjects_page.continue.click
       end
 
-      it 'displays the courses' do
-        expect(results_page.courses.first).to have_main_address
-        expect(results_page.heading.text).to eq('4 courses found')
-      end
-
       it 'retains the query parameters' do
         expect_page_to_be_displayed_with_query(
           page: results_page,


### PR DESCRIPTION
### Context

A [support ticket](https://trello.com/c/pZatjybt/859-find-page-not-showing-location) was raised by a provider on how we render the location information on Find, when a candidate searches with 'Across England'.

We're currently rendering the providers address, rather than the site address. As an interim fix we will no longer render the location row, unless the candidate does a locations search.

### Changes proposed in this pull request

If a candidate searches 'Across England' or 'By provider' then don't render the locations row.

### Guidance to review

This is only an interim fix until we can come up with a reliable solution.

### Trello card

https://trello.com/c/pZatjybt/859-find-page-not-showing-location

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
