### PR TITLE
Fixing a typo in our copy talking about advisers

### DIFF
--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,7 +1,6 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %>
-     for free. They’re all experienced teachers who can help you to prepare your application, book school
+  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %> for free. They’re all experienced teachers who can help you to prepare your application, book school
     experience, and access exclusive teaching events.</p>
   <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or
     <%= govuk_link_to 'chat online', t('get_into_teaching.url_online_chat') %>

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,6 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
-  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %> for free. They’re all experienced teachers who can help you to prepare your application, book school
+  <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %> 
+  for free. They’re all experienced teachers who can help you to prepare your application, book school
     experience, and access exclusive teaching events.</p>
   <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or
     <%= govuk_link_to 'chat online', t('get_into_teaching.url_online_chat') %>

--- a/app/views/courses/_advice.html.erb
+++ b/app/views/courses/_advice.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
   <p class="govuk-body">For support and advice, you can speak to a <%= govuk_link_to 'teacher training adviser', t('get_into_teaching.url_get_an_advisor') %>
-    adviser for free. They’re all experienced teachers who can help you to prepare your application, book school
+     for free. They’re all experienced teachers who can help you to prepare your application, book school
     experience, and access exclusive teaching events.</p>
   <p class="govuk-body">You can also call <%= t('service_name.get_into_teaching') %> free of charge on <%= t('get_into_teaching.tel') %>, or
     <%= govuk_link_to 'chat online', t('get_into_teaching.url_online_chat') %>


### PR DESCRIPTION
### Context

We found a typo, this PR fixes it: 
![image](https://user-images.githubusercontent.com/35870975/152822999-4fbd3b21-cbcd-445a-b40a-fe863872e774.png)


### Changes proposed in this pull request

### Guidance to review

### Trello card

https://trello.com/c/mW7JxuV2

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
