### PR TITLE
[3928] - new search flow

### DIFF
--- a/app/components/hidden_fields_component.html.erb
+++ b/app/components/hidden_fields_component.html.erb
@@ -1,0 +1,9 @@
+<% params.reject { |key, _value| key.in?(exclude_keys) }.each do |field_name, field_value| %>
+  <% if field_value.is_a?(Array) %>
+    <% field_value.each do |array_value| %>
+      <%= form.hidden_field(field_name, multiple: true, value: array_value) %>
+    <% end %>
+  <% else %>
+    <%= form.hidden_field(field_name, value: field_value) %>
+  <% end %>
+<% end %>

--- a/app/components/hidden_fields_component.rb
+++ b/app/components/hidden_fields_component.rb
@@ -1,0 +1,14 @@
+class HiddenFieldsComponent < ViewComponent::Base
+  attr_reader :query_params, :form_name, :form, :exclude_keys
+
+  def initialize(query_params:, form_name:, form:, exclude_keys: [])
+    @query_params = query_params
+    @form_name = form_name
+    @form = form
+    @exclude_keys = exclude_keys
+  end
+
+  def params
+    query_params[form_name] || query_params
+  end
+end

--- a/app/components/search/primary_subject_selection_component.html.erb
+++ b/app/components/search/primary_subject_selection_component.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-l'>
+      <%= I18n.t('subjects.primary_title') %>
+    </h1>
+
+    <p class="govuk-body">
+      As a trainee primary teacher you’ll learn to teach all subjects across the national curriculum.
+    </p>
+
+    <p class="govuk-body">
+      Some courses also enable you to develop your knowledge of a particular subject. When you’re a teacher, you could
+      take on a role to influence the way it’s taught in your school - for example, mentoring your teacher colleagues
+      to teach that subject better.
+    </p>
+
+    <%= form.govuk_collection_check_boxes :subject_codes, form.object.primary_subjects,
+      :code, :name, legend: { text: "Which courses would you like to find?" }
+    %>
+
+    <%= form.govuk_submit 'Find courses' %>
+  </div>
+</div>

--- a/app/components/search/primary_subject_selection_component.rb
+++ b/app/components/search/primary_subject_selection_component.rb
@@ -1,0 +1,13 @@
+module Search
+  class PrimarySubjectSelectionComponent < ViewComponent::Base
+    attr_reader :form
+
+    def initialize(form)
+      @form = form
+    end
+
+    def render?
+      form.object.age_group == 'primary'
+    end
+  end
+end

--- a/app/components/search/secondary_subject_selection_component.html.erb
+++ b/app/components/search/secondary_subject_selection_component.html.erb
@@ -5,7 +5,7 @@
     </h1>
 
     <p class="govuk-hint">
-      Select all subjects you are interested in teaching
+      Select all subjects you are interested in teaching. We’ll show you courses that train you to teach those subjects.
     </p>
 
     <%= form.govuk_collection_check_boxes :subject_codes, secondary_subjects,

--- a/app/components/search/secondary_subject_selection_component.html.erb
+++ b/app/components/search/secondary_subject_selection_component.html.erb
@@ -1,0 +1,17 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class='govuk-heading-l'>
+      <%= I18n.t('subjects.secondary_title') %>
+    </h1>
+
+    <p class="govuk-hint">
+      Select all subjects you are interested in teaching
+    </p>
+
+    <%= form.govuk_collection_check_boxes :subject_codes, secondary_subjects,
+      :code, :name, :financial_info, legend: { text: "Which courses would you like to find?" }
+    %>
+
+    <%= form.govuk_submit 'Find courses' %>
+  </div>
+</div>

--- a/app/components/search/secondary_subject_selection_component.rb
+++ b/app/components/search/secondary_subject_selection_component.rb
@@ -1,0 +1,31 @@
+module Search
+  class SecondarySubjectSelectionComponent < ViewComponent::Base
+    attr_reader :form
+
+    def initialize(form)
+      @form = form
+    end
+
+    def render?
+      form.object.age_group == 'secondary'
+    end
+
+    def secondary_subjects
+      form.object.secondary_subjects.map do |subject|
+        financial_info = nil
+
+        if FeatureFlag.active?(:bursaries_and_scholarships_announced)
+          if subject.decorate.has_scholarship_and_bursary?
+            financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} and bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} are available"
+          elsif subject.decorate.has_scholarship?
+            financial_info = "Scholarships of £#{number_with_delimiter(subject.scholarship, delimiter: ',')} are available"
+          elsif subject.decorate.has_bursary?
+            financial_info = "Bursaries of £#{number_with_delimiter(subject.bursary_amount, delimiter: ',')} available"
+          end
+        end
+
+        Struct.new(:code, :name, :financial_info).new(subject.subject_code, subject.subject_name, financial_info)
+      end
+    end
+  end
+end

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -74,7 +74,11 @@ module ResultFilters
     def next_step(all_params)
       submitted_params = get_params_for_selected_option(all_params)
       if flash[:start_wizard]
-        start_subject_path(submitted_params)
+        if FeatureFlag.active?(:new_search_flow)
+          age_groups_path(submitted_params)
+        else
+          start_subject_path(submitted_params)
+        end
       else
         results_path(submitted_params)
       end

--- a/app/controllers/search/age_groups_controller.rb
+++ b/app/controllers/search/age_groups_controller.rb
@@ -1,0 +1,43 @@
+module Search
+  class AgeGroupsController < ApplicationController
+    include FilterParameters
+
+    before_action :build_backlink_query_parameters
+
+    def new
+      @age_groups_form = AgeGroupsForm.new(age_group: params[:age_group])
+    end
+
+    def create
+      @age_groups_form = AgeGroupsForm.new(age_group: form_params[:age_group])
+
+      if @age_groups_form.valid?
+        if form_params[:age_group] == 'further_education'
+          redirect_to results_path(further_education_params)
+        else
+          redirect_to subjects_path(filter_params[:search_age_groups_form])
+        end
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def further_education_params
+      filter_params[:search_age_groups_form].merge(age_group: @age_groups_form.age_group, subject_codes: ['41'])
+    end
+
+    def form_params
+      params
+        .require(:search_age_groups_form)
+        .permit(:age_group)
+    end
+
+    def build_backlink_query_parameters
+      @backlink_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+                                              .query_parameters_with_defaults
+                                              .except(:search_age_groups_form)
+    end
+  end
+end

--- a/app/controllers/search/subjects_controller.rb
+++ b/app/controllers/search/subjects_controller.rb
@@ -1,0 +1,39 @@
+module Search
+  class SubjectsController < ApplicationController
+    include FilterParameters
+
+    before_action :build_backlink_query_parameters
+
+    def new
+      @subjects_form = Search::SubjectsForm.new(subject_codes: params[:subject_codes], age_group: params[:age_group])
+    end
+
+    def create
+      @subjects_form = Search::SubjectsForm.new(subject_codes: sanitised_subject_codes, age_group: form_params[:age_group])
+
+      if @subjects_form.valid?
+        redirect_to results_path(filter_params[:search_subjects_form].merge(subject_codes: @subjects_form.subject_codes))
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def sanitised_subject_codes
+      form_params['subject_codes'].delete_if(&:blank?)
+    end
+
+    def form_params
+      params
+        .require(:search_subjects_form)
+        .permit(:age_group, subject_codes: [])
+    end
+
+    def build_backlink_query_parameters
+      @backlink_query_parameters = ResultsView.new(query_parameters: request.query_parameters)
+                                              .query_parameters_with_defaults
+                                              .except(:search_subjects_form)
+    end
+  end
+end

--- a/app/form_objects/search/age_groups_form.rb
+++ b/app/form_objects/search/age_groups_form.rb
@@ -1,0 +1,10 @@
+module Search
+  class AgeGroupsForm
+    include ActiveModel::Model
+
+    attr_accessor :age_group
+
+    validates :age_group, presence: true
+    validates :age_group, inclusion: { in: %w[primary secondary further_education] }
+  end
+end

--- a/app/form_objects/search/subjects_form.rb
+++ b/app/form_objects/search/subjects_form.rb
@@ -1,0 +1,30 @@
+module Search
+  class SubjectsForm
+    include ActiveModel::Model
+
+    attr_accessor :subject_codes, :age_group
+
+    validates :subject_codes, presence: true
+
+    def primary_subjects
+      primary_subjects = subject_areas.find { |sa| sa.id == 'PrimarySubject' }.subjects
+
+      primary_subjects.map do |subject|
+        Struct.new(:code, :name).new(subject.subject_code, subject.subject_name)
+      end
+    end
+
+    def secondary_subjects
+      secondary_subjects = subject_areas.find { |sa| sa.id == 'SecondarySubject' }.subjects
+      modern_languages_subjects = subject_areas.find { |sa| sa.id == 'ModernLanguagesSubject' }.subjects
+
+      secondary_subjects + modern_languages_subjects.sort_by(&:subject_name)
+    end
+
+  private
+
+    def subject_areas
+      @subject_areas ||= SubjectArea.includes(:subjects).all
+    end
+  end
+end

--- a/app/form_objects/search/subjects_form.rb
+++ b/app/form_objects/search/subjects_form.rb
@@ -18,7 +18,7 @@ module Search
       secondary_subjects = subject_areas.find { |sa| sa.id == 'SecondarySubject' }.subjects
       modern_languages_subjects = subject_areas.find { |sa| sa.id == 'ModernLanguagesSubject' }.subjects
 
-      secondary_subjects + modern_languages_subjects.sort_by(&:subject_name)
+      (secondary_subjects + modern_languages_subjects).sort_by(&:subject_name)
     end
 
   private

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -8,6 +8,7 @@ class FeatureFlags
       [:send_web_requests_to_big_query, 'Send events to Google Big Query', 'Apply team'],
       [:bursaries_and_scholarships_announced, 'Display scholarship and bursary information', 'Apply team'],
       [:componentised_results, 'Refactors the view templates into Rails view components for the results page', 'Apply team'],
+      [:new_search_flow, 'A new search flow which first asks which age you would like to teach', 'Apply team']
     ]
   end
 end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -8,7 +8,7 @@ class FeatureFlags
       [:send_web_requests_to_big_query, 'Send events to Google Big Query', 'Apply team'],
       [:bursaries_and_scholarships_announced, 'Display scholarship and bursary information', 'Apply team'],
       [:componentised_results, 'Refactors the view templates into Rails view components for the results page', 'Apply team'],
-      [:new_search_flow, 'A new search flow which first asks which age you would like to teach', 'Apply team']
+      [:new_search_flow, 'A new search flow which first asks which age you would like to teach', 'Apply team'],
     ]
   end
 end

--- a/app/views/result_filters/subject/start.html.erb
+++ b/app/views/result_filters/subject/start.html.erb
@@ -1,11 +1,11 @@
 <% content_for :before_content do %>
-  <%= govuk_back_link({
-    text: 'Back to location',
-    href: root_path(@results_filter_query_parameters),
-    html_attributes: {
-      data: { qa: 'page-back' },
-    },
-  }) %>
+<%= govuk_back_link({
+text: 'Back to location',
+href: root_path(@results_filter_query_parameters),
+html_attributes: {
+data: { qa: 'page-back' },
+},
+}) %>
 <% end %>
 
 <%= render 'result_filters/subject/form', submit_button_text: 'Continue' %>

--- a/app/views/search/age_groups/new.html.erb
+++ b/app/views/search/age_groups/new.html.erb
@@ -21,7 +21,7 @@
         form_name: :search_age_groups_form,
         exclude_keys: ['age_group']) %>
 
-      <%= f.govuk_radio_buttons_fieldset :age_group, legend: { text: I18n.t('age_groups.title'), size: 'xl', tag: 'h1' } do %>
+      <%= f.govuk_radio_buttons_fieldset :age_group, legend: { text: I18n.t('age_groups.title'), size: 'l', tag: 'h1' } do %>
         <%= f.govuk_radio_button :age_group, 'primary', label: { text: 'Primary' }, link_errors: true %>
         <%= f.govuk_radio_button :age_group, 'secondary', label: { text: 'Secondary' } %>
         <%= f.govuk_radio_divider %>

--- a/app/views/search/age_groups/new.html.erb
+++ b/app/views/search/age_groups/new.html.erb
@@ -1,0 +1,34 @@
+<%= content_for :page_title, title_with_error_prefix(I18n.t('age_groups.title'), @age_groups_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link({
+    text: 'Back',
+    href: root_path(@backlink_query_parameters),
+    html_attributes: {
+      data: { qa: 'page-back' },
+    },
+  }) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @age_groups_form, url: age_groups_create_path, method: :get) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render HiddenFieldsComponent.new(
+        query_params: request.query_parameters,
+        form: f,
+        form_name: :search_age_groups_form,
+        exclude_keys: ['age_group']) %>
+
+      <%= f.govuk_radio_buttons_fieldset :age_group, legend: { text: I18n.t('age_groups.title'), size: 'xl', tag: 'h1' } do %>
+        <%= f.govuk_radio_button :age_group, 'primary', label: { text: 'Primary' }, link_errors: true %>
+        <%= f.govuk_radio_button :age_group, 'secondary', label: { text: 'Secondary' } %>
+        <%= f.govuk_radio_divider %>
+        <%= f.govuk_radio_button :age_group, 'further_education', label: { text: 'Further education' } %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search/age_groups/new.html.erb
+++ b/app/views/search/age_groups/new.html.erb
@@ -25,7 +25,7 @@
         <%= f.govuk_radio_button :age_group, 'primary', label: { text: 'Primary' }, link_errors: true %>
         <%= f.govuk_radio_button :age_group, 'secondary', label: { text: 'Secondary' } %>
         <%= f.govuk_radio_divider %>
-        <%= f.govuk_radio_button :age_group, 'further_education', label: { text: 'Further education' } %>
+        <%= f.govuk_radio_button :age_group, 'further_education', label: { text: 'Further education' }, hint:  { text: I18n.t('age_groups.further_education.hint') } %>
       <% end %>
 
       <%= f.govuk_submit 'Continue' %>

--- a/app/views/search/subjects/new.html.erb
+++ b/app/views/search/subjects/new.html.erb
@@ -1,0 +1,23 @@
+<%= content_for :page_title, title_with_error_prefix(I18n.t('subjects.title'), @subjects_form.errors.any?) %>
+<% content_for :before_content do %>
+  <%= govuk_back_link({
+    text: 'Back',
+    href: age_groups_path(@backlink_query_parameters),
+    html_attributes: {
+      data: { qa: 'page-back' },
+    },
+  }) %>
+<% end %>
+<%= form_with(model: @subjects_form, url: subjects_create_path, method: :get) do |f| %>
+  <%= f.govuk_error_summary %>
+
+  <%= render HiddenFieldsComponent.new(
+    query_params: request.query_parameters,
+    form: f,
+    form_name: :search_subjects_form,
+    exclude_keys: ['subject_codes']) %>
+
+  <%= render Search::PrimarySubjectSelectionComponent.new(f) %>
+  <%= render Search::SecondarySubjectSelectionComponent.new(f) %>
+<% end %>
+

--- a/config/locales/age_groups.yml
+++ b/config/locales/age_groups.yml
@@ -1,0 +1,10 @@
+en:
+  age_groups:
+    title: Which age group do you want to teach?
+  activemodel:
+    errors:
+      models:
+        search/age_groups_form:
+          attributes:
+            age_group:
+              blank: Select an age group

--- a/config/locales/age_groups.yml
+++ b/config/locales/age_groups.yml
@@ -1,6 +1,8 @@
 en:
   age_groups:
     title: Which age group do you want to teach?
+    further_education:
+      hint: For example, teaching A levels or vocational courses
   activemodel:
     errors:
       models:

--- a/config/locales/subjects.yml
+++ b/config/locales/subjects.yml
@@ -1,0 +1,12 @@
+en:
+  subjects:
+    title: Select a subject
+    primary_title: Primary courses with subject specialisms
+    secondary_title: Which secondary subjects are you interested in?
+  activemodel:
+    errors:
+      models:
+        search/subjects_form:
+          attributes:
+            subject_codes:
+              blank: Select at least one subject

--- a/config/locales/subjects.yml
+++ b/config/locales/subjects.yml
@@ -2,7 +2,7 @@ en:
   subjects:
     title: Select a subject
     primary_title: Primary courses with subject specialisms
-    secondary_title: Which secondary subjects are you interested in?
+    secondary_title: Which secondary subjects do you want to teach?
   activemodel:
     errors:
       models:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,14 @@ Rails.application.routes.draw do
   get '/confirm-environment' => 'confirm_environment#new'
   post '/confirm-environment' => 'confirm_environment#create'
 
+  # new search flow
+  scope module: 'search' do
+    get '/age-groups' => 'age_groups#new'
+    get '/age-groups-submit' => 'age_groups#create', as: :age_groups_create
+    get '/subjects' => 'subjects#new'
+    get '/subjects-submit' => 'subjects#create', as: :subjects_create
+  end
+
   scope module: 'result_filters' do
     root to: 'location#start'
   end

--- a/spec/features/search/new_flow/across_england/further_education_spec.rb
+++ b/spec/features/search/new_flow/across_england/further_education_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching across England' do
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  before do
+    stub_subjects
+    stub_courses_request
+    stub_subject_areas
+  end
+
+  scenario 'Candidate searches for further education courses across England' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+    when_i_visit_the_start_page
+    and_i_select_the_across_england_radio_button
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present
+
+    when_i_select_the_further_education_radio_button
+    and_i_click_continue
+    then_i_should_see_the_results_page
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_across_england_radio_button
+    choose 'Across England'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content('Which age group do you want to teach?')
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('l=2')
+    end
+  end
+
+  def when_i_select_the_further_education_radio_button
+    choose 'Further education'
+  end
+
+  def then_i_should_see_the_results_page
+    expect(page).to have_current_path('/results?age_group=further_education&l=2&subject_codes%5B%5D=41')
+  end
+
+  def stub_courses_request
+    stub_courses(query: results_page_parameters({ 'filter[subjects]' => '41' }), course_count: 10)
+  end
+end

--- a/spec/features/search/new_flow/across_england/primary_spec.rb
+++ b/spec/features/search/new_flow/across_england/primary_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching across England' do
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  before do
+    stub_subjects
+    stub_courses_request
+    stub_subject_areas
+  end
+
+  scenario 'Candidate searches for primary courses across England' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+    when_i_visit_the_start_page
+    and_i_select_the_across_england_radio_button
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present
+
+    when_i_click_back
+    then_i_should_see_the_start_page
+    and_the_across_england_radio_button_is_selected
+
+    when_i_click_continue
+    then_i_should_see_the_age_groups_form
+
+    when_i_click_continue
+    i_should_see_an_age_group_validation_error
+
+    when_i_select_the_primary_radio_button
+    and_i_click_continue
+    then_i_should_see_the_subjects_form
+    and_the_correct_subjects_form_page_url_and_query_params_are_present
+
+    when_i_click_back
+    then_i_should_see_the_age_groups_form
+    and_age_group_radio_selected
+
+    when_i_click_continue
+    then_i_should_see_the_subjects_form
+
+    when_i_click_find_courses
+    then_i_should_see_a_subjects_validation_error
+
+    when_i_select_the_primary_subject_textbox
+    and_i_click_find_courses
+    then_i_should_see_the_results_page
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_across_england_radio_button
+    choose 'Across England'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def when_i_click_continue
+    and_i_click_continue
+  end
+
+  def then_i_should_see_the_start_page
+    expect(page).to have_content('Find courses by location or by training provider')
+  end
+
+  def and_the_across_england_radio_button_is_selected
+    expect(find_field('Across England')).to be_checked
+  end
+
+  def and_age_group_radio_selected
+    expect(find_field('Primary')).to be_checked
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content(I18n.t('age_groups.title'))
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('l=2')
+    end
+  end
+
+  def and_the_correct_subjects_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/subjects')
+      expect(uri.query).to eq('age_group=primary&fulltime=false&hasvacancies=true&l=2&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&senCourses=false')
+    end
+  end
+
+  def i_should_see_an_age_group_validation_error
+    expect(page).to have_content('Select an age group')
+  end
+
+  def when_i_select_the_primary_radio_button
+    choose 'Primary'
+  end
+
+  def then_i_should_see_the_subjects_form
+    expect(page).to have_content('Primary courses with subject specialisms')
+  end
+
+  def and_i_click_find_courses
+    click_button 'Find courses'
+  end
+
+  def when_i_click_find_courses
+    and_i_click_find_courses
+  end
+
+  def then_i_should_see_a_subjects_validation_error
+    expect(page).to have_content('Select at least one subject')
+  end
+
+  def when_i_select_the_primary_subject_textbox
+    check 'Primary'
+  end
+
+  def then_i_should_see_the_results_page
+    expect(page).to have_current_path('/results?age_group=primary&fulltime=false&hasvacancies=true&l=2&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&senCourses=false&subject_codes%5B%5D=00')
+  end
+
+  def stub_courses_request
+    stub_courses(query: results_page_parameters({ 'filter[subjects]' => '00' }), course_count: 10)
+  end
+end

--- a/spec/features/search/new_flow/across_england/secondary_spec.rb
+++ b/spec/features/search/new_flow/across_england/secondary_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature 'Searching across England' do
   end
 
   def then_i_should_see_the_subjects_form
-    expect(page).to have_content('Which secondary subjects are you interested in?')
+    expect(page).to have_content('Which secondary subjects do you want to teach?')
   end
 
   def and_i_click_find_courses

--- a/spec/features/search/new_flow/across_england/secondary_spec.rb
+++ b/spec/features/search/new_flow/across_england/secondary_spec.rb
@@ -1,0 +1,120 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching across England' do
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  before do
+    stub_subjects
+    stub_courses_request
+    stub_subject_areas
+  end
+
+  scenario 'Candidate searches for secondary courses across England' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+    when_i_visit_the_start_page
+    and_i_select_the_across_england_radio_button
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present
+
+    when_i_select_the_secondary_radio_button
+    and_i_click_continue
+    then_i_should_see_the_subjects_form
+    and_the_correct_subjects_form_page_url_and_query_params_are_present
+
+    when_i_click_back
+    then_i_should_see_the_age_groups_form
+    and_age_group_radio_selected
+
+    when_i_click_continue
+    then_i_should_see_the_subjects_form
+
+    when_i_click_find_courses
+    then_i_should_see_a_subjects_validation_error
+
+    when_i_select_the_secondary_subject_textbox
+    and_i_click_find_courses
+    then_i_should_see_the_results_page
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_across_england_radio_button
+    choose 'Across England'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def when_i_click_continue
+    and_i_click_continue
+  end
+
+  def and_age_group_radio_selected
+    expect(find_field('Secondary')).to be_checked
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content('Which age group do you want to teach?')
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('l=2')
+    end
+  end
+
+  def and_the_correct_subjects_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/subjects')
+      expect(uri.query).to eq('age_group=secondary&l=2')
+    end
+  end
+
+  def when_i_select_the_secondary_radio_button
+    choose 'Secondary'
+  end
+
+  def then_i_should_see_the_subjects_form
+    expect(page).to have_content('Which secondary subjects are you interested in?')
+  end
+
+  def and_i_click_find_courses
+    click_button 'Find courses'
+  end
+
+  def when_i_click_find_courses
+    and_i_click_find_courses
+  end
+
+  def then_i_should_see_a_subjects_validation_error
+    expect(page).to have_content('Select at least one subject')
+  end
+
+  def when_i_select_the_secondary_subject_textbox
+    check 'Art and design'
+  end
+
+  def then_i_should_see_the_results_page
+    expect(page).to have_current_path('/results?age_group=secondary&fulltime=false&hasvacancies=true&l=2&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&senCourses=false&subject_codes%5B%5D=W1')
+  end
+
+  def stub_courses_request
+    stub_courses(query: results_page_parameters({ 'filter[subjects]' => 'W1' }), course_count: 10)
+  end
+end

--- a/spec/features/search/new_flow/editing_a_search_spec.rb
+++ b/spec/features/search/new_flow/editing_a_search_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.feature 'Editing a search' do
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+
+  before do
+    stub_subjects
+    stub_courses_request
+    stub_subject_areas
+  end
+
+  scenario 'Candidate edits their search' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+
+    when_i_execute_a_valid_search
+    then_i_should_see_the_results_page
+
+    when_i_change_my_search_query
+    then_i_should_see_the_start_page
+    and_the_across_england_radio_button_should_be_selected
+
+    when_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_primary_radio_button_should_be_selected
+
+    when_i_click_continue
+    then_i_should_see_the_subjects_form
+    and_the_primary_checkbox_should_be_selected
+  end
+
+  def when_i_execute_a_valid_search
+    when_i_visit_the_start_page
+    and_i_select_the_across_england_radio_button
+    and_i_click_continue
+    and_i_select_the_primary_radio_button
+    and_i_click_continue
+    and_i_select_the_primary_subject_checkbox
+    and_i_click_find_courses
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_across_england_radio_button
+    choose 'Across England'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def when_i_click_continue
+    and_i_click_continue
+  end
+
+  def and_age_group_radio_selected
+    expect(find_field('Primary')).to be_checked
+  end
+
+  def and_i_select_the_primary_radio_button
+    choose 'Primary'
+  end
+
+  def and_i_click_find_courses
+    click_button 'Find courses'
+  end
+
+  def when_i_click_find_courses
+    and_i_click_find_courses
+  end
+
+  def and_i_select_the_primary_subject_checkbox
+    check 'Primary'
+  end
+
+  def then_i_should_see_the_results_page
+    expect(page).to have_current_path('/results?age_group=primary&l=2&subject_codes%5B%5D=00')
+  end
+
+  def when_i_change_my_search_query
+    click_link 'Change'
+  end
+
+  def then_i_should_see_the_start_page
+    expect(page).to have_content('Find courses by location or by training provider')
+  end
+
+  def and_the_across_england_radio_button_should_be_selected
+    expect(find_field('Across England')).to be_checked
+  end
+
+  def and_the_primary_radio_button_should_be_selected
+    expect(find_field('Primary')).to be_checked
+  end
+
+  def then_i_should_see_the_subjects_form
+    expect(page).to have_content(I18n.t('subjects.primary_title'))
+  end
+
+  def and_the_primary_checkbox_should_be_selected
+    expect(find_field('Primary')).to be_checked
+  end
+
+  def stub_courses_request
+    stub_courses(query: results_page_parameters({ 'filter[subjects]' => '00' }), course_count: 10)
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content(I18n.t('age_groups.title'))
+  end
+end

--- a/spec/form_objects/search/age_groups_form_spec.rb
+++ b/spec/form_objects/search/age_groups_form_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+module Search
+  describe AgeGroupsForm do
+    describe 'validation' do
+      it 'is not valid when no option is selected' do
+        form = Search::AgeGroupsForm.new
+
+        expect(form.valid?).to be(false)
+      end
+
+      it 'is not valid when selected option is not one of the accepted age groups' do
+        form = Search::AgeGroupsForm.new(age_group: 'foo')
+
+        expect(form.valid?).to be(false)
+      end
+
+      %w[primary secondary further_education].each do |age_group|
+        it "is valid when option selected is #{age_group}" do
+          form = Search::AgeGroupsForm.new(age_group: age_group)
+
+          expect(form.valid?).to be(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/form_objects/search/subjects_form_spec.rb
+++ b/spec/form_objects/search/subjects_form_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+module Search
+  describe SubjectsForm do
+    describe 'validation' do
+      it 'is not valid when subject codes are not present' do
+        form = Search::SubjectsForm.new
+
+        expect(form.valid?).to be(false)
+      end
+
+      it 'is valid when subject codes are present' do
+        form = Search::SubjectsForm.new(subject_codes: %w[01 02])
+
+        expect(form.valid?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Find currently asks users to select a subject using an Accordion which groups checkboxes by Primary, Secondary, Secondary: Modern languages, Further education and SEND.

### Changes proposed in this pull request
Depending on what you select:

* Primary takes you to a page listing all the primary subjects - there is also some updated content on this page
* Secondary takes you to a list of all secondary subjects in alphabetical order
* Further Education takes you straight to results.

SEND is no longer asked as part of the initial flow, as this is included as a filter instead.

### Guidance to review
- Visit '/feature-flags' and turn on the 'new_search_flow' feature flag
- IMPORTANT - this new flow currently works for 'searching by location' / 'across England' only. New flow for 'searching by provider' will be done in a followup PR

### Trello card
https://trello.com/c/N3mjUhBq/3928-dev-change-subject-accordion-page-to-a-primary-secondary-fe-flow

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
