### PR TITLE
Migrate to GitHub container registry

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -7,7 +7,7 @@ on:
     - cron: '0 12 * * 0'
 
 env:
-  DOCKER_IMAGE: dfedigital/find-teacher-training
+  DOCKER_IMAGE: ghcr.io/dfe-digital/find-teacher-training
 
 jobs:
   build:
@@ -46,12 +46,13 @@ jobs:
           secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
           key: SNYK_TOKEN
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.12.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
 
 env:
-  DOCKER_IMAGE: dfedigital/find-teacher-training
+  DOCKER_IMAGE: ghcr.io/dfe-digital/find-teacher-training
 
 jobs:
   build:
@@ -20,12 +20,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.4.0
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.12.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -77,8 +78,8 @@ jobs:
           load: ${{ github.actor == 'dependabot[bot]' }}
           target: base-image
           cache-from: |
-            ${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
-            ${{ env.DOCKER_IMAGE}}:base-image-main
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:base-image-main
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             COMMIT_SHA=${{ env.IMAGE_TAG}}
@@ -92,9 +93,9 @@ jobs:
           push: false
           load: true
           cache-from: |
-            ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
-            ${{ env.DOCKER_IMAGE}}:main
-            ${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:main
+            type=registry,ref=${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             COMMIT_SHA=${{ env.IMAGE_TAG}}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ifndef VERBOSE
 .SILENT:
 endif
 
-IMAGE=dfedigital/find-teacher-training:${IMAGE_TAG}
+IMAGE=ghcr.io/dfe-digital/find-teacher-training:${IMAGE_TAG}
 
 .PHONY: help
 help: ## Show this help
@@ -119,7 +119,7 @@ deploy-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_paas_sso_code=$(PASSCODE))
-	$(eval export TF_VAR_paas_app_docker_image=dfedigital/find-teacher-training:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_app_docker_image=ghcr.io/dfe-digital/find-teacher-training:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_app_config_file=./workspace_variables/app_config.yml)
 	az account set -s ${AZ_SUBSCRIPTION} && az account show
 	cd terraform && terraform init -reconfigure -backend-config=workspace_variables/$(DEPLOY_ENV)_backend.tfvars $(backend_key)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: redis:alpine
   web:
     build: .
-    image: dfedigital/find-teacher-training:${IMAGE_TAG:-latest}
+    image: ghcr.io/dfe-digital/find-teacher-training:${IMAGE_TAG:-latest}
     ports:
       - "3000:3000"
     depends_on:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,7 @@ Setup the following environment variables. Hint: Use [direnv](https://direnv.net
 ```yml
   TF_VAR_paas_user= # cf username with SpaceDeveloper permissions
   TF_VAR_paas_password= #password of the cf user
-  TF_VAR_paas_app_docker_image= dfedigital/find-teacher-training:${COMMIT_SHA}
+  TF_VAR_paas_app_docker_image= ghcr.io/dfe-digital/find-teacher-training:${COMMIT_SHA}
 ```
 Login to azure cli and set the subscription context
 

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -19,7 +19,6 @@ resource cloudfoundry_app web_app {
   name                       = local.web_app_name
   command                    = local.web_app_start_command
   docker_image               = var.app_docker_image
-  docker_credentials         = var.docker_credentials
   health_check_type          = "http"
   health_check_http_endpoint = "/ping"
   instances                  = var.web_app_instances
@@ -49,7 +48,6 @@ resource cloudfoundry_app worker_app {
   name               = local.worker_app_name
   command            = local.worker_app_start_command
   docker_image       = var.app_docker_image
-  docker_credentials = var.docker_credentials
   health_check_type  = "process"
   instances          = var.worker_app_instances
   memory             = var.worker_app_memory

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -30,8 +30,6 @@ variable logstash_url {}
 
 variable app_environment_variables { type = map }
 
-variable docker_credentials { type = map }
-
 locals {
   app_name_suffix           = var.app_environment_config != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
   web_app_name              = "find-${local.app_name_suffix}"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -47,7 +47,6 @@ module paas {
   redis_service_plan        = var.paas_redis_service_plan
   logstash_url              = local.infra_secrets.LOGSTASH_URL
   app_environment_variables = local.paas_app_environment_variables
-  docker_credentials        = local.docker_credentials
 }
 
 provider statuscake {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,9 +44,5 @@ locals {
   app_secrets                    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
   infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.app_config, local.app_secrets)
-  docker_credentials = {
-    username = local.infra_secrets.DOCKERHUB_USERNAME
-    password = local.infra_secrets.DOCKERHUB_PASSWORD
-  }
   azure_credentials = try(jsondecode(var.azure_credentials), null)
 }


### PR DESCRIPTION
### Context

Containers for this repo are currently published to Dockerhub.  Publishing images to GitHub container registry is simpler and more secure.

### Changes proposed in this pull request

This commit migrates workflows from Dockerhub to the GitHub Container Packages registry.

### Guidance to review

- Confirm that image is being published as a GitHub Container Package
- Confirm that deployment is using the correct GitHub Container Package

### Trello card

https://trello.com/c/wVT0QcJ4

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
