### PR TITLE
[4125] Add slack notification when feature flag updated

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,9 @@ gem 'govuk-components', '~> 2.0.1'
 # Data integration with BigQuery
 gem 'google-cloud-bigquery'
 
+# For outgoing http requests
+gem 'http'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
     deep_merge (1.2.1)
     diff-lcs (1.4.4)
     docile (1.3.2)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -179,6 +181,9 @@ GEM
     faraday_middleware (1.1.0)
       faraday (~> 1.0)
     ffi (1.15.3)
+    ffi-compiler (1.0.1)
+      ffi (>= 1.0.0)
+      rake
     foreman (0.87.2)
     fugit (1.4.4)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -228,6 +233,14 @@ GEM
       deep_merge (~> 1.2.1)
     hashdiff (1.0.1)
     html_tokenizer (0.0.7)
+    http (5.0.4)
+      addressable (~> 2.8)
+      http-cookie (~> 1.0)
+      http-form_data (~> 2.2)
+      llhttp-ffi (~> 0.4.0)
+    http-cookie (1.0.4)
+      domain_name (~> 0.5)
+    http-form_data (2.3.0)
     httpclient (2.8.3)
     i18n (1.8.11)
       concurrent-ruby (~> 1.0)
@@ -263,6 +276,9 @@ GEM
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    llhttp-ffi (0.4.0)
+      ffi-compiler (~> 1.0)
+      rake (~> 13.0)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -462,6 +478,9 @@ GEM
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8)
     unicode-display_width (2.1.0)
     view_component (2.36.0)
       activesupport (>= 5.0.0, < 8.0)
@@ -516,6 +535,7 @@ DEPENDENCIES
   google-cloud-bigquery
   govuk-components (~> 2.0.1)
   govuk_design_system_formbuilder (~> 2.7.5)
+  http
   json-schema
   json_api_client
   jsonapi-deserializable

--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -8,6 +8,11 @@ class FeatureFlagsController < ApplicationController
   def update
     FeatureFlag.send(action, feature_name)
 
+    SlackNotificationJob.perform_now(
+      ":flags: Feature ‘#{feature_name}‘ was activated",
+      feature_flags_path,
+    )
+
     flash[:success] = "Feature ‘#{feature_name.humanize}’ #{action}d"
     redirect_to feature_flags_path
   end

--- a/app/job/slack_notification_job.rb
+++ b/app/job/slack_notification_job.rb
@@ -1,0 +1,43 @@
+require 'http'
+
+class SlackNotificationJob < ApplicationJob
+  def perform(text, url = nil)
+    @webhook_url = Settings.STATE_CHANGE_SLACK_URL
+    if @webhook_url.present?
+      message = url.present? ? hyperlink(text, url) : text
+      post_to_slack message
+    end
+  end
+
+private
+
+  def hyperlink(text, url)
+    "<#{url}|#{text}>"
+  end
+
+  def post_to_slack(text)
+    if HostingEnvironment.production?
+      slack_message = text
+      slack_channel = '#twd_apply_tech'
+    else
+      slack_message = "[#{HostingEnvironment.environment_name.upcase}] #{text}"
+      slack_channel = '#twd_apply_test'
+    end
+
+    payload = {
+      username: 'Find postgraduate teacher training',
+      channel: slack_channel,
+      text: slack_message,
+      mrkdwn: true,
+      icon_emoji: ':livecanary:',
+    }
+
+    response = HTTP.post(@webhook_url, body: payload.to_json)
+
+    unless response.status.success?
+      raise SlackMessageError, "Slack error: #{response.body}"
+    end
+  end
+
+  class SlackMessageError < StandardError; end
+end

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,3 +7,4 @@ valid_referers:
   - https://www.find-postgraduate-teacher-training.education.gov.uk
 basic_auth_username: replace_me
 basic_auth_password: replace_me
+STATE_CHANGE_SLACK_URL: replace_me

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -11,3 +11,4 @@ background_jobs: # scheduled jobs run on all environments except dev and test - 
 basic_auth_enabled: false
 basic_auth_username: foo
 basic_auth_password: bar
+STATE_CHANGE_SLACK_URL: https://example.com/webhook

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'Feature flags', type: :feature do
     within(summary_card) { click_link 'Confirm environment to make changes' }
     fill_in 'Type ‘test’ to confirm that you want to proceed', with: 'test'
     click_button 'Continue'
+    stub_slack_notification_job
 
     within(summary_card) { click_button 'Activate' }
   end
@@ -68,5 +69,18 @@ RSpec.describe 'Feature flags', type: :feature do
 
   def feature
     @feature ||= FeatureFlag.features[:test_feature]
+  end
+
+  def stub_slack_notification_job
+    stub_request(:post, 'https://example.com/webhook')
+      .with(
+        body: '{"username":"Find postgraduate teacher training","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was activated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
+        headers: {
+          'Connection' => 'close',
+          'Host' => 'example.com',
+          'User-Agent' => 'http.rb/5.0.4',
+        },
+      )
+      .to_return(status: 200, body: '', headers: {})
   end
 end

--- a/spec/jobs/slack_notification_job_spec.rb
+++ b/spec/jobs/slack_notification_job_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe SlackNotificationJob do
+  describe '#perform' do
+    it 'sends a Slack notification to this webhook if the URL is set' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+      invoke_worker
+
+      expect(slack_request).to have_been_made
+    end
+
+    it 'does not send a Slack notification if STATE_CHANGE_SLACK_URL is empty' do
+      allow(Settings).to receive(:STATE_CHANGE_SLACK_URL).and_return(nil)
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+      invoke_worker
+
+      expect(slack_request).not_to have_been_made
+    end
+
+    it 'raises an error if Slack responds with one' do
+      stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 400, headers: {})
+
+      expect { invoke_worker }.to raise_error(SlackNotificationJob::SlackMessageError)
+    end
+
+    it 'includes a link if given' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
+      invoke_worker
+
+      # Slack will begin the message with a < character (this codepoint) when presenting content as a link
+      expect(slack_request.with(body: /\[TEST\] \\u003/)).to have_been_made
+    end
+
+    it 'does not include a link if none given' do
+      slack_request = stub_request(:post, 'https://example.com/webhook')
+        .to_return(status: 200, headers: {})
+
+      described_class.new.perform('example text')
+
+      expect(slack_request.with(body: /\[TEST\] example text/)).to have_been_made
+    end
+  end
+
+  def invoke_worker
+    described_class.new.perform('example text', 'https://example.com/support')
+  end
+end


### PR DESCRIPTION
### Context

Send slack notifications when feature flags are upated on `/feature-flags`. The channel the notification is sent to is dependent on the environment (see changes proposed). 

### Changes proposed in this pull request

- Link slack text to `/feature-flags` page
- Add `http` gem
- Add `SlackNotificationJob` class
- Dynamic `webhook_url` based on the environment (Uses `Settings`)
- Post to `#twd_apply_tech` if production else post to `#twd_apply_test`

### Guidance to review

- Replace `Settings.STATE_CHANGE_SLACK_URL` in `app/job/slack_notification_job.rb` with the equivalent secret in `QA`. Feel free to ask me. 
- Fire up the app and navigate to `/feature-flags`
- Flip a few of the feature flags and admire the notifications on `#twd_apply_test`
- Ensure the secrets have been added correctly to Find production

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
