### PR TITLE
Use email address as link text for mailto

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -100,7 +100,7 @@
           colour: environment_colour,
         },
       ) do %>
-        This is a new service – <%= bat_contact_mail_to 'give feedback or report a problem', subject: 'Feedback about Find postgraduate teacher training', no_visited_state: true %>
+        Give feedback or report a problem: <%= bat_contact_mail_to subject: 'Feedback about Find postgraduate teacher training', no_visited_state: true %>
       <% end %>
 
       <%= yield(:before_content) %>


### PR DESCRIPTION
This makes it clearer that the link will open an email client, which might otherwise be unexpected and annoying, for example if the link opens Outlook but you use Gmail.

Using the email address as link text makes it easier for users to copy and paste the email address into their preferred email app if needed.

## Screenshots

### Before

<img width="981" alt="Screenshot 2022-02-24 at 13 45 29" src="https://user-images.githubusercontent.com/30665/155536154-ea79b2ab-e720-4a1e-be98-362195e5dc87.png">

<img width="348" alt="Screenshot 2022-02-24 at 13 49 14" src="https://user-images.githubusercontent.com/30665/155536451-0733ddca-957d-48ac-801e-33e8aa81ff11.png">

### After

<img width="985" alt="Screenshot 2022-02-24 at 13 46 02" src="https://user-images.githubusercontent.com/30665/155536193-de7beafe-c3b5-49f6-a198-41e4e50b3580.png">

<img width="306" alt="Screenshot 2022-02-24 at 13 49 44" src="https://user-images.githubusercontent.com/30665/155536474-314f907d-5a77-4e6a-a9d2-0289130ff0ec.png">

