### PR TITLE
Allow dependabot triggered PRs to login into GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
 env:
   DOCKER_IMAGE: ghcr.io/dfe-digital/find-teacher-training
 
+permissions:
+  packages: write
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     name: build
@@ -21,7 +26,6 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Login to GitHub Container Registry
-        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.13.0
         with:
           registry: ghcr.io
@@ -74,8 +78,7 @@ jobs:
         with:
           tags: |
             ${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
-          push: ${{ github.actor != 'dependabot[bot]' }}
-          load: ${{ github.actor == 'dependabot[bot]' }}
+          push: true
           target: base-image
           cache-from: |
             type=registry,ref=${{ env.DOCKER_IMAGE}}:base-image-${{ env.BRANCH_TAG }}
@@ -145,7 +148,7 @@ jobs:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
-        if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') && github.actor != 'dependabot[bot]' }}
+        if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
         run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
       - name: Trigger QA Deployment


### PR DESCRIPTION
### Context

Currently builds on dependabot raised PR fail if the deploy label is added because the GHCR login step is skipped.

### Changes proposed in this pull request

Remove the condition on the GHCR login step.  This allow the image to be pushed by a later step if the deploy label is added to the PR.  

### Guidance to review

- In order to test this change a dependabot PR will need to be triggered with this change already in the main branch.  It's therefore not possible to test it fully prior to merging.  The documentation that this change is based on should be reviewed to check that it has been understood correctly - https://docs.github.com/en/actions/security-guides/automatic-token-authentication#how-the-permissions-are-calculated-for-a-workflow-job

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
