### PR TITLE
Upgrade node from 12 to 16 and ruby from 2.7.2 to 2.7.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 2.7.2
-yarn 1.22.10
-nodejs 12.18.4
+ruby 2.7.5
+yarn 1.22.17
+nodejs 16.13.2
 terraform 0.13.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_RUBY_IMAGE=ruby:2.7.2-alpine3.12
+ARG BASE_RUBY_IMAGE=ruby:2.7.5-alpine3.15
 
 FROM ${BASE_RUBY_IMAGE} AS base-image
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.7.2'
+ruby '2.7.5'
 
 gem 'pkg-config', '~> 1.4.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,7 +579,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.2p137
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.1.4

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ## Prerequisites
 
-- Ruby 2.7.2
-- NodeJS 12.18.x
+- Ruby 2.7.5
+- NodeJS 16.13.x
 - Yarn 1.22.x
 
 ## Using asdf-vm to manage tool versions

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "engines": {
-    "node": "^12.18.0"
+    "node": "^16.13.0",
+    "yarn": "^1.22.17"
   },
   "dependencies": {
     "@rails/webpacker": "^5.4.3",
     "accessible-autocomplete": "^2.0.3",
     "govuk-frontend": "^4.0.0",
     "jquery": "^3.6.0",
-    "lodash.throttle": "^4.1.1",
-    "yarn": "^1.22.17"
+    "lodash.throttle": "^4.1.1"
   },
   "devDependencies": {
     "jest": "^27.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9597,11 +9597,6 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yarn@^1.22.17:
-  version "1.22.17"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.17.tgz#bf910747d22497b573131f7341c0e1d15c74036c"
-  integrity sha512-H0p241BXaH0UN9IeH//RT82tl5PfNraVpSpEoW+ET7lmopNC61eZ+A+IDvU8FM6Go5vx162SncDL8J1ZjRBriQ==
-
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
(Also move `yarn` into the `engines` section of the `package.json` as it's not a strict dependency.)

This brings the versions up to date with the same ones used in Apply.