### PR TITLE
Remove 'Ancient Greek' subject checkbox

### DIFF
--- a/app/form_objects/search/subjects_form.rb
+++ b/app/form_objects/search/subjects_form.rb
@@ -7,7 +7,7 @@ module Search
     validates :subject_codes, presence: true
 
     # These subjects don’t currently match any courses, and so can be dropped.
-    IGNORED_SUBJECTS = ['Philosophy', 'Modern Languages', 'Ancient Hebrew'].freeze
+    IGNORED_SUBJECTS = ['Philosophy', 'Modern Languages', 'Ancient Hebrew', 'Ancient Greek'].freeze
 
     def primary_subjects
       primary_subjects = subject_areas.find { |sa| sa.id == 'PrimarySubject' }.subjects


### PR DESCRIPTION
There are [no courses for this subject](https://www.find-postgraduate-teacher-training.service.gov.uk/results?hasvacancies=false&fulltime=true&parttime=true&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&degree_required=show_all_courses&l=2&subject_codes%5B%5D=A1) so we can remove this checkbox.

See #1189

In future we might want to make the list of subjects dynamic, based upon course availability.

