### PR TITLE
Drop basic auth enabled feature flag

### DIFF
--- a/app/controllers/concerns/http_auth_concern.rb
+++ b/app/controllers/concerns/http_auth_concern.rb
@@ -6,8 +6,6 @@ module HttpAuthConcern
   end
 
   def http_authenticate
-    return true unless FeatureFlag.active?(:basic_auth_enabled)
-
     authenticate_or_request_with_http_basic do |username, password|
       username == Settings.basic_auth_username && password == Settings.basic_auth_password
     end

--- a/app/lib/feature_flags.rb
+++ b/app/lib/feature_flags.rb
@@ -1,7 +1,6 @@
 class FeatureFlags
   def self.all
     [
-      [:basic_auth_enabled, 'Protects requests with basic authentication', 'Apply team'],
       [:maintenance_mode, 'Puts Find into maintenance mode', 'Apply team'],
       [:maintenance_banner, 'Displays the maintenance mode banner', 'Apply team'],
       [:cache_courses, 'Caches request to the Teacher Training API for individual courses', 'Apply team'],

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -8,7 +8,6 @@ google:
     dataset: bat-find-test-events
 redis_url: redis://localhost:6379/9
 background_jobs: # scheduled jobs run on all environments except dev and test - see settings:
-basic_auth_enabled: false
 basic_auth_username: foo
 basic_auth_password: bar
 STATE_CHANGE_SLACK_URL: https://example.com/webhook

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe 'Feature flags', type: :feature do
     given_there_is_a_feature_flag_set_up
 
     when_i_visit_the_features_page
+    i_should_see_access_denied
+
+    given_i_am_authenticated
+    when_i_visit_the_features_page
     then_i_should_see_the_existing_feature_flags
 
     when_i_activate_the_feature
@@ -28,6 +32,14 @@ RSpec.describe 'Feature flags', type: :feature do
 
   def when_i_visit_the_features_page
     visit feature_flags_path
+  end
+
+  def given_i_am_authenticated
+    page.driver.browser.authorize 'foo', 'bar'
+  end
+
+  def i_should_see_access_denied
+    expect(page).to have_content('Access denied')
   end
 
   def then_i_should_see_the_existing_feature_flags

--- a/spec/requests/basic_auth_spec.rb
+++ b/spec/requests/basic_auth_spec.rb
@@ -1,33 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe 'Require basic authentication', type: :request do
-  it 'requests when basic auth is disabled are let through' do
-    FeatureFlag.deactivate('basic_auth_enabled')
-
-    get feature_flags_path
-
-    expect(response).to have_http_status(:ok)
-  end
-
-  it 'requests without basic auth get 401' do
-    FeatureFlag.activate('basic_auth_enabled')
-
+  it 'requests to feature flag path get 401' do
     get feature_flags_path
 
     expect(response).to have_http_status(:unauthorized)
   end
 
   it 'requests with invalid basic auth get 401' do
-    FeatureFlag.activate('basic_auth_enabled')
-
     get feature_flags_path, headers: basic_auth_headers('wrong', 'auth')
 
     expect(response).to have_http_status(:unauthorized)
   end
 
   it 'requests with valid basic auth get 200' do
-    FeatureFlag.activate('basic_auth_enabled')
-
     get feature_flags_path, headers: basic_auth_headers('foo', 'bar')
 
     expect(response).to have_http_status(:ok)


### PR DESCRIPTION
### Context

Dropping the basic auth feature flag as this doesn't serve any real purpose.

### Changes proposed in this pull request

- Remove the feature flag logic
- Remove the feature flag
- Remove the setting
- Rework the feature test, to authorise the user in order to test `/feature-flags`

### Guidance to review

Anything missing?

https://trello.com/c/aBrwB5XP/4537-remove-basicauth-feature-flag

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
