### PR TITLE
Add check to bursary component

### DIFF
--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -5,8 +5,8 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <% unless bursary_requirements.empty? %>
-        <% bursary_requirements.each do |requirement| %>
+     <% bursary_requirements.each do |requirement| %>
+      <% unless bursary_requirements.empty? || duplicate_requirement(requirement) %>
           <li><%= requirement %></li>
         <% end %>
       <% end %>

--- a/app/components/courses/financial_support/bursary_component.rb
+++ b/app/components/courses/financial_support/bursary_component.rb
@@ -10,6 +10,10 @@ module Courses
       def initialize(course)
         @course = course
       end
+
+      def duplicate_requirement(requirement)
+        bursary_first_line_ending.sub!(/[.:]$/, '') == requirement
+      end
     end
   end
 end

--- a/spec/components/courses/financial_support/bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/bursary_component_spec.rb
@@ -6,19 +6,36 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
   context "'bursaries_and_scholarships_announced' feature flag is on" do
     before do
       allow(FeatureFlag).to receive(:active?).with(:bursaries_and_scholarships_announced).and_return(true)
+      render_inline(described_class.new(course))
     end
 
     it 'renders bursary details' do
-      result = render_inline(described_class.new(course))
-
-      expect(result.text).to include('You’ll get a bursary of £3,000')
+      expect(rendered_component).to have_text('You’ll get a bursary of £3,000')
     end
 
     context 'bursary requirements' do
       it 'renders bursary requirements' do
-        result = render_inline(described_class.new(course))
+        expect(rendered_component).to have_text('a degree of 2:2 or above in any subject')
+      end
+    end
 
-        expect(result.text).to include('a degree of 2:2 or above in any subject')
+    describe '#duplicate_requirements' do
+      let(:requirement) { 'a degree of 2:2 or above in any subject' }
+
+      context 'requirement and bursary_first_line_ending are identical' do
+        let(:course) { build(:course, subjects: [build(:subject, :modern_languages, bursary_amount: 3000)]).decorate }
+
+        it 'does not render duplicate bursary requirements' do
+          expect(rendered_component).to have_no_css('ul.govuk-list.govuk-list--bullet', text: 'a degree of 2:2 or above in any subject')
+          expect(described_class.new(course).duplicate_requirement(requirement)).to be_truthy
+        end
+      end
+
+      context 'requirement and bursary_first_line_ending are not identical' do
+        it 'renders both requirement and bursary first line ending' do
+          expect(rendered_component).to have_css('ul.govuk-list.govuk-list--bullet', text: 'a degree of 2:2 or above in any subject')
+          expect(described_class.new(course).duplicate_requirement(requirement)).to be_falsey
+        end
       end
     end
   end
@@ -27,9 +44,9 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
     it 'does not render bursary details' do
       allow(FeatureFlag).to receive(:active?).with(:bursaries_and_scholarships_announced).and_return(false)
 
-      result = render_inline(described_class.new(course))
+      render_inline(described_class.new(course))
 
-      expect(result.text).not_to include('You’ll get a bursary of £3,000')
+      expect(rendered_component).not_to have_text('You’ll get a bursary of £3,000')
     end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/ZPdtoydi/4382-dev-find-repeated-content-on-fees-and-financial-support-section
### Changes proposed in this pull request
* New method which stops double rendering of same requirement in financial support section
* Unit test in component

### Guidance to review
Visit course with a bursary and verify that it does not render 'a degree of 2:2 or above in any subject' twice
### Trello card

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
