### PR TITLE
Fix feature flag wording when deactivated

### DIFF
--- a/app/controllers/feature_flags_controller.rb
+++ b/app/controllers/feature_flags_controller.rb
@@ -9,7 +9,7 @@ class FeatureFlagsController < ApplicationController
     FeatureFlag.send(action, feature_name)
 
     SlackNotificationJob.perform_now(
-      ":flags: Feature ‘#{feature_name}‘ was activated",
+      ":flags: Feature ‘#{feature_name}‘ was #{action}d",
       feature_flags_path,
     )
 

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Feature flags', type: :feature do
     within(summary_card) { click_link 'Confirm environment to make changes' }
     fill_in 'Type ‘test’ to confirm that you want to proceed', with: 'test'
     click_button 'Continue'
-    stub_slack_notification_job
+    stub_activate_slack_notification_job
 
     within(summary_card) { click_button 'Activate' }
   end
@@ -55,6 +55,7 @@ RSpec.describe 'Feature flags', type: :feature do
   end
 
   def when_i_deactivate_the_feature
+    stub_deactivate_slack_notification_job
     within(summary_card) { click_button 'Deactivate' }
   end
 
@@ -71,10 +72,23 @@ RSpec.describe 'Feature flags', type: :feature do
     @feature ||= FeatureFlag.features[:test_feature]
   end
 
-  def stub_slack_notification_job
+  def stub_activate_slack_notification_job
     stub_request(:post, 'https://example.com/webhook')
       .with(
         body: '{"username":"Find postgraduate teacher training","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was activated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
+        headers: {
+          'Connection' => 'close',
+          'Host' => 'example.com',
+          'User-Agent' => 'http.rb/5.0.4',
+        },
+      )
+      .to_return(status: 200, body: '', headers: {})
+  end
+
+  def stub_deactivate_slack_notification_job
+    stub_request(:post, 'https://example.com/webhook')
+      .with(
+        body: '{"username":"Find postgraduate teacher training","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was deactivated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
         headers: {
           'Connection' => 'close',
           'Host' => 'example.com',


### PR DESCRIPTION
### Context

The wording of the slack notification that fires when a feature flag is deactivated was inaccurate because it was hardcoded. This makes PR ensures `activated` or `deactivated` is rendered depending on which is happening.  

### Changes proposed in this pull request

- Use the `action` instead of hard coding `activated`

### Guidance to review

- Replace `Settings.STATE_CHANGE_SLACK_URL` in `app/job/slack_notification_job.rb` with the equivalent secret in `QA`. Feel free to ask me. 
- Fire up the app and navigate to `/feature-flags`
- Flip a few of the feature flags and check the wording of the notifications on `#twd_apply_test` when activating and deactivating the flags.
### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
