### PR TITLE
Delete GitHub environment along with review app

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -2,8 +2,6 @@ name: deploy
 description: deploys application
 
 inputs:
-  actions-api-access-token:
-    required: true
   azure_credentials:
     required: true
   environment:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   build:
     name: Build
-    outputs: 
+    outputs:
       image_tag: ${{ env.IMAGE_TAG }}
       branch_tag: ${{ env.BRANCH_TAG }}
     runs-on: ubuntu-latest
@@ -127,7 +127,7 @@ jobs:
   test:
     name: Unit Tests
     needs: [build]
-    outputs: 
+    outputs:
       image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
@@ -157,7 +157,7 @@ jobs:
         run: make publish.codeclimate
         env:
           GIT_BRANCH: ${{ needs.build.outputs.branch_tag }}
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }} 
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
 
   deploy_review:
     name: Deploy Review Environment
@@ -171,7 +171,7 @@ jobs:
         id: deployment
         with:
           step: start
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: review-${{ github.event.pull_request.number }}
           ref: ${{ needs.build.outputs.image_tag }}
 
@@ -182,7 +182,6 @@ jobs:
         id: deploy_review
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
           environment: review
           pr: ${{ github.event.pull_request.number }}
@@ -195,7 +194,7 @@ jobs:
         uses: bobheadxi/deployments@v1
         with:
           step: finish
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: review-${{ github.event.pull_request.number }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
@@ -211,7 +210,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
+      matrix:
         environment: [qa,staging,production,sandbox]
       max-parallel: 1
     steps:
@@ -222,7 +221,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
           environment: ${{ matrix.environment }}
           sha: ${{ needs.test.outputs.image_tag }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,6 +14,7 @@ env:
   DOCKER_IMAGE: ghcr.io/dfe-digital/find-teacher-training
 
 permissions:
+  deployments: write
   packages: write
   contents: write
   pull-requests: write

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -79,26 +79,10 @@ jobs:
           token:  ${{ secrets.GITHUB_TOKEN }}
           env:    review-${{ env.PR_NUMBER }}
 
-      - uses: actions/github-script@v5
-        name: Remove environment entity
-        if: always() && (steps.deactivate-env.outcome == 'success')
+      - name: Delete review-${{ env.PR_NUMBER }} environment
+        if:   always() && (steps.deactivate-env.outcome == 'success')
+        uses: bobheadxi/deployments@v1
         with:
-          github-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-          script: |
-            const environment = process.env.DEPLOY_ENV || ''
-
-            if (environment) {
-              github.rest.repos.deleteAnEnvironment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                environment_name: environment
-              }).then(res => {
-                  console.log(`The environment ${environment} was removed successfully.`)
-              }).catch(err => {
-                  core.setFailed(err.message)
-              })
-            } else {
-              core.setFailed('An environment was not passed for deletion.')
-            }
-        env:
-          DEPLOY_ENV: review-${{ env.PR_NUMBER }}
+          step:   delete-env
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -71,9 +71,34 @@ jobs:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}
 
       - name: Update ${{ env.PR_NUMBER }} status
+        id: deactivate-env
         if:   ${{ always() && env.TF_STATE_EXISTS == 'true' }}
         uses: bobheadxi/deployments@v1
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
           env:    review-${{ env.PR_NUMBER }}
+
+      - uses: actions/github-script@v5
+        name: Remove environment entity
+        if: always() && (steps.deactivate-env.outcome == 'success')
+        with:
+          github-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          script: |
+            const environment = process.env.DEPLOY_ENV || ''
+
+            if (environment) {
+              github.rest.repos.deleteAnEnvironment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                environment_name: environment
+              }).then(res => {
+                  console.log(`The environment ${environment} was removed successfully.`)
+              }).catch(err => {
+                  core.setFailed(err.message)
+              })
+            } else {
+              core.setFailed('An environment was not passed for deletion.')
+            }
+        env:
+          DEPLOY_ENV: ${{env.DEPLOY_ENV}}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -84,5 +84,5 @@ jobs:
         uses: bobheadxi/deployments@v1
         with:
           step:   delete-env
-          token:  ${{ secrets.GITHUB_TOKEN }}
+          token:  ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -101,4 +101,4 @@ jobs:
               core.setFailed('An environment was not passed for deletion.')
             }
         env:
-          DEPLOY_ENV: ${{env.DEPLOY_ENV}}
+          DEPLOY_ENV: review-${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', github.event.inputs.environment)] }}
           environment: ${{ github.event.inputs.environment }}
           sha: ${{ github.event.inputs.sha }}


### PR DESCRIPTION
### Context
A GitHub environment is created for each review app that is deployed, this environment persists after the review app is deleted.

### Changes proposed in this pull request
Add a step to the delete-review-app workflow to delete the environment.

### Guidance to review


### Trello card
https://trello.com/c/ybnYhCK3

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
