### PR TITLE
simplify fees and financial support section

### DIFF
--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -16,15 +16,7 @@
     <% end %>
 
     <p class="govuk-body">
-      To qualify for a scholarship you’ll need a degree of 2:1 or above in <%= subject_name %> or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
-    </p>
-
-    <p class="govuk-body">
-      You cannot claim both a bursary and a scholarship - you can only claim one.
-    </p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to 'Find out more about bursaries and scholarships', t('get_into_teaching.url_bursaries_and_scholarships') %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
+      <%= govuk_link_to 'Find out about bursaries or scholarships, including eligibilty criteria', t('get_into_teaching.url_bursaries_and_scholarships') %>.
     </p>
 
     <p class="govuk-body">


### PR DESCRIPTION
this is because:

- policies may change yearly and so keeping content up to date is difficult 
- scholarship bodies set their own eligibility criteria which we have not verified 
- all the content is on GIT, and may be changed frequently on GIT, so we don't want to risk being inconsistent or inaccurate 
