### PR TITLE
Add worklow to refresh docker cache weekly

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -1,0 +1,104 @@
+name: Build No Cache
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 12 * * 0'
+
+env:
+  DOCKER_IMAGE: dfedigital/find-teacher-training
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Set Environment variable
+        run: |
+          GIT_REF=${{ github.ref }}
+          GIT_BRANCH=${GIT_REF##*/}
+          echo "BRANCH_TAG=$GIT_BRANCH" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$GITHUB_SHA" >> $GITHUB_ENV
+          # tag build to the review env for vars and secrets
+          tf_vars_file=terraform/workspace_variables/review.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+      - name: Validate Azure Key Vault secrets
+        uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+        with:
+          KEY_VAULT: ${{ env.KEY_VAULT_NAME }}
+          SECRETS: |
+            ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+
+      - uses: DFE-Digital/keyvault-yaml-secret@v1
+        id: get-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+          key: SNYK_TOKEN
+
+      - name: Login to DockerHub
+        if: github.actor != 'dependabot[bot]'
+        uses: docker/login-action@v1.12.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build Docker Image - base-image target
+        uses: docker/build-push-action@v2
+        with:
+          tags: |
+            ${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
+          push: true
+          target: base-image
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.IMAGE_TAG}}
+
+      - name: Build Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          tags: |
+            ${{ env.DOCKER_IMAGE}}:${{ env.IMAGE_TAG}}
+            ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          push: false
+          load: true
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            COMMIT_SHA=${{ env.IMAGE_TAG}}
+
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
+          args: --file=Dockerfile
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images
+        if: ${{ success() }}
+        run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+
+      - name: 'Notify #twd_apply_tech on failure'
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_apply_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':sad-beaver:'
+          SLACK_USERNAME: Find Teacher Training
+          SLACK_TITLE: Build failure on weekly rebuild cache workflow
+          SLACK_MESSAGE: ':alert: Build failure :sadparrot:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,24 @@ jobs:
           # This is the latest commit on the actual PR branch
           echo "IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
+      - name: Set Environment variable
+        run: |
+          # tag build to the review env for vars and secrets
+          tf_vars_file=terraform/workspace_variables/review.tfvars.json
+          echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+          echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+      - uses: DFE-Digital/keyvault-yaml-secret@v1
+        id: get-secret
+        with:
+          keyvault: ${{ env.KEY_VAULT_NAME }}
+          secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+          key: SNYK_TOKEN
+
       - name: Build Docker Image - base-image target
         uses: docker/build-push-action@v2
         with:
@@ -69,8 +87,8 @@ jobs:
           tags: |
             ${{ env.DOCKER_IMAGE}}:${{ env.IMAGE_TAG}}
             ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
-          push: ${{ github.actor != 'dependabot[bot]' }}
-          load: ${{ github.actor == 'dependabot[bot]' }}
+          push: false
+          load: true
           cache-from: |
             ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
             ${{ env.DOCKER_IMAGE}}:main
@@ -78,6 +96,10 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             COMMIT_SHA=${{ env.IMAGE_TAG}}
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images for review
+        if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+        run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
       - name: Trigger Review App Deployment
         if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
@@ -88,9 +110,13 @@ jobs:
           token:  ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
           inputs: '{"pr": "${{ github.event.pull_request.number }}", "sha": "${{ env.IMAGE_TAG }}"}'
 
-      - name: Pull image if not loaded
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        run: docker pull ${DOCKER_IMAGE}:${{ env.IMAGE_TAG }}
+      - name: Run Snyk to check Docker image for vulnerabilities
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
+          args: --file=Dockerfile --severity-threshold=high
 
       - name: Run ruby linter
         run: make rubocop
@@ -113,6 +139,10 @@ jobs:
         env:
           GIT_BRANCH: ${{ env.BRANCH_TAG }}
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
+
+      - name: Push ${{ env.DOCKER_IMAGE }} images
+        if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
+        run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
       - name: Trigger QA Deployment
         if: ${{ success() && github.ref == 'refs/heads/main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
+RUN apk add --no-cache gmp=6.2.1-r1
+
 COPY --from=base-image ${FREEDESKTOP_MIME_TYPES_PATH} ${FREEDESKTOP_MIME_TYPES_PATH}
 COPY --from=base-image /app /app
 COPY --from=base-image /usr/local/bundle/ /usr/local/bundle/

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,7 +17,10 @@ All PRs merged will be continuously deployed to `Production` using the below wor
 
 ![Deployment Process](./deploy-workflow.png "GitHub Actions Workflow")
 
-- A build is triggered for the merged PR commit and the tagged docker image is published to DockerHub, a QA deployment is next triggered (see [build.yml](/.github/workflows/build.yml))
+- A build is triggered for the merged PR commit
+- The built docker image is scanned by SNYK for vulnerabilities and then runs through various code tests. If these tests are successful the tagged image is published to DockerHub, and a QA deployment is next triggered (see [build.yml](/.github/workflows/build.yml))
+- If the docker image SNYK scan fails due to vulnerabilities, it may be the docker image cached layers must be refreshed. To do this, run the "Build No Cache" workflow manually. This workflow is scheduled to run every week to minimise this issue
+- Once a successful deployment to QA is complete, the workflow triggers a smoke test run for the environment and awaits a successful completion of smoke tests
 - Once a successful deployment to QA is complete, the workflow triggers a smoke test run for the environment and awaits a successful completion of smoke tests
 - Upon completion of the above, the workflow triggers the deployment to the next environment
 - The merged PR commit is finally deployed to `Production`. (see [deploy.yml](/.github/workflows/deploy.yml))


### PR DESCRIPTION
### Context

https://trello.com/c/UdUEnOJu/511-reload-docker-image-cache

Schedule a weekly refresh of the docker image cache, so that we pick up updates to the base images

### Changes proposed in this pull request

New workflow for weekly docker image cache refresh
Add SNYK scan to build workflow
Bump GMP version as not yet in base image

### Guidance to review

Run workflow against branch
Run review app

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
