### PR TITLE
Add inset text to results page

### DIFF
--- a/app/components/results/results_component.html.erb
+++ b/app/components/results/results_component.html.erb
@@ -16,7 +16,7 @@
     <div class="govuk-inset-text">
       Speak with teacher training providers near you.
       <%= govuk_link_to 'Teacher training events',
-                        'https://getintoteaching.education.gov.uk/events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner'
+                        t('get_into_teaching.url_teacher_training_events')
       %>
     </div>
     <%= render Results::SortByComponent.new(results: results) %>

--- a/app/components/results/results_component.html.erb
+++ b/app/components/results/results_component.html.erb
@@ -12,6 +12,13 @@
   </div>
   <div class="app-filter-layout__content">
     <%= render Results::NoResultsComponent.new(results: results) %>
+
+    <div class="govuk-inset-text">
+      Speak with teacher training providers near you.
+      <%= govuk_link_to 'Teacher training events',
+                        'https://getintoteaching.education.gov.uk/events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner'
+      %>
+    </div>
     <%= render Results::SortByComponent.new(results: results) %>
     <%= render Results::SuggestedSearchesComponent.new(results: results) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -83,6 +83,7 @@ en:
     url_funding_your_training: https://getintoteaching.education.gov.uk/funding-your-training
     url_bursaries_and_scholarships: https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships
     url_improve_your_subject_knowledge: https://getintoteaching.education.gov.uk/improve-your-subject-knowledge
+    url_teacher_training_events: https://getintoteaching.education.gov.uk/events?utm_source=find-postgraduate-teacher-training.service.gov.uk&utm_medium=referral&utm_campaign=find_banner
   cycles:
     real:
       name: 'Same as production environment'

--- a/spec/components/results/results_component_spec.rb
+++ b/spec/components/results/results_component_spec.rb
@@ -39,6 +39,15 @@ describe Results::ResultsComponent, type: :component do
 
       expect(component.text).to include('No courses found')
     end
+
+    it 'renders the inset text' do
+      stub_courses(query: {}, course_count: 0)
+      courses = Course.where(recruitment_cycle_year: RecruitmentCycle.current_year).all
+      component = render_inline(
+        described_class.new(results: results_view, courses: courses),
+      )
+      expect(component.text).to include('Speak with teacher training providers near you')
+    end
   end
 
   context 'when there are 10 matching courses' do
@@ -81,6 +90,21 @@ describe Results::ResultsComponent, type: :component do
       end
 
       expect(component.text).to include('10 courses found')
+    end
+
+    it 'renders the inset text' do
+      component = render_inline(
+        described_class.new(results: results_view, courses: courses),
+      )
+
+      courses.each do |course|
+        expect(Results::SearchResultComponent).to have_received(:new).with(
+          course: course,
+          has_sites: true,
+          filtered_by_location: false,
+        )
+      end
+      expect(component.text).to include('Speak with teacher training providers near you')
     end
   end
 end


### PR DESCRIPTION
### Context

Help to promote GIT event attendance by displaying a link on the results page, using inset text.

### Changes proposed in this pull request

<img width="1265" alt="image" src="https://user-images.githubusercontent.com/50492247/164260990-227e6e40-301b-4da9-9df6-86749b25af69.png">


### Trello card

https://trello.com/c/BfJWB9FI/4631-promote-ttt-events-in-find-results-pages

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
