### PR TITLE
Refine conditions for smoke test execution

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -23,6 +23,7 @@ inputs:
 runs:
   using: composite
   steps:
+    # all steps prior to the "Evaluate job status" step require an id to ensure that we correctly report the deployment outcome
     - name: Start ${{ inputs.environment }} Deployment
       uses: bobheadxi/deployments@v1
       id: deployment
@@ -33,6 +34,7 @@ runs:
         ref: ${{ inputs.sha }}
 
     - name: Set Environment variable
+      id: set_env_var
       shell: bash
       run: |
         if [ -n "${{ inputs.pr }}" ]; then
@@ -41,7 +43,7 @@ runs:
           echo "DEPLOY_URL=https://find-pr-${{ inputs.pr }}.london.cloudapps.digital" >> $GITHUB_ENV
         else
           echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
-        fi;
+        fi
 
         tf_vars_file=terraform/workspace_variables/${DEPLOY_ENV}.tfvars.json
         echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
@@ -51,15 +53,18 @@ runs:
         DEPLOY_ENV: ${{ inputs.environment }}
 
     - name: Use Terraform v0.13.5
+      id: use_terraform
       uses: hashicorp/setup-terraform@v1.3.2
       with:
         terraform_version: 0.13.5
 
     - uses: azure/login@v1.3.0
+      id: login_azure
       with:
         creds: ${{ inputs.azure_credentials }}
 
     - name: Validate Azure Key Vault secrets
+      id: validate_key_vault_secrets
       uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
       with:
         KEY_VAULT: ${{ env.key_vault_name }}
@@ -68,6 +73,7 @@ runs:
           ${{ env.key_vault_infra_secret_name }}
 
     - name: Terraform init, plan & apply
+      id: apply_terraform
       shell: bash
       run: make ${{ env.DEPLOY_ENV }} ci deploy
       env:
@@ -78,25 +84,27 @@ runs:
         CONFIRM_PRODUCTION:       yes
 
     - name: Set Cypress environment variable
+      id: set_cypress_env_var
       shell: bash
       run: |
         echo "RAILS_ENV=$RAILS_ENV" >> $GITHUB_ENV
         echo "CYPRESS_ENVIRONMENT=$RAILS_ENV" >> $GITHUB_ENV
         if [ -n "${{ inputs.pr }}" ]; then
           echo "CYPRESS_ENV_VARS=--env BASE_URL=https://find-pr-${{ inputs.pr }}.london.cloudapps.digital" >> $GITHUB_ENV
-        fi;
+        fi
       env:
         RAILS_ENV: ${{ inputs.environment }}
 
     - name: Run smoke tests
-      id: cypress_run
+      id: run_cypress
       shell: bash
       run: |
         npm install
         npx cypress run ${{ env.CYPRESS_ENV_VARS }}
 
     - name: Upload Cypress screenshot and videos
-      if:   steps.cypress_run.outcome == 'success' || steps.cypress_run.outcome == 'failure' || steps.cypress_run.outcome == 'cancelled'
+      id: upload_cypress
+      if:   steps.run_cypress.outcome == 'success' || steps.run_cypress.outcome == 'failure' || steps.run_cypress.outcome == 'cancelled'
       uses: actions/upload-artifact@v2.3.1
       with:
         name: smoke-test-${{ inputs.environment }}
@@ -106,14 +114,24 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
 
+    - name: Evaluate job status
+      if: always()
+      shell: bash
+      run: |
+        if [[ ${{ join(steps.*.outcome, ',') }} =~ "failure" ]]; then
+          echo JOB_STATUS="failure" >> $GITHUB_ENV
+        else
+          echo JOB_STATUS="success" >> $GITHUB_ENV
+        fi
+
     - name: Update ${{ inputs.environment }} status
-      if: ${{ always() }}
+      if: always()
       uses: bobheadxi/deployments@v1
       with:
         step: finish
         token: ${{ inputs.actions-api-access-token }}
         env: ${{ inputs.environment }}
-        status: ${{ job.status }}
+        status: ${{ env.JOB_STATUS }}
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
         ref: ${{ inputs.sha }}
         env_url: ${{ env.DEPLOY_URL }}

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -96,7 +96,7 @@ runs:
         npx cypress run ${{ env.CYPRESS_ENV_VARS }}
 
     - name: Upload Cypress screenshot and videos
-      if:   always()
+      if:   steps.cypress_run.outcome == 'success' || steps.cypress_run.outcome == 'failure' || steps.cypress_run.outcome == 'cancelled'
       uses: actions/upload-artifact@v2.3.1
       with:
         name: smoke-test-${{ inputs.environment }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build:
-    name: build
+    name: Build
     outputs: 
       image_tag: ${{ env.IMAGE_TAG }}
       branch_tag: ${{ env.BRANCH_TAG }}


### PR DESCRIPTION
### Context

The smoke test results are uploaded even if a previous step fails, this is desirable if that step is the smoke test execution but if  an earlier step fails the reported results are confusing.  If the smoke test fails but the upload succeeds the `job.status` is successful, as this context property is used to report on whether the deployment has succeeded deployments with failed tests are reported as successful.

### Changes proposed in this pull request

This change ensures that the results are uploaded only if the tests are executed and deployment outcomes are correctly reported:
- the `outcome` property of the `run_cypress` step is used as the condition for the upload step
- a step is added to evaluate the outcome of all preceding steps
- all steps prior to this are given an `id` to ensure that their `outcome` property is accessible

https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context

### Guidance to review

A failing step was temporarily added as part of development to test the process.  The failing step can be seen [here](https://github.com/DFE-Digital/find-teacher-training/runs/5406471806?check_suite_focus=true#step:3:319) and the deployment result is logged [here](https://github.com/DFE-Digital/find-teacher-training/runs/5406471806?check_suite_focus=true#step:3:319).  This is displayed in the [Environment page](https://github.com/DFE-Digital/find-teacher-training/deployments) of the GitHub UI like this:

![image](https://user-images.githubusercontent.com/34914709/156578119-9ea91caa-ffcb-4d97-907d-8a55fc6758de.png)

- Consider whether this is the desired behaviour

### Trello card

https://trello.com/c/grpMynpF

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
