### PR TITLE
[4234] - WIP: Refactor start page

### DIFF
--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -8,6 +8,11 @@ module ResultFilters
     def new; end
 
     def start
+      if FeatureFlag.active?(:new_search_flow)
+        redirect_to start_path
+        return
+      end
+
       flash[:start_wizard] = true
     end
 

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -9,7 +9,7 @@ module ResultFilters
 
     def start
       if FeatureFlag.active?(:new_search_flow)
-        redirect_to start_path
+        redirect_to start_path(request.query_parameters)
         return
       end
 

--- a/app/controllers/search/start_controller.rb
+++ b/app/controllers/search/start_controller.rb
@@ -1,0 +1,41 @@
+module Search
+  class StartController < ApplicationController
+    include FilterParameters
+
+    before_action :check_provider_cache_is_populated
+    # before_action :build_results_filter_query_parameters
+
+    def new
+      @start_form = StartForm.new
+    end
+
+    def create
+      @start_form = StartForm.new(form_params)
+
+      if @start_form.valid?
+        redirect_to next_step
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def form_params
+      params.require(:search_start_form).permit(:l, :lq, :query)
+    end
+
+    def check_provider_cache_is_populated
+      if Rails.env.development? && TeacherTrainingPublicAPI::ProvidersCache.read.empty?
+        message = 'The TeacherTrainingPublicAPI::ProvidersCache is currently empty. Please run `TeacherTrainingPublicAPI::SyncAllProviders.call` in the Rails console.'
+        raise ProviderCacheEmptyError, message
+      end
+    end
+
+    def build_results_filter_query_parameters
+      @results_filter_query_parameters = merge_previous_parameters(
+        ResultsView.new(query_parameters: request.query_parameters).query_parameters_with_defaults,
+      )
+    end
+  end
+end

--- a/app/form_objects/search/start_form.rb
+++ b/app/form_objects/search/start_form.rb
@@ -8,8 +8,6 @@ module Search
     validates :lq, presence: true, if: :location_search?
     validates :query, presence: true, if: :provider_search?
 
-    private
-
     def location_search?
       l == '1'
     end

--- a/app/form_objects/search/start_form.rb
+++ b/app/form_objects/search/start_form.rb
@@ -1,0 +1,21 @@
+module Search
+  class StartForm
+    include ActiveModel::Model
+
+    attr_accessor :l, :lq, :query
+
+    validates :l, presence: true
+    validates :lq, presence: true, if: :location_search?
+    validates :query, presence: true, if: :provider_search?
+
+    private
+
+    def location_search?
+      l == '1'
+    end
+
+    def provider_search?
+      l == '3'
+    end
+  end
+end

--- a/app/services/geocoder_service.rb
+++ b/app/services/geocoder_service.rb
@@ -1,0 +1,34 @@
+class GeocoderService
+  def self.location_params_for(query)
+    new(query).location_params
+  end
+
+  def initialize(query)
+    @query = query
+  end
+
+  def location_params
+    results = Geocoder.search(query, components: 'country:UK').first
+    if results
+      {
+        lat: results.latitude,
+        lng: results.longitude,
+        loc: results.address,
+        lq: query,
+        c: country(results),
+        sortby: ResultsView::DISTANCE,
+      }
+    end
+  end
+
+private
+
+  attr_reader :query
+
+  def country(results)
+    flattened_results = results.address_components.map(&:values).flatten
+    countries = [DEVOLVED_NATIONS, 'England'].flatten
+
+    countries.each { |country| return country if flattened_results.include?(country) }
+  end
+end

--- a/app/views/search/start/new.html.erb
+++ b/app/views/search/start/new.html.erb
@@ -1,0 +1,32 @@
+<%= content_for :page_title, title_with_error_prefix(I18n.t('start.title'), @start_form.errors.any?) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(model: @start_form, url: start_path, data: { 'ga-event-form' => 'Start' }, method: :post) do |f| %>
+      <%= f.govuk_error_summary %>
+
+      <%= render HiddenFieldsComponent.new(
+        query_params: request.query_parameters,
+        form: f,
+        form_name: :search_start_form,
+        exclude_keys: %w[l query rad]) %>
+
+      <%= f.govuk_radio_buttons_fieldset :search_types, legend: { text: 'Find courses by location or by training provider', size: 'l', tag: 'h1' } do %>
+        <%= f.govuk_radio_button :l, '1', label: { text: 'By city, town or postcode' }, link_errors: true do %>
+          <%= f.govuk_text_field :lq, label: { text: "Postcode, town or city" } %>
+          <div id="location-autocomplete" class="govuk-body"></div>
+        <% end %>
+        <%= f.govuk_radio_button :l, '2', label: { text: 'Across England' } %>
+        <%= f.govuk_radio_button :l, '3', label: { text: 'By school, university or other training provider' }, link_errors: true do %>
+          <% if select_provider_options %>
+            <%= f.govuk_collection_select :query, select_provider_options, :id, :name, label: { text: "School, university or other training provider"} %>
+          <% else %>
+            <%= f.govuk_text_field :query, label: { text: "School, university or other training provider" } %>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit 'Continue' %>
+    <% end %>
+  </div>
+</div>

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -44,13 +44,25 @@ const filterToggleButton = new FilterToggleButton({
 
 filterToggleButton.init()
 
+//TODO: Deprecated - to be removed when new search flow feature flag is removed
 initAutocomplete({
   element: "location-autocomplete",
   input: "location",
   path: "/location-suggestions",
 });
 
-initCachedProvidersAutocomplete();
+// Autocomplete for new search flow location search
+initAutocomplete({
+  element: "location-autocomplete",
+  input: "search-start-form-lq-field",
+  path: "/location-suggestions",
+});
+
+//TODO: Deprecated - to be removed when new search flow feature flag is removed
+initCachedProvidersAutocomplete({inputIds: ['query']});
+
+// Autocomplete for new search flow provider search
+initCachedProvidersAutocomplete({inputIds: ['search-start-form-query-field', 'search-start-form-query-field-error']});
 
 loadAnalytics();
 

--- a/app/webpacker/scripts/cached-providers-autocomplete.js
+++ b/app/webpacker/scripts/cached-providers-autocomplete.js
@@ -1,10 +1,10 @@
 import accessibleAutocomplete from "accessible-autocomplete";
 
-export const initCachedProvidersAutocomplete = () => {
-  const inputId = 'query'
+export const initCachedProvidersAutocomplete = ({inputIds}) => {
   const autocompleteId = 'provider-autocomplete'
 
-  try {
+  inputIds.forEach((inputId) => {
+    try {
       const selectElement = document.getElementById(inputId)
 
       if (!selectElement) return
@@ -17,8 +17,10 @@ export const initCachedProvidersAutocomplete = () => {
         autoselect: false,
         confirmOnBlur: false,
         showNoOptionsFound: true,
+        showAllValues: false,
       })
-  } catch (err) {
-    console.error(`Could not enhance ${autocompleteId}`, err)
-  }
+    } catch (err) {
+      console.error(`Could not enhance ${autocompleteId}`, err)
+    }
+  })
 }

--- a/app/webpacker/scripts/cached-providers-autocomplete.spec.js
+++ b/app/webpacker/scripts/cached-providers-autocomplete.spec.js
@@ -18,7 +18,7 @@ describe("initACachedProvidersAutocomplete", () => {
         </div>
       `
 
-    initCachedProvidersAutocomplete()
+    initCachedProvidersAutocomplete({inputIds: ['query']})
   })
 
   it('should instantiate an autocomplete', () => {

--- a/config/locales/start.yml
+++ b/config/locales/start.yml
@@ -1,0 +1,14 @@
+en:
+  start:
+    title: Find courses by location or by training provider
+  activemodel:
+    errors:
+      models:
+        search/start_form:
+          attributes:
+            l:
+              blank: Select an option to find courses
+            query:
+              blank: Enter a school, university or other training provider
+            lq:
+              blank: Enter a city, town or postcode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,10 @@ Rails.application.routes.draw do
   post '/confirm-environment' => 'confirm_environment#create'
 
   # new search flow
+
   scope module: 'search' do
+    get 'start', to: 'start#new'
+    post 'start', to: 'start#create'
     get '/age-groups' => 'age_groups#new'
     get '/age-groups-submit' => 'age_groups#create', as: :age_groups_create
     get '/subjects' => 'subjects#new'

--- a/spec/form_objects/search/start_form_spec.rb
+++ b/spec/form_objects/search/start_form_spec.rb
@@ -25,7 +25,7 @@ module Search
 
       context 'provider search' do
         it 'is not valid if provider query is not present' do
-          form = described_class.new(l: '2')
+          form = described_class.new(l: '3')
 
           expect(form.valid?).to be(false)
         end

--- a/spec/form_objects/search/start_form_spec.rb
+++ b/spec/form_objects/search/start_form_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+module Search
+  describe StartForm do
+    describe 'validation' do
+      it 'is not valid if search type is not present' do
+        form = described_class.new
+
+        expect(form.valid?).to be(false)
+      end
+
+      context 'location search' do
+        it 'is not valid if location query is not present' do
+          form = described_class.new(l: '1')
+
+          expect(form.valid?).to be(false)
+        end
+
+        it 'is valid if location query is present' do
+          form = described_class.new(l: 'location', lq: 'Newcastle')
+
+          expect(form.valid?).to be(true)
+        end
+      end
+
+      context 'provider search' do
+        it 'is not valid if provider query is not present' do
+          form = described_class.new(l: '2')
+
+          expect(form.valid?).to be(false)
+        end
+
+        it 'is valid if provider query is present' do
+          form = described_class.new(l: '2', query: 'Gorse SCITT')
+
+          expect(form.valid?).to be(true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

IMPORTANT - https://github.com/DFE-Digital/find-teacher-training/pull/1118 needs to be merged first

We want to bring the start page ('/') in line with the new search flow journey.

We want to remove the use of the 'flash object' for validation errors on this page and rely on the form object only. 

We also can remove the `flash[:start_wizard]` references as candidates should be directed down through the new search flow (selecting age group and subjects) whenever they edit their search query rather than redirected straight to the results page. 

### Changes proposed in this pull request

Note this is still a work in progress.

Things done so far:
- When the `new_search_flow` feature flag is activated the user is directed to a new view / controller 
- A new form has been created, validation is working
- The location search part of the journey has been wired up

Things to do:
- wire up the 'across England' and 'provider' search journeys
- check code coverage and add specs if req'd

Other things we may want to do:
- Currently we are still using the following legacy query params `l` (search type), `lq` (location query) and `query` (provider query). We should probably rename these to `search-type`, `location-query` and `search-query` however it is probably worth waiting until the `new_search_flow` feature flag is removed

### Trello card
https://trello.com/c/5GelL6MG/4234-draft-find-refactor-start-page

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
