### PR TITLE
move course button and no vacancies warning text to top of course pages

### DIFF
--- a/app/components/courses/apply_component.html.erb
+++ b/app/components/courses/apply_component.html.erb
@@ -11,7 +11,7 @@
             ) %>
       </p>
     <% else %>
-      <%= govuk_warning_text(text: 'You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only show courses with vacancies’.') %>
+      <%= govuk_warning_text(text: 'You cannot apply for this course because it has no vacancies.') %>
     <% end %>
   <% else %>
     <div data-qa="course__end_of_cycle_notice">

--- a/app/components/courses/contents_component.html.erb
+++ b/app/components/courses/contents_component.html.erb
@@ -23,5 +23,4 @@
   <% end %>
   <li><%= govuk_link_to 'Contact this training provider', '#section-contact' %></li>
   <li><%= govuk_link_to 'Support and advice', '#section-advice' %></li>
-  <li><%= govuk_link_to 'Apply', '#section-apply' %></li>
 </ul>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,6 +24,8 @@
 
   <%= render Courses::SummaryComponent.new(course) %>
 
+    <%= render Courses::ApplyComponent.new(course) %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render Courses::ContentsComponent.new(course) %>
@@ -60,7 +62,6 @@
 
       <%= render partial: 'courses/advice' %>
 
-      <%= render Courses::ApplyComponent.new(course) %>
     </div>
   </div>
 </div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,7 +24,7 @@
 
   <%= render Courses::SummaryComponent.new(course) %>
 
-    <%= render Courses::ApplyComponent.new(course) %>
+  <%= render Courses::ApplyComponent.new(course) %>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -61,6 +61,8 @@
       <%= render Courses::ContactDetailsComponent.new(course) %>
 
       <%= render partial: 'courses/advice' %>
+
+      <%= render Courses::ApplyComponent.new(course) %>
 
     </div>
   </div>

--- a/spec/components/courses/apply_component_spec.rb
+++ b/spec/components/courses/apply_component_spec.rb
@@ -21,7 +21,7 @@ describe Courses::ApplyComponent, type: :component do
 
       result = render_inline(described_class.new(course))
 
-      expect(result.text).to include('You cannot apply for this course because it currently has no vacancies.')
+      expect(result.text).to include('You cannot apply for this course because it has no vacancies.')
     end
   end
 


### PR DESCRIPTION
Currently the apply button, and no vacancies warning, appear right at the bottom of the page. 

Users might struggle to fin them because our pages are so long. 

Move these to the top of the page, as well as the bottom, so they're more visible.

![Screenshot 2022-04-12 at 15 07 34](https://user-images.githubusercontent.com/56349171/162980997-a0e535ed-15ee-4d1e-84e1-c4bb0881c25e.png)

![Screenshot 2022-04-12 at 15 08 01](https://user-images.githubusercontent.com/56349171/162981092-e144285f-c482-42a0-bbd9-dfc84c6c178a.png)

## Question

I couldn't see how this change looks at the end of the cycle, when other content replaces the apply button. See screenshot for the content that replaces the button (also described in the design history entry here: https://bat-design-history.netlify.app/find-teacher-training/changes-to-find-at-the-end-of-2021-cycle/#the-deadline-to-apply-again-has-passed). 

How do I simulate the end of cycle locally, so I can see this in context?

![Screenshot 2022-04-12 at 15 11 07](https://user-images.githubusercontent.com/56349171/162981737-15de64bd-2047-474a-85c6-2a9e06b2133c.png)

