### PR TITLE
Move warning text to the top

### DIFF
--- a/app/components/courses/contents_component.html.erb
+++ b/app/components/courses/contents_component.html.erb
@@ -23,5 +23,5 @@
   <% end %>
   <li><%= govuk_link_to 'Contact this training provider', '#section-contact' %></li>
   <li><%= govuk_link_to 'Support and advice', '#section-advice' %></li>
-  <li><%= govuk_link_to 'Apply', '#section-apply' %></li>
+  <% if course.has_vacancies? %> <li><%= govuk_link_to 'Apply', '#section-apply' %></li> <% end %>
 </ul>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -24,6 +24,8 @@
 
   <%= render Courses::SummaryComponent.new(course) %>
 
+  <%= render Courses::ApplyComponent.new(course) unless course.has_vacancies? %>
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render Courses::ContentsComponent.new(course) %>
@@ -60,7 +62,7 @@
 
       <%= render partial: 'courses/advice' %>
 
-      <%= render Courses::ApplyComponent.new(course) %>
+      <%= render Courses::ApplyComponent.new(course) if course.has_vacancies? || !CycleTimetable.mid_cycle? %>
     </div>
   </div>
 </div>

--- a/spec/components/courses/contents_component_spec.rb
+++ b/spec/components/courses/contents_component_spec.rb
@@ -48,4 +48,25 @@ describe Courses::ContentsComponent, type: :component do
       expect(result.text).not_to include('School placements')
     end
   end
+
+  context 'when the course has vacancies' do
+    it 'does render the apply link' do
+      provider = build(:provider).decorate
+      course = build(:course, has_vacancies?: true, provider: provider).decorate
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).to include('Apply')
+    end
+  end
+
+  context 'when the course does not have vacancies' do
+    it 'does not render the apply link' do
+      provider = build(:provider).decorate
+      course = build(:course, has_vacancies?: false, provider: provider).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.text).not_to include('Apply')
+    end
+  end
 end


### PR DESCRIPTION
### Context

Moving the warning text which appears if a course does not have vacancies to help make this more clear, earlier on to candidates but keeping the Apply button at the bottom for now.

### Changes proposed in this pull request

- Move warning text to the top
- Keep the apply button and end of cycle text at the bottom

### Guidance to review

Is the logic all correct?

### Trello card

https://trello.com/c/XIgsStek/4570-design-move-course-full-warning-to-top-of-find-pages

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
