### PR TITLE
[487] Increase deploy workflow timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
   prepare-matrix:
     name: Prepare Environment Matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 15
     outputs:
       environments: ${{ steps.select-environments.outputs.environments || steps.set-pr-environment.outputs.environments }}
     steps:
@@ -48,6 +47,11 @@ jobs:
         name: Wait for other inprogress deployment runs
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+        with:
+          initial-wait-seconds: 12
+          poll-interval-seconds: 20
+          abort-after-seconds: 1800
+          same-branch-only: true
 
   deploy:
     name: ${{ matrix.environment }} Deployment


### PR DESCRIPTION
### Context
The timeout was set to 15 minutes at the job level but this is often reached when multiple PRs are merged quickly.

### Changes proposed in this pull request
We now use the same configuration as in the other services: set it to 30 minutes at the wait step level and only lock the workflow runs when on the same branch.

### Guidance to review
Same configuration as Register, etc

### Trello card
https://trello.com/c/GS44pWv6

### Checklist

- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
