### PR TITLE
Find feature flags: Step 1 - set up basic auth

### DIFF
--- a/app/controllers/concerns/http_auth_concern.rb
+++ b/app/controllers/concerns/http_auth_concern.rb
@@ -1,0 +1,15 @@
+module HttpAuthConcern
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :http_authenticate
+  end
+
+  def http_authenticate
+    return true unless Settings.basic_auth_enabled
+
+    authenticate_or_request_with_http_basic do |username, password|
+      username == Settings.basic_auth_username && password == Settings.basic_auth_password
+    end
+  end
+end

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -1,0 +1,5 @@
+class FeatureFlagsController < ApplicationController
+  include HttpAuthConcern
+
+  def index; end
+end

--- a/app/views/feature_flags/index.html.erb
+++ b/app/views/feature_flags/index.html.erb
@@ -1,0 +1,3 @@
+<%= content_for :page_title, 'Feature flags' %>
+
+<h2 class="govuk-heading-xl">Feature flags</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
   post '/cycles', to: 'switcher#update', as: :switch_cycle_schedule
 
+  get '/feature-flags', to: 'feature_flags#index'
+
   scope module: 'result_filters' do
     root to: 'location#start'
   end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -10,3 +10,7 @@ feature_flags:
   send_web_requests_to_big_query: true
   cache_courses: true
   bursaries_and_scholarships_announced: true
+
+basic_auth_enabled: true
+basic_auth_username: replace_me
+basic_auth_password: replace_me

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -8,7 +8,12 @@ google:
     dataset: bat-find-test-events
 redis_url: redis://localhost:6379/9
 background_jobs: # scheduled jobs run on all environments except dev and test - see settings.yml
+
 feature_flags:
   new_filters: true
   cache_courses: true
   bursaries_and_scholarships_announced: true
+
+basic_auth_enabled: false
+basic_auth_username: foo
+basic_auth_password: bar

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'Require basic authentication', type: :request do
+  it 'requests when basic auth is disabled are let through' do
+    allow(Settings).to receive(:basic_auth_enabled).and_return false
+
+    get feature_flags_path
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'requests without basic auth get 401' do
+    allow(Settings).to receive(:basic_auth_enabled).and_return true
+
+    get feature_flags_path
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'requests with invalid basic auth get 401' do
+    allow(Settings).to receive(:basic_auth_enabled).and_return true
+
+    get feature_flags_path, headers: basic_auth_headers('wrong', 'auth')
+
+    expect(response).to have_http_status(:unauthorized)
+  end
+
+  it 'requests with valid basic auth get 200' do
+    allow(Settings).to receive(:basic_auth_enabled).and_return true
+
+    get feature_flags_path, headers: basic_auth_headers('foo', 'bar')
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  def basic_auth_headers(user, password)
+    { 'HTTP_AUTHORIZATION' => \
+           ActionController::HttpAuthentication::Basic.encode_credentials(user, password) }
+  end
+end


### PR DESCRIPTION
### Context

Currently feature flags on Find are controlled via environment variables. This means we need to redeploy whenever we want to toggle a flag.

Apply on the other hand has the means to toggle flags live in production with the need to redeploy.

We want to be able to store Feature Flag state in Redis and have the means to toggle feature flags via a basic-auth-protected UI

### Changes proposed in this pull request

Set up basic auth and create a dummy Feature flags UI page that is protected by basic auth in production

### Guidance to review

The basic auth is enabled in production. To see it in development add the following to your `development.local.yaml` and visit `/feature-flags`

```
basic_auth_enabled: true
basic_auth_username: foo
basic_auth_password: bar
```

### Trello card

https://trello.com/c/raFhJfIq/4123-find-feature-flags-step-1-set-up-basic-auth

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
