### PR TITLE
Remove search feature flag

### DIFF
--- a/app/components/deadline_banner_component.rb
+++ b/app/components/deadline_banner_component.rb
@@ -20,7 +20,7 @@ private
   end
 
   def find_opens
-    CycleTimetable.find_opens.to_s(:month_and_year)
+    CycleTimetable.find_opens.to_formatted_s(:month_and_year)
   end
 
   def find_reopens

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -74,11 +74,7 @@ module ResultFilters
     def next_step(all_params)
       submitted_params = get_params_for_selected_option(all_params)
       if flash[:start_wizard]
-        if FeatureFlag.active?(:new_search_flow)
-          age_groups_path(submitted_params)
-        else
-          start_subject_path(submitted_params)
-        end
+        age_groups_path(submitted_params)
       else
         results_path(submitted_params)
       end

--- a/app/controllers/result_filters/provider_controller.rb
+++ b/app/controllers/result_filters/provider_controller.rb
@@ -24,11 +24,7 @@ module ResultFilters
         redirect_back
       elsif @provider_suggestions.count == 1
         params = filter_params_without_previous_parameters.merge(query: @provider_suggestions.first.provider_name)
-        if FeatureFlag.active?(:new_search_flow)
-          redirect_to age_groups_path(params)
-        else
-          redirect_to start_subject_path(params)
-        end
+        redirect_to age_groups_path(params)
       end
     end
 

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -8,7 +8,6 @@ class FeatureFlags
       [:send_web_requests_to_big_query, 'Send events to Google Big Query', 'Apply team'],
       [:bursaries_and_scholarships_announced, 'Display scholarship and bursary information', 'Apply team'],
       [:componentised_results, 'Refactors the view templates into Rails view components for the results page', 'Apply team'],
-      [:new_search_flow, 'A new search flow which first asks which age you would like to teach', 'Apply team'],
     ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,7 +8,6 @@ require 'active_model/railtie'
 require 'active_job/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'
-require 'view_component/engine'
 require './app/middleware/csharp_subject_conversion_middleware'
 require './app/middleware/handle_bad_multipart_form_data_middleware'
 

--- a/spec/features/cycle_switcher_spec.rb
+++ b/spec/features/cycle_switcher_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Cycle switcher', type: :feature do
     click_button 'Update point in recruitment cycle'
     visit root_path
 
-    expect(page).to have_text("If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_s(:month_and_year)}")
+    expect(page).to have_text("If you’re applying for the first time since applications opened in #{CycleTimetable.find_opens.to_formatted_s(:month_and_year)}")
   end
 
   it "shows the 'cycle has closed' banner" do

--- a/spec/features/search/location_and_provider_spec.rb
+++ b/spec/features/search/location_and_provider_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature 'Results page new area and provider filter' do
           start_page.find_courses.click
 
           URI(current_url).then do |uri|
-            expect(uri.path).to eq('/start/subject')
+            expect(uri.path).to eq('/age-groups')
             expect(uri.query)
               .to eq('c=England&l=1&lat=51.4980188&lng=-0.1300436&loc=Westminster%2C+London+SW1P+3BT%2C+UK&lq=SW1P+3BT&rad=50&sortby=2')
           end
@@ -267,7 +267,7 @@ RSpec.feature 'Results page new area and provider filter' do
         filter_page.find_courses.click
 
         URI(current_url).then do |uri|
-          expect(uri.path).to eq('/start/subject')
+          expect(uri.path).to eq('/age-groups')
           expect(uri.query).to eq('l=2')
         end
       end
@@ -395,7 +395,7 @@ RSpec.feature 'Results page new area and provider filter' do
       filter_page.provider_search.select(provider_name)
       filter_page.find_courses.click
 
-      expect(page).to have_current_path('/start/subject?l=3&query=Provider+1')
+      expect(page).to have_current_path('/age-groups?l=3&query=Provider+1')
     end
   end
 

--- a/spec/features/search/new_flow/across_england/further_education_spec.rb
+++ b/spec/features/search/new_flow/across_england/further_education_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Searching across England' do
   end
 
   scenario 'Candidate searches for further education courses across England' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -22,11 +21,6 @@ RSpec.feature 'Searching across England' do
     when_i_select_the_further_education_radio_button
     and_i_click_continue
     then_i_should_see_the_results_page
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/search/new_flow/across_england/primary_spec.rb
+++ b/spec/features/search/new_flow/across_england/primary_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Searching across England' do
   end
 
   scenario 'Candidate searches for primary courses across England' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -47,11 +46,6 @@ RSpec.feature 'Searching across England' do
     when_i_select_the_primary_subject_textbox
     and_i_click_find_courses
     then_i_should_see_the_results_page
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/search/new_flow/across_england/secondary_spec.rb
+++ b/spec/features/search/new_flow/across_england/secondary_spec.rb
@@ -12,7 +12,6 @@ RSpec.feature 'Searching across England' do
   end
 
   scenario 'Candidate searches for secondary courses across England' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
     when_i_visit_the_start_page
     and_i_select_the_across_england_radio_button
     and_i_click_continue
@@ -38,11 +37,6 @@ RSpec.feature 'Searching across England' do
     when_i_select_the_secondary_subject_textbox
     and_i_click_find_courses
     then_i_should_see_the_results_page
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/search/new_flow/editing_a_search_spec.rb
+++ b/spec/features/search/new_flow/editing_a_search_spec.rb
@@ -12,8 +12,6 @@ RSpec.feature 'Editing a search' do
   end
 
   scenario 'Candidate edits their search' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
-
     when_i_execute_a_valid_search
     then_i_should_see_the_results_page
 
@@ -38,11 +36,6 @@ RSpec.feature 'Editing a search' do
     and_i_click_continue
     and_i_select_the_primary_subject_checkbox
     and_i_click_find_courses
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/search/new_flow/location_spec.rb
+++ b/spec/features/search/new_flow/location_spec.rb
@@ -6,8 +6,6 @@ RSpec.feature 'Searching by location' do
   end
 
   scenario 'Candidate searches by location' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
-
     when_i_visit_the_start_page
     and_i_select_the_location_radio_button
     and_i_click_continue
@@ -24,11 +22,6 @@ RSpec.feature 'Searching by location' do
 
     # Note that the remainder of the search flow is has
     # test coverage in 'spec/features/new_flow/across_england'
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def when_i_visit_the_start_page

--- a/spec/features/search/new_flow/provider_spec.rb
+++ b/spec/features/search/new_flow/provider_spec.rb
@@ -4,7 +4,6 @@ RSpec.feature 'Searching by provider' do
   include StubbedRequests::Providers
 
   scenario 'Candidate searches by provider' do
-    given_that_the_new_search_flow_feature_flag_is_enabled
     and_the_provider_cache_is_enabled
 
     when_i_visit_the_start_page
@@ -23,11 +22,6 @@ RSpec.feature 'Searching by provider' do
 
     # Note that the remainder of the search flow is has
     # test coverage in 'spec/features/new_flow/across_england'
-  end
-
-  def given_that_the_new_search_flow_feature_flag_is_enabled
-    allow(FeatureFlag).to receive(:active?).and_call_original
-    allow(FeatureFlag).to receive(:active?).with(:new_search_flow).and_return(true)
   end
 
   def and_the_provider_cache_is_enabled


### PR DESCRIPTION
### Context

This feature flag isn't used any more, and the smoke tests are broken because of it.

### Changes proposed in this pull request

Remove it!

And fix a couple of deprecation warnings.

### Trello card

https://trello.com/c/nXr7jlKe/4325-finish-find-new-search-flow

### Checklist

- [X] Rebased `main`
- [X] Cleaned commit history
- [X] Tested by running locally
