### PR TITLE
Update links to Get into teaching

### DIFF
--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -14,8 +14,6 @@
 
     <p class="govuk-body">
       You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
-      Find out about <%= govuk_link_to 'eligibility', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %> and
-      <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
     </p>
   <% end %>
 

--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
 
   <p class="govuk-body">

--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
   </p>
 
   <p class="govuk-body">

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -28,11 +28,11 @@
     </p>
 
     <p class="govuk-body">
-      You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may also be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
     </p>
   <% else %>
     <p class="govuk-body">
-      You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
     </p>
   <% end %>
 

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -24,7 +24,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
+      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
     </p>
 
     <p class="govuk-body">

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -24,7 +24,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
+      <%= govuk_link_to 'Find out more about bursaries and scholarships', t('get_into_teaching.url_bursaries_and_scholarships') %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
     </p>
 
     <p class="govuk-body">

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -32,7 +32,7 @@
     </p>
   <% else %>
     <p class="govuk-body">
-      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
     </p>
   <% end %>
 

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,10 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to t('service_name.get_into_teaching'), t('get_into_teaching.url_get_an_advisor') %>
+  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %>
     adviser for free. They’re all experienced teachers who can help you to prepare your application, book school
     experience, and access exclusive teaching events.</p>
   <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or
-    speak to an adviser using their  <%= govuk_link_to 'online chat service', t('get_into_teaching.url_online_chat') %>
+    <%= govuk_link_to 'chat online', t('get_into_teaching.url_online_chat') %>
     <%= t('get_into_teaching.opening_times') %> (except public holidays).</p>
 
   <p class="govuk-body">Find out about the different

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -14,8 +14,6 @@
 
     <p class="govuk-body">
       You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
-      Find out about <%= govuk_link_to 'eligibility', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %> and
-      <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
     </p>
   <% end %>
 

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/financial_support/_bursary.html.erb
+++ b/app/views/courses/financial_support/_bursary.html.erb
@@ -18,7 +18,7 @@
   <% end %>
 
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
   </p>
 
   <p class="govuk-body">

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,6 +1,6 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
   </p>
   <p class="govuk-body">
     Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#rate' %>.

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,6 +1,6 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
   </p>
   <p class="govuk-body">
     Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#rate' %>.

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -28,11 +28,11 @@
     </p>
 
     <p class="govuk-body">
-      You may also be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may also be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
     </p>
   <% else %>
     <p class="govuk-body">
-      You may be eligible for a <%= govuk_link_to 'loan while you study', 'https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans' %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
     </p>
   <% end %>
 

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -24,7 +24,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to 'how you’ll be paid', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary' %>.
+      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
     </p>
 
     <p class="govuk-body">

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -24,7 +24,7 @@
     </p>
 
     <p class="govuk-body">
-      Find out how to <%= govuk_link_to 'apply for a scholarship', 'https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships' %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
+      <%= govuk_link_to 'Find out more about bursaries and scholarships', t('get_into_teaching.url_bursaries_and_scholarships') %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
     </p>
 
     <p class="govuk-body">

--- a/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/courses/financial_support/_scholarship_and_bursary.html.erb
@@ -28,11 +28,11 @@
     </p>
 
     <p class="govuk-body">
-      You may also be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may also be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
     </p>
   <% else %>
     <p class="govuk-body">
-      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %> – note that you’ll have to apply for <%= govuk_link_to 'undergraduate student finance', 'https://www.gov.uk/student-finance' %>.
+      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
     </p>
   <% end %>
 

--- a/app/views/result_filters/subject/_form.html.erb
+++ b/app/views/result_filters/subject/_form.html.erb
@@ -64,7 +64,7 @@
                           <% if subject.subject_knowledge_enhancement_course_available %>
                             <span class="govuk-!-display-block" data-qa="subject__ske_course">
                               You can <%= subject.decorate.has_scholarship? || subject.decorate.has_bursary? ? 'also' : '' %> take a
-                              <%= govuk_link_to 'subject knowledge enhancement (SKE) course', 'https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#subject-knowledge-enhancement-courses' %>.
+                              <%= govuk_link_to 'subject knowledge enhancement (SKE) course', t('get_into_teaching.url_improve_your_subject_knowledge') %>.
                             </span>
                           <% end %>
                         <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
+    url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships
   cycles:
     real:
       name: 'Same as production environment'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,7 @@ en:
     url_get_an_advisor: https://adviser-getintoteaching.education.gov.uk
     url_online_chat: https://getintoteaching.education.gov.uk/#talk-to-us
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
+    url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
   cycles:
     real:
       name: 'Same as production environment'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -82,6 +82,7 @@ en:
     url_ways_to_train: https://getintoteaching.education.gov.uk/ways-to-train
     url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
     url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships
+    url_improve_your_subject_knowledge: https://getintoteaching.education.gov.uk/improve-your-subject-knowledge
   cycles:
     real:
       name: 'Same as production environment'


### PR DESCRIPTION
@EllieNodder @avinhurry and @EmmaFrith  reviewed links to the Get into teaching service, discovering some that have changed and others that have moved. This updates the links and improves the link text.

Additionally, all the URLs have been moved to the `en.yml` locale file, to make it easier for us to audit where we are linking to in future.

[Trello card](https://trello.com/c/Ihs4Ib6P/4318-edit-links-from-find-and-apply-to-git)