### PR TITLE
Delete GitHub environment

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -2,8 +2,6 @@ name: deploy
 description: deploys application
 
 inputs:
-  actions-api-access-token:
-    required: true
   azure_credentials:
     required: true
   environment:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,6 +14,7 @@ env:
   DOCKER_IMAGE: ghcr.io/dfe-digital/find-teacher-training
 
 permissions:
+  deployments: write
   packages: write
   contents: write
   pull-requests: write
@@ -21,7 +22,7 @@ permissions:
 jobs:
   build:
     name: Build
-    outputs: 
+    outputs:
       image_tag: ${{ env.IMAGE_TAG }}
       branch_tag: ${{ env.BRANCH_TAG }}
     runs-on: ubuntu-latest
@@ -127,7 +128,7 @@ jobs:
   test:
     name: Unit Tests
     needs: [build]
-    outputs: 
+    outputs:
       image_tag: ${{ needs.build.outputs.image_tag }}
     runs-on: ubuntu-latest
     steps:
@@ -157,7 +158,7 @@ jobs:
         run: make publish.codeclimate
         env:
           GIT_BRANCH: ${{ needs.build.outputs.branch_tag }}
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }} 
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}
 
   deploy_review:
     name: Deploy Review Environment
@@ -171,7 +172,7 @@ jobs:
         id: deployment
         with:
           step: start
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: review-${{ github.event.pull_request.number }}
           ref: ${{ needs.build.outputs.image_tag }}
 
@@ -182,7 +183,6 @@ jobs:
         id: deploy_review
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
           environment: review
           pr: ${{ github.event.pull_request.number }}
@@ -195,7 +195,7 @@ jobs:
         uses: bobheadxi/deployments@v1
         with:
           step: finish
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           env: review-${{ github.event.pull_request.number }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
@@ -211,7 +211,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
+      matrix:
         environment: [qa,staging,production,sandbox]
       max-parallel: 1
     steps:
@@ -222,7 +222,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
           environment: ${{ matrix.environment }}
           sha: ${{ needs.test.outputs.image_tag }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  deployments: write
+
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
@@ -71,9 +74,18 @@ jobs:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}
 
       - name: Update ${{ env.PR_NUMBER }} status
+        id: deactivate-env
         if:   ${{ always() && env.TF_STATE_EXISTS == 'true' }}
         uses: bobheadxi/deployments@v1
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    review-${{ env.PR_NUMBER }}
+
+      - name: Delete review-${{ env.PR_NUMBER }} environment
+        if:   always() && (steps.deactivate-env.outcome == 'success')
+        uses: bobheadxi/deployments@v1
+        with:
+          step:   delete-env
+          token:  ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', github.event.inputs.environment)] }}
           environment: ${{ github.event.inputs.environment }}
           sha: ${{ github.event.inputs.sha }}


### PR DESCRIPTION
### Context
A GitHub environment is created for each review app that is deployed, this environment persists after the review app is deleted.

### Changes proposed in this pull request
- Removed unneeded references to `ACTIONS_API_ACCESS_TOKEN` secret, this is now only used for the step below
- Add a step to the delete-review-app workflow to delete the environment

### Guidance to review
- Close PR to test delete process, reopen PR once tested

### Trello card
https://trello.com/c/ybnYhCK3

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally

