### PR TITLE
Drop 3 of the subject checkboxes

### DIFF
--- a/app/form_objects/search/subjects_form.rb
+++ b/app/form_objects/search/subjects_form.rb
@@ -6,6 +6,9 @@ module Search
 
     validates :subject_codes, presence: true
 
+    # These subjects don’t currently match any courses, and so can be dropped.
+    IGNORED_SUBJECTS = ['Philosophy', 'Modern Languages', 'Ancient Hebrew'].freeze
+
     def primary_subjects
       primary_subjects = subject_areas.find { |sa| sa.id == 'PrimarySubject' }.subjects
 
@@ -16,6 +19,7 @@ module Search
 
     def secondary_subjects
       secondary_subjects = subject_areas.find { |sa| sa.id == 'SecondarySubject' }.subjects
+        .reject { |sa| IGNORED_SUBJECTS.include?(sa.subject_name) }
       modern_languages_subjects = subject_areas.find { |sa| sa.id == 'ModernLanguagesSubject' }.subjects
 
       (secondary_subjects + modern_languages_subjects).sort_by(&:subject_name)

--- a/spec/features/search/new_flow/across_england/secondary_spec.rb
+++ b/spec/features/search/new_flow/across_england/secondary_spec.rb
@@ -22,6 +22,7 @@ RSpec.feature 'Searching across England' do
     when_i_select_the_secondary_radio_button
     and_i_click_continue
     then_i_should_see_the_subjects_form
+    and_i_should_not_see_hidden_subjects
     and_the_correct_subjects_form_page_url_and_query_params_are_present
 
     when_i_click_back
@@ -92,6 +93,12 @@ RSpec.feature 'Searching across England' do
 
   def then_i_should_see_the_subjects_form
     expect(page).to have_content('Which secondary subjects do you want to teach?')
+  end
+
+  def and_i_should_not_see_hidden_subjects
+    expect(page).not_to have_content('Ancient Hebrew')
+    expect(page).not_to have_content('Philosophy')
+    expect(page).not_to have_content('Modern Languages')
   end
 
   def and_i_click_find_courses


### PR DESCRIPTION
Since moving to the new search flow, 2 subjects have reappeared that [were previously ignored](https://github.com/DFE-Digital/find-teacher-training/blob/main/app/views/result_filters/subject/_form.html.erb#L37), "Modern Languages" and "Philosophy". These don't return any courses.

In addition, "Ancient Hebrew" has recently been added as subject but does not yet have any courses associated with it.

We can drop these 3 checkboxes for now.

In future we could look at a way of perhaps moving this logic into the teacher training API itself.

[Trello card](https://trello.com/c/KjU8xdRc/4309-remove-modern-languages-from-the-find-filter-options)