### PR TITLE
Fixes deletion of review app GitHub environment

### DIFF
--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -76,4 +76,4 @@ jobs:
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
-          env:    ${{ env.PR_NUMBER }}
+          env:    review-${{ env.PR_NUMBER }}


### PR DESCRIPTION
### Context
A previous commit changed the naming convention for review app environments in GitHub. 

### Changes proposed in this pull request
This change updates the delete-review-app workflow to align with that change.

### Guidance to review
- Check that review app environments are getting deleted after PR close

### Trello card
https://trello.com/c/5M0gehU9

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
