### PR TITLE
Remove notifications from smoke test for review

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -55,7 +55,7 @@ jobs:
           retention-days: 7
 
       - name: 'Nofiy #twd_apply_tech on failure'
-        if: failure()
+        if: failure() && github.event.inputs.pr == ''
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: twd_apply_tech


### PR DESCRIPTION
### Context

Remove slack channel notifications from smoke test or deploy failures for review environments.
[https://trello.com/c/i9GEROze/472-remove-notifications-from-smoke-test-or-deploy-failures-for-review-app](url)

### Changes proposed in this pull request

in smoke-test.yml
line 58: if: failure()
change to
line 58: if: failure() && github.event.inputs.pr == ''

No notification step in deploy.yml, so no change required.
