### PR TITLE
Update the financial support section on find course pages

### DIFF
--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -1,27 +1,26 @@
 <div data-qa="course__bursary_details">
   <% if FeatureFlag.active?(:bursaries_and_scholarships_announced) %>
     <p class="govuk-body">
-      You’ll get a bursary of <%= number_to_currency(bursary_amount) %> if you have <%= bursary_first_line_ending %>
+      You could be eligible for a bursary of <%= number_to_currency(bursary_amount) %>.
     </p>
 
-    <ul class="govuk-list govuk-list--bullet">
-     <% bursary_requirements.each do |requirement| %>
-      <% unless bursary_requirements.empty? || duplicate_requirement(requirement) %>
-          <li><%= requirement %></li>
-        <% end %>
-      <% end %>
-    </ul>
-
     <p class="govuk-body">
-      You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
+      To be eligible for a bursary you’ll need a 2:2 degree in any subject.
+      You do not need to apply for a bursary.
+      If you’re eligible, you’ll automatically start receiving it when you start the course. 
     </p>
   <% end %>
 
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
+    You may also be eligible for a student loan.
+    These are normally for undergraduate courses but you can also apply if you do postgraduate teacher training.
+    <%= govuk_link_to('Find out how much loan you could get using the student finance calculator', 'https://www.gov.uk/student-finance-calculator') %>.
   </p>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#rate' %>.
+    Depending on your immigration status, financial support may not be available.
+    Find out about
+    <%= govuk_link_to('training to teach if you’re a non-UK citizen', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen') %>,
+    including financial support.
   </p>
 </div>

--- a/app/components/courses/financial_support/bursary_component.html.erb
+++ b/app/components/courses/financial_support/bursary_component.html.erb
@@ -20,7 +20,6 @@
   <p class="govuk-body">
     Depending on your immigration status, financial support may not be available.
     Find out about
-    <%= govuk_link_to('training to teach if you’re a non-UK citizen', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen') %>,
-    including financial support.
+    <%= govuk_link_to('training to teach if you’re a non-UK citizen', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen') %>.
   </p>
 </div>

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -5,8 +5,8 @@
     </p>
 
     <ul class="govuk-list govuk-list--bullet">
-      <li data-qa="course__scholarship_amount">a scholarship of <%= number_to_currency(scholarship_amount) %></li>
       <li data-qa="course__bursary_amount">a bursary of <%= number_to_currency(bursary_amount) %></li>
+      <li data-qa="course__scholarship_amount">a scholarship of <%= number_to_currency(scholarship_amount) %></li>
     </ul>
 
     <% if has_early_career_payments? %>
@@ -16,27 +16,19 @@
     <% end %>
 
     <p class="govuk-body">
-      To qualify for a scholarship you’ll need a degree of 2:1 or above in <%= subject_name %> or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
+      To be eligible for a bursary you’ll need a 2:2 degree in any subject. You do not need to apply for a bursary. If you’re eligible, you’ll automatically start receiving it when you start the course.
     </p>
 
     <p class="govuk-body">
-      You cannot claim both a bursary and a scholarship - you can only claim one.
-    </p>
-
-    <p class="govuk-body">
-      <%= govuk_link_to 'Find out more about bursaries and scholarships', t('get_into_teaching.url_bursaries_and_scholarships') %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course.
-    </p>
-
-    <p class="govuk-body">
-      You may also be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
-    </p>
-  <% else %>
-    <p class="govuk-body">
-      You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
+      For a scholarship, you’ll need to apply through the Chartered Institute for IT. <%= govuk_link_to('Check whether you’re eligible for a scholarship and find out how to apply', 'https://www.bcs.org/qualifications-and-certifications/training-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/') %>.
     </p>
   <% end %>
 
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#rate' %>.
+    You may also be eligible for a student loan. These are normally for undergraduate courses but you can also apply if you do postgraduate teacher training. <%= govuk_link_to('Find out how much loan you could get using the student finance calculator', 'https://www.gov.uk/student-finance-calculator') %>.
+  </p>
+
+  <p class="govuk-body">
+    Depending on your immigration status, financial support may not be available. Find out about <%= govuk_link_to('training to teach if you’re a non-UK citizen', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen') %>, including financial support.
   </p>
 </div>

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.html.erb
@@ -19,9 +19,11 @@
       To be eligible for a bursary you’ll need a 2:2 degree in any subject. You do not need to apply for a bursary. If you’re eligible, you’ll automatically start receiving it when you start the course.
     </p>
 
-    <p class="govuk-body">
-      For a scholarship, you’ll need to apply through the Chartered Institute for IT. <%= govuk_link_to('Check whether you’re eligible for a scholarship and find out how to apply', 'https://www.bcs.org/qualifications-and-certifications/training-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/') %>.
-    </p>
+    <% if scholarship_body.present? %>
+      <p class="govuk-body">
+        For a scholarship, you’ll need to apply through the <%= scholarship_body %>. <%= govuk_link_to('Check whether you’re eligible for a scholarship and find out how to apply', scholarship_url) %>.
+      </p>
+    <% end %>
   <% end %>
 
   <p class="govuk-body">

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.rb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.rb
@@ -13,6 +13,14 @@ module Courses
       def initialize(course)
         @course = course
       end
+
+      def scholarship_body
+        I18n.t("scholarships.#{subject_name.downcase}.body", default: nil)
+      end
+
+      def scholarship_url
+        I18n.t("scholarships.#{subject_name.downcase}.url", default: nil)
+      end
     end
   end
 end

--- a/app/components/courses/financial_support/scholarship_and_bursary_component.rb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.rb
@@ -1,6 +1,8 @@
 module Courses
   module FinancialSupport
     class ScholarshipAndBursaryComponent < ViewComponent::Base
+      include ViewHelper
+
       attr_reader :course
 
       delegate :scholarship_amount,

--- a/app/controllers/result_filters/location_controller.rb
+++ b/app/controllers/result_filters/location_controller.rb
@@ -39,7 +39,7 @@ module ResultFilters
     end
 
     def check_provider_cache_is_populated
-      if Rails.env.development? && TeacherTrainingPublicAPI::ProvidersCache.read.empty?
+      if Rails.env.development? && !TeacherTrainingPublicAPI::ProvidersCache.read&.present?
         message = 'The TeacherTrainingPublicAPI::ProvidersCache is currently empty. Please run `TeacherTrainingPublicAPI::SyncAllProviders.call` in the Rails console.'
         raise ProviderCacheEmptyError, message
       end

--- a/app/views/courses/financial_support/_loan.html.erb
+++ b/app/views/courses/financial_support/_loan.html.erb
@@ -1,8 +1,12 @@
 <div data-qa="course__loan_details">
   <p class="govuk-body">
-    You may be eligible for a <%= govuk_link_to 'loan while you study', t('get_into_teaching.url_funding_your_training') %>.
+    You may be eligible for a student loan.
+    These are normally for undergraduate courses but you can also apply if you do postgraduate teacher training.
+    <%= govuk_link_to('Find out how much loan you could get using the student finance calculator', 'https://www.gov.uk/student-finance-calculator') %>. 
   </p>
   <p class="govuk-body">
-    Find out about financial support if you’re from <%= govuk_link_to 'outside the UK', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen#rate' %>.
+    Depending on your immigration status, financial support may not be available.
+    Find out about 
+    <%= govuk_link_to('training to teach if you’re a non-UK citizen', 'https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-if-youre-a-non-uk-citizen') %>, including financial support. 
   </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -102,3 +102,16 @@ en:
     today_is_after_find_opens:
       name: Find has reopened
       description: Candidates can browse courses on Find. Courses returned from the Teacher Traininig API will be from next year's recruitment cycle
+  scholarships:
+    physics:
+      body: Institute of Physics
+      url: https://www.iop.org/about/support-grants/iop-teacher-training-scholarships
+    chemistry:
+      body: Royal Society of Chemistry
+      url: https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/
+    computing:
+      body: Chartered Institute for IT
+      url: https://www.bcs.org/qualifications-and-certifications/training-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/
+    mathematics:
+      body: Institute of Mathematics and its Applications
+      url: http://teachingmathsscholars.org/about

--- a/spec/components/courses/fees_and_financial_support_component_spec.rb
+++ b/spec/components/courses/fees_and_financial_support_component_spec.rb
@@ -25,7 +25,7 @@ describe Courses::FeesAndFinancialSupportComponent, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You may be eligible for a loan while you study')
+      expect(result.text).to include('You may be eligible for a student loan')
       expect(result.text).not_to include('You do not have to apply for a bursary')
     end
   end
@@ -38,7 +38,7 @@ describe Courses::FeesAndFinancialSupportComponent, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You do not have to apply for a bursary')
+      expect(result.text).to include('You do not need to apply for a bursary')
     end
   end
 
@@ -50,7 +50,7 @@ describe Courses::FeesAndFinancialSupportComponent, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You cannot claim both a bursary and a scholarship - you can only claim one.')
+      expect(result.text).to include('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
     end
   end
 
@@ -60,7 +60,7 @@ describe Courses::FeesAndFinancialSupportComponent, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You may be eligible for a loan while you study')
+      expect(result.text).to include('You may be eligible for a student loan')
     end
   end
 

--- a/spec/components/courses/financial_support/bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/bursary_component_spec.rb
@@ -10,12 +10,12 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
     end
 
     it 'renders bursary details' do
-      expect(rendered_component).to have_text('You’ll get a bursary of £3,000')
+      expect(rendered_component).to have_text('You could be eligible for a bursary of £3,000')
     end
 
     context 'bursary requirements' do
       it 'renders bursary requirements' do
-        expect(rendered_component).to have_text('a degree of 2:2 or above in any subject')
+        expect(rendered_component).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
       end
     end
 
@@ -33,7 +33,7 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
 
       context 'requirement and bursary_first_line_ending are not identical' do
         it 'renders both requirement and bursary first line ending' do
-          expect(rendered_component).to have_css('ul.govuk-list.govuk-list--bullet', text: 'a degree of 2:2 or above in any subject')
+          expect(rendered_component).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
           expect(described_class.new(course).duplicate_requirement(requirement)).to be_falsey
         end
       end

--- a/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
@@ -52,13 +52,10 @@ describe Courses::FinancialSupport::ScholarshipAndBursaryComponent, type: :compo
       }
 
       it 'renders link to scholarship body' do
-        result = render_inline(described_class.new(course))
+        render_inline(described_class.new(course))
 
-        expect(result.text).to include('For a scholarship, you’ll need to apply through the Royal Society of Chemistry')
-        expect(result).to have_selector(
-          "a[href='https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/']",
-          text: 'Check whether you’re eligible for a scholarship and find out how to apply',
-        )
+        expect(rendered_component).to have_text('For a scholarship, you’ll need to apply through the Royal Society of Chemistry')
+        expect(rendered_component).to have_link('Check whether you’re eligible for a scholarship and find out how to apply', href: 'https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/')
       end
     end
 

--- a/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
@@ -38,6 +38,48 @@ describe Courses::FinancialSupport::ScholarshipAndBursaryComponent, type: :compo
         expect(result.text).not_to include('With a scholarship or bursary, you’ll also get early career payments of £2,000')
       end
     end
+
+    context 'when course has a scholarship' do
+      let(:course) {
+        build(:course,
+              subjects: [
+                build(:subject,
+                      subject_name: 'chemistry',
+                      scholarship: 2000,
+                      bursary_amount: 3000,
+                      early_career_payments: 2000),
+              ]).decorate
+      }
+
+      it 'renders link to scholarship body' do
+        result = render_inline(described_class.new(course))
+
+        expect(result.text).to include('For a scholarship, you’ll need to apply through the Royal Society of Chemistry')
+        expect(result).to have_selector(
+          "a[href='https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/']",
+          text: 'Check whether you’re eligible for a scholarship and find out how to apply',
+        )
+      end
+    end
+
+    context 'when course has scholarship but we don\'t have a institution to obtain further info from' do
+      let(:course) {
+        build(:course,
+              subjects: [
+                build(:subject,
+                      subject_name: 'french',
+                      scholarship: 2000,
+                      bursary_amount: 3000,
+                      early_career_payments: 2000),
+              ]).decorate
+      }
+
+      it 'does not try to render link to scholarship body' do
+        result = render_inline(described_class.new(course))
+
+        expect(result.text).not_to include('For a scholarship, you’ll need to apply through')
+      end
+    end
   end
 
   context "'bursaries_and_scholarships_announced' feature flag is off" do


### PR DESCRIPTION
### Context

There are 3 versions of the financial support section on Find course pages:

* scholarships, bursaries and loans are available
* bursaries and loans are available
* loans are available

We need to correct inaccuracies in all three cases.

### Changes proposed in this pull request

Updates to the content in the _Fees and financial support_ section of the course show page.

#### Loans only
![image](https://user-images.githubusercontent.com/450843/157878038-983ae5e3-558a-41d8-9c1c-2108eeb2a7f7.png)

#### With bursaries

![image](https://user-images.githubusercontent.com/450843/157878083-fce09364-bdad-4f62-897c-ff6e05458b9f.png)

#### With scholarships and bursaries

![image](https://user-images.githubusercontent.com/450843/157878142-b40ff2ca-97d4-47a5-8bd8-fcbce20c898d.png)

### Guidance to review
Per comment may help.

### Trello card

https://trello.com/c/WbRMUPAi/4498-dev-update-the-financial-support-section-on-find-course-pages

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
