### PR TITLE
[4209] - Wire up provider search to the new flow

### DIFF
--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -23,9 +23,12 @@ module ResultFilters
         flash[:error] = [I18n.t('location_filter.fields.provider'), I18n.t('location_filter.errors.missing_provider')]
         redirect_back
       elsif @provider_suggestions.count == 1
-        redirect_to start_subject_path(
-          filter_params_without_previous_parameters.merge(query: @provider_suggestions.first.provider_name),
-        )
+        params = filter_params_without_previous_parameters.merge(query: @provider_suggestions.first.provider_name)
+        if FeatureFlag.active?(:new_search_flow)
+          redirect_to age_groups_path(params)
+        else
+          redirect_to start_subject_path(params)
+        end
       end
     end
 

--- a/spec/features/search/location_and_provider_spec.rb
+++ b/spec/features/search/location_and_provider_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
+# TODO: these specs are deprecated and should be removed once the
+# new search flow is switched on permanently
+
 RSpec.feature 'Results page new area and provider filter' do
   include StubbedRequests::Courses
   include StubbedRequests::Providers

--- a/spec/features/search/new_flow/location_spec.rb
+++ b/spec/features/search/new_flow/location_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching by location' do
+  before do
+    stub_geocoder
+  end
+
+  scenario 'Candidate searches by location' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+
+    when_i_visit_the_start_page
+    and_i_select_the_location_radio_button
+    and_i_click_continue
+    then_i_should_see_a_missing_location_validation_error
+
+    when_i_enter_a_location
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present
+
+    when_i_click_back
+    then_i_should_see_the_start_page
+    and_the_location_radio_button_is_selected
+
+    # Note that the remainder of the search flow is has
+    # test coverage in 'spec/features/new_flow/across_england'
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_location_radio_button
+    choose 'By city, town or postcode'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_a_missing_location_validation_error
+    expect(page).to have_content('Enter a city, town or postcode')
+  end
+
+  def when_i_enter_a_location
+    fill_in 'Postcode, town or city', with: 'Yorkshire'
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content(I18n.t('age_groups.title'))
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('c=England&l=1&lat=51.4524877&lng=-0.1204749&loc=AA+Teamworks+W+Yorks+SCITT%2C+School+Street%2C+Greetland%2C+Halifax%2C+West+Yorkshire+HX4+8JB&lq=Yorkshire&rad=50&sortby=2')
+    end
+  end
+
+  def then_i_should_see_the_start_page
+    expect(page).to have_content('Find courses by location or by training provider')
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def and_the_location_radio_button_is_selected
+    expect(find_field('By city, town or postcode')).to be_checked
+  end
+end

--- a/spec/features/search/new_flow/provider_spec.rb
+++ b/spec/features/search/new_flow/provider_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching by provider' do
+  include StubbedRequests::Providers
+
+  scenario 'Candidate searches by provider' do
+    given_that_the_new_search_flow_feature_flag_is_enabled
+    and_the_provider_cache_is_enabled
+
+    when_i_visit_the_start_page
+    and_i_select_the_provider_radio_button
+    and_i_click_continue
+    then_i_should_see_a_missing_provider_validation_error
+
+    when_i_select_the_provider
+    and_i_click_continue
+    then_i_should_see_the_age_groups_form
+    and_the_correct_age_group_form_page_url_and_query_params_are_present
+
+    when_i_click_back
+    then_i_should_see_the_start_page
+    and_the_provider_radio_button_is_selected
+
+    # Note that the remainder of the search flow is has
+    # test coverage in 'spec/features/new_flow/across_england'
+  end
+
+  def given_that_the_new_search_flow_feature_flag_is_enabled
+    allow(FeatureFlag).to receive(:active?).and_call_original
+    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
+  end
+
+  def and_the_provider_cache_is_enabled
+    cached_providers = [
+      {
+        name: 'Provider 1',
+        code: 'ABC',
+      },
+    ].to_json
+
+    allow(TeacherTrainingPublicAPI::ProvidersCache).to receive(:read).and_return(cached_providers)
+
+    stub_one_provider(
+      query: {
+        'fields[providers]' => 'provider_code,provider_name',
+        'search' => 'Provider 1 (ABC)',
+      },
+    )
+  end
+
+  def when_i_visit_the_start_page
+    visit root_path
+  end
+
+  def and_i_select_the_provider_radio_button
+    choose 'By school, university or other training provider'
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def then_i_should_see_a_missing_provider_validation_error
+    expect(page).to have_content('Enter a school, university or other training provider')
+  end
+
+  def when_i_select_the_provider
+    select 'Provider 1 (ABC)', from: 'query'
+  end
+
+  def then_i_should_see_the_age_groups_form
+    expect(page).to have_content(I18n.t('age_groups.title'))
+  end
+
+  def and_the_correct_age_group_form_page_url_and_query_params_are_present
+    URI(current_url).then do |uri|
+      expect(uri.path).to eq('/age-groups')
+      expect(uri.query).to eq('l=3&query=ACME+SCITT+0')
+    end
+  end
+
+  def then_i_should_see_the_start_page
+    expect(page).to have_content('Find courses by location or by training provider')
+  end
+
+  def when_i_click_back
+    click_link 'Back'
+  end
+
+  def and_the_provider_radio_button_is_selected
+    expect(find_field('By school, university or other training provider')).to be_checked
+  end
+end

--- a/spec/features/search/subjects_spec.rb
+++ b/spec/features/search/subjects_spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
+# TODO: these specs are deprecated and should be removed once the
+# new search flow is switched on permanently
+
 RSpec.feature 'Results page new subject filter' do
   include StubbedRequests::Courses
   include StubbedRequests::SubjectAreas


### PR DESCRIPTION
### Context 

We have wired up searching by 'location' and 'across England' to the new search flow. We now need to do the same for searching by 'provider'. 

### Changes in the pull request 
- Wire up provider search to the new flow
- Add fix so the the provider search value is rehydrated on the start page when clicking back 

### Guidance for pull request 
- Visit '/feature-flags' and activate the 'new_search_flow' feature flag 

### Trello 
https://trello.com/c/coZ9yN3R/4209-primary-secondary-fe-flow-apply-to-provider-search-journey