### PR TITLE
Update StatusCake contact groups

### DIFF
--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -20,7 +20,7 @@ statuscake_alerts = {
     website_url    = "https://www.find-postgraduate-teacher-training.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [151103]
+    contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -20,7 +20,7 @@ statuscake_alerts = {
     website_url    = "https://qa.find-postgraduate-teacher-training.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [188603]
+    contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -20,7 +20,7 @@ statuscake_alerts = {
     website_url    = "https://sandbox.find-postgraduate-teacher-training.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [188603]
+    contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -19,7 +19,7 @@ statuscake_alerts = {
     website_url    = "https://staging.find-postgraduate-teacher-training.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [188603]
+    contact_group  = [204421]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }


### PR DESCRIPTION
### Context

Alerts are currently routed to BAT-DevOps-Slack-Prod (Slack & email) or BAT-DevOps-Slack-All (just email).

### Changes proposed in this pull request

Alerts will be routed to Slack-Apply-Tech webhook instead of BAT-DevOps-Slack-Prod or just email.  Updated contact groups in workspace variable files for production, sandbox, staging and qa.  

### Guidance to review

Do the channels match the expected channels.

### Trello card

https://trello.com/c/q3F2WvuS

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
