### PR TITLE
Redesign promoted event link

### DIFF
--- a/app/components/results/results_component.html.erb
+++ b/app/components/results/results_component.html.erb
@@ -11,14 +11,14 @@
     <%= render Results::FilterComponent.new(results: results) %>
   </div>
   <div class="app-filter-layout__content">
-    <%= render Results::NoResultsComponent.new(results: results) %>
 
-    <div class="govuk-inset-text">
-      Talk to teacher training providers at an 
-      <%= govuk_link_to 'event near you',
+    <div class="app-promoted-link">
+      <%= govuk_link_to 'Talk to teacher training providers at an event near you',
                         t('get_into_teaching.url_teacher_training_events')
       %>.
     </div>
+
+    <%= render Results::NoResultsComponent.new(results: results) %>
     <%= render Results::SortByComponent.new(results: results) %>
     <%= render Results::SuggestedSearchesComponent.new(results: results) %>
 

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -28,5 +28,6 @@ $git-brand-colour: #159964;
 @import "components/toggle";
 @import "components/autocomplete";
 @import "components/summary-card";
+@import "components/promoted-link";
 
 @import "patterns/filters";

--- a/app/webpacker/styles/components/_promoted-link.scss
+++ b/app/webpacker/styles/components/_promoted-link.scss
@@ -1,0 +1,7 @@
+.app-promoted-link {
+  @include govuk-responsive-padding(3);
+  @include govuk-responsive-margin(3, "bottom");
+  @include govuk-font($size: 19);
+  @include govuk-text-colour;
+  background-color: govuk-colour("light-grey");
+}


### PR DESCRIPTION
Move this above the "Sorted by" component, and redesign to use a background colour instead of inset text.

This promoted event link was added as an experiment, to see if it made an impact.

The inset text component is known to sometimes be ignored by users, and should probably be reserved for introducing alternative "voices" (for example quoting a message from another organisation).

Moving the link up also brings the "Sorted by" component back closer to the content it describes.

🗂️  [Trello card](https://trello.com/c/HgsSuqHr/2971-update-find-banner-for-event-promotion)

## Screenshots
### Before

<img width="989" alt="Screenshot 2022-04-28 at 15 37 12" src="https://user-images.githubusercontent.com/30665/165777545-6fe79a84-d795-4573-a232-955145fb6de4.png">

### After

<img width="1007" alt="Screenshot 2022-04-28 at 15 36 53" src="https://user-images.githubusercontent.com/30665/165777577-1defb930-fcea-4ff5-8ea6-70846da33767.png">

