### PR TITLE
Stop deployment status marking deployment inactive

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -135,6 +135,7 @@ runs:
         deployment_id: ${{ steps.deployment.outputs.deployment_id }}
         ref: ${{ inputs.sha }}
         env_url: ${{ env.DEPLOY_URL }}
+        override: false
 
     - name: 'Notify #twd_apply_tech on failure'
       if: failure() && inputs.pr == ''


### PR DESCRIPTION
### Context

The deployment status update task by default (in version 1.1.0) actively marks previous deployments as inactive, this results in a large number of API calls which in turn causes a rate limiting failure.

### Changes proposed in this pull request

This change disables that function and explicitly enables the builtin GitHub behaviour that marks all previously successful deployments as inactive.

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
