### PR TITLE
Simplify support links in footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -136,24 +136,14 @@
     <%= govuk_footer do |footer| %>
       <%= footer.meta do %>
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-          <h2 class="govuk-heading-m">Get support</h2>
-          <div class="govuk-grid-row govuk-!-margin-bottom-5">
-            <div class="govuk-grid-column-one-half">
-              <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Telephone</h2>
-              <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16">
-                <li><%= t('get_into_teaching.tel') %></li>
-                <li><%= t('get_into_teaching.opening_times') %></li>
-                <li>Free of charge</li>
-              </ul>
-            </div>
-            <div class="govuk-grid-column-one-half">
-              <h2 class="govuk-heading-s govuk-!-margin-bottom-1">Online chat</h2>
-              <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
-                <li><%= link_to 'Talk to an adviser online', t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></li>
-                <li><%= t('get_into_teaching.opening_times') %></li>
-              </ul>
-            </div>
-          </div>
+          <h2 class="govuk-heading-m">Get help</h2>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-1">Call <%= t('get_into_teaching.tel') %> or <%= link_to 'chat online', t('get_into_teaching.url_online_chat'), class: 'govuk-footer__link' %></p>
+
+          <p class="govuk-body-s govuk-!-margin-bottom-1"><%= t('get_into_teaching.opening_times') %></p>
+
+          <p class="govuk-body-s">Free of charge</p>
+
           <h2 class="govuk-visually-hidden">Support links</h2>
           <ul class="govuk-footer__inline-list govuk-!-margin-bottom-0">
             <li class="govuk-footer__inline-list-item">


### PR DESCRIPTION
Combine both telephone and online chat, as both are free and have the same opening hours.

This change was already made in the Apply for teacher training service.

## Screenshots

### Before

<img width="1036" alt="Screenshot 2022-01-31 at 10 20 48" src="https://user-images.githubusercontent.com/30665/151776626-7606f919-4df1-4927-9cb0-ffdb05279fe4.png">

### After

<img width="1053" alt="Screenshot 2022-01-31 at 10 20 09" src="https://user-images.githubusercontent.com/30665/151776619-bb8531f4-c382-4744-8c2d-232eeb6992ba.png">


