### PR TITLE
Merge checkbox legend with the h1 for secondary subjects

### DIFF
--- a/app/components/search/secondary_subject_selection_component.html.erb
+++ b/app/components/search/secondary_subject_selection_component.html.erb
@@ -1,15 +1,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class='govuk-heading-l'>
-      <%= I18n.t('subjects.secondary_title') %>
-    </h1>
-
-    <p class="govuk-hint">
-      Select all subjects you are interested in teaching. We’ll show you courses that train you to teach those subjects.
-    </p>
 
     <%= form.govuk_collection_check_boxes :subject_codes, secondary_subjects,
-      :code, :name, :financial_info, legend: { text: "Which courses would you like to find?" }
+      :code, :name, :financial_info, legend: { text: t('subjects.secondary_title'), size: 'l', tag: 'h1' }
     %>
 
     <%= form.govuk_submit 'Find courses' %>


### PR DESCRIPTION
This simplifies the heading structure of the page, reducing the duplication.

🗂️  [Trello card](https://trello.com/c/HQrIlDpQ/4385-heading-hint-text-and-label-all-repeat-one-another)

## Screenshots

### Before

![secondary-before](https://user-images.githubusercontent.com/30665/153627953-bb6ac340-110b-4bfa-98a0-0808fccd5abd.png)

### After

![secondary-after](https://user-images.githubusercontent.com/30665/153627986-762c697c-e32f-4215-abcd-8df77238f889.png)


