### PR TITLE
deploy_all job uses output from test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,8 @@ jobs:
   test:
     name: Unit Tests
     needs: [build]
+    outputs: 
+      image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -197,6 +199,6 @@ jobs:
           actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
           environment: ${{ matrix.environment }}
-          sha: ${{ needs.build.outputs.image_tag }}
+          sha: ${{ needs.test.outputs.image_tag }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
           terraform-state-access-key: ${{ secrets[format('TERRAFORM_STATE_ACCESS_KEY_{0}', matrix.environment)] }}


### PR DESCRIPTION
### Context

This fixes an issue where the docker image tag wasn't getting passed to the deploy_all job in the build-and-deploy workflow which was then defaulting to the main tag.

### Changes proposed in this pull request

Add out to test job
Use output from test job in deploy_all instead of output from build

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
