### PR TITLE
Reinstate feedback link on results page

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -1,4 +1,6 @@
 class ResultsController < ApplicationController
+  before_action :render_feedback_component
+
   def index
     service = DeprecatedParametersService.new(parameters: request.query_parameters)
     if service.deprecated?

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -27,6 +27,10 @@ describe 'results', type: :feature do
     end
   end
 
+  it 'displays a feedback link' do
+    expect(results_page.text).to have_content('How can we improve this page?')
+  end
+
   context 'provider sorting' do
     let(:ascending_stub) do
       stub_courses(


### PR DESCRIPTION
This was taken out in error at ac2464a6b

### Context

https://ukgovernmentdfe.slack.com/archives/CP18YJXPY/p1636553342237000?thread_ts=1636551466.234000&cid=CP18YJXPY

### Changes proposed in this pull request

Reinstate the link and add a spec (tho specs will be revamped in due course)