### PR TITLE
Tweak service name

### DIFF
--- a/app/job/slack_notification_job.rb
+++ b/app/job/slack_notification_job.rb
@@ -25,7 +25,7 @@ private
     end
 
     payload = {
-      username: 'Find postgraduate teacher training',
+      username: 'Find teacher training courses',
       channel: slack_channel,
       text: slack_message,
       mrkdwn: true,

--- a/app/views/cookie_preferences/_cookie_preferences_form.html.erb
+++ b/app/views/cookie_preferences/_cookie_preferences_form.html.erb
@@ -1,10 +1,10 @@
 <div class="app-cookie-preferences">
   <%= render partial: 'shared/error_message', locals: { error_anchor_id: 'cookie-consent-accept' } %>
-  <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘Find postgraduate teacher training’. This information helps us improve our service.</p>
+  <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use ‘Find teacher training courses’. This information helps us improve our service.</p>
   <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
   <p class="govuk-body">Google Analytics stores anonymised information about:</p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>how you got to ‘Find postgraduate teacher training’</li>
+    <li>how you got to ‘Find teacher training courses’</li>
     <li>the pages you visit on this site and how long you spend on them</li>
     <li>what you click on while you’re visiting the site</li>
   </ul>

--- a/app/views/cookie_preferences/new.html.erb
+++ b/app/views/cookie_preferences/new.html.erb
@@ -6,10 +6,10 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
-      <p class="govuk-body">We use cookies to make ‘Find postgraduate teacher training’ work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make ‘Find teacher training courses’ work and collect information about how you use our service.</p>
 
       <h3 class="govuk-heading-m">Essential cookies</h3>
-      <p class="govuk-body">Essential cookies keep your information secure while you use ‘Find postgraduate teacher training’. We do not need to ask permission to use them.</p>
+      <p class="govuk-body">Essential cookies keep your information secure while you use ‘Find teacher training courses’. We do not need to ask permission to use them.</p>
 
       <table class="govuk-table">
         <thead class="govuk-table__header">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template">
   <head>
-    <title><%= content_for(:page_title) %> - Find postgraduate teacher training - GOV.UK</title>
+    <title><%= content_for(:page_title) %> - Find teacher training courses - GOV.UK</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
@@ -25,7 +25,7 @@
     </script>
 
     <% unless current_page?(cookie_preferences_path) %>
-      <% heading_text = 'Cookies on Find postgraduate teacher training' %>
+      <% heading_text = 'Cookies on Find teacher training courses' %>
       <%= govuk_cookie_banner(
         html_attributes: {
           aria: {
@@ -88,7 +88,7 @@
     <%= govuk_skip_link %>
 
     <%= govuk_header(
-      service_name: 'Find postgraduate teacher training',
+      service_name: 'Find teacher training courses',
       service_url: root_path,
       classes: "govuk-!-display-none-print app-header #{environment_header_class}",
     ) %>
@@ -100,7 +100,7 @@
           colour: environment_colour,
         },
       ) do %>
-        Give feedback or report a problem: <%= bat_contact_mail_to subject: 'Feedback about Find postgraduate teacher training', no_visited_state: true %>
+        Give feedback or report a problem: <%= bat_contact_mail_to subject: 'Feedback about Find teacher training courses', no_visited_state: true %>
       <% end %>
 
       <%= yield(:before_content) %>

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,9 +1,9 @@
-<%= content_for :page_title, 'Accessibility statement for Find postgraduate teacher training' %>
+<%= content_for :page_title, 'Accessibility statement for Find teacher training courses' %>
 
 <div class="govuk-width-container">
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Accessibility statement for Find postgraduate teacher training</h1>
+      <h1 class="govuk-heading-xl">Accessibility statement for Find teacher training courses</h1>
 
       <p class="govuk-body">This service is run by the Becoming a Teacher team at the Department for Education (DfE). We want as many people as possible to be able to use the service. For example, that means users should be able to:</p>
       <ul class="govuk-list govuk-list--bullet">
@@ -25,7 +25,7 @@
       <p class="govuk-body">The Becoming a Teacher team is committed to making this service accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
 
       <p class="govuk-body">
-        Find postgraduate teacher training is fully compliant with the
+        Find teacher training courses is fully compliant with the
         <%= govuk_link_to 'Web Content Accessibility Guidelines (WCAG) version 2.1', 'https://www.w3.org/TR/WCAG21/' %>
         AA standard.
       </p>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -6,7 +6,7 @@
       <h1 class="govuk-heading-xl">Privacy policy</h1>
 
       <h2 class="govuk-heading-l">Who we are</h2>
-      <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Find postgraduate teacher training’.</p>
+      <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Find teacher training courses’.</p>
 
       <h2 class="govuk-heading-l">How we will use your information</h2>
       <p class="govuk-body">We receive your personal data in the form of your IP address and are processing it in order to track traffic to the service and continuously improve our service to better meet users’ needs. In some instances, we may also collect your email address for similar purposes. More information about this work is available if you wish to contact us at <%= bat_contact_mail_to %>.</p>

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -6,20 +6,20 @@
       <h1 class="govuk-heading-xl">Terms and conditions</h1>
 
       <h2 class="govuk-heading-l">Using our website</h2>
-      <p class="govuk-body">The ‘Find postgraduate teacher training’ service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.</p>
+      <p class="govuk-body">The ‘Find teacher training courses’ service is maintained for your personal use and viewing. Access and use by you of this site constitutes your acceptance of these terms and conditions. This takes effect from the date on which you first use this website.</p>
 
-      <h2 class="govuk-heading-l">Linking to Find postgraduate teacher training </h2>
-      <p class="govuk-body">We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find postgraduate teacher training’ pages must be displayed in the user’s entire browser window.</p>
+      <h2 class="govuk-heading-l">Linking to Find teacher training courses </h2>
+      <p class="govuk-body">We do not object to you linking directly to pages on this site and you do not need to ask permission to do so. However, we do not permit our pages to be loaded into frames on your site. The ‘Find teacher training courses’ pages must be displayed in the user’s entire browser window.</p>
 
-      <h2 class="govuk-heading-l">Linking from Find postgraduate teacher training</h2>
+      <h2 class="govuk-heading-l">Linking from Find teacher training courses</h2>
       <p class="govuk-body">We are not responsible for the content or reliability of the websites we link to and do not necessarily endorse the views expressed within them. We aim to replace broken links to other sites but cannot guarantee that these links will always work as we have no control over the availability of other sites.</p>
 
       <h2 class="govuk-heading-l">Virus protection</h2>
       <p class="govuk-body">We make every effort to check and test material at all stages of production. It is always wise for you to run an anti-virus program on all material downloaded from the Internet. We cannot accept any responsibility for any loss, disruption or damage to your data or your computer system which may occur whilst using material derived from this website.</p>
 
       <h2 class="govuk-heading-l">Disclaimer</h2>
-      <p class="govuk-body">‘Find postgraduate teacher training’ and material relating to government information, products and services (or to third party information, products and services), is provided ‘as is’, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
-      <p class="govuk-body">We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the ‘Find postgraduate teacher training’.</p>
+      <p class="govuk-body">‘Find teacher training courses’ and material relating to government information, products and services (or to third party information, products and services), is provided ‘as is’, without any representation or endorsement made and without warranty of any kind whether express or implied, including but not limited to the implied warranties of satisfactory quality, fitness for a particular purpose, non-infringement, compatibility, security and accuracy.</p>
+      <p class="govuk-body">We do not warrant that the functions contained in the material contained in this site will be uninterrupted or error free, that defects will be corrected, or that this site or the server that makes it available are free of viruses or represent the full functionality, accuracy, reliability of the materials. In no event will we be liable for any loss or damage including, without limitation, indirect or consequential loss or damage, or any loss or damages whatsoever arising from use or loss of use of, data or profits arising out of or in connection with the use of the ‘Find teacher training courses’.</p>
       <p class="govuk-body">These terms and conditions shall be governed by and construed in accordance with the laws of England and Wales. Any dispute arising under these terms and conditions shall be subject to the exclusive jurisdiction of the courts of England and Wales.</p>
     </div>
   </div>

--- a/app/webpacker/scripts/cookie-banner.spec.js
+++ b/app/webpacker/scripts/cookie-banner.spec.js
@@ -12,11 +12,11 @@ import CookieBanner from './cookie-banner'
 import {checkConsentedToCookieExists} from './cookie-helper'
 
 const templateHTML = `
-<div class="govuk-cookie-banner" role="region" aria-label="Cookies on Find postgraduate teacher training" data-module="govuk-cookie-banner" data-qa="cookie-banner">
+<div class="govuk-cookie-banner" role="region" aria-label="Cookies on Find teacher training courses" data-module="govuk-cookie-banner" data-qa="cookie-banner">
   <div class="govuk-cookie-banner__message govuk-width-container" hidden="hidden" data-module="govuk-cookie-banner-choice-message" data-qa="cookie-banner-choice-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find teacher training courses</h2>
         <div class="govuk-cookie-banner__content">
           <p>We use some essential cookies to make this service work.</p>
           <p>We’d also like to use analytics cookies so we can understand how you use the service and make improvements.</p>
@@ -34,7 +34,7 @@ const templateHTML = `
   <div class="govuk-cookie-banner__message govuk-width-container" hidden="hidden" data-module="govuk-cookie-banner-confirmation-message" data-qa="cookie-banner-confirmation-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find teacher training courses</h2>
         <div class="govuk-cookie-banner__content">
           <p>
             You’ve
@@ -55,7 +55,7 @@ const templateHTML = `
   <div class="govuk-cookie-banner__message govuk-width-container" data-module="govuk-cookie-banner-fallback-message" data-qa="cookie-banner-fallback-message">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading">Cookies on Find postgraduate teacher training</h2>
+        <h2 class="govuk-cookie-banner__heading">Cookies on Find teacher training courses</h2>
         <div class="govuk-cookie-banner__content">
           <p>We use cookies to make this service work and collect analytics information. To accept or reject cookies, turn on JavaScript in your browser settings or reload this page.</p>
         </div>

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -24,7 +24,7 @@
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-const DEFAULT_PAGE_TITLE = "Find postgraduate teacher training - GOV.UK";
+const DEFAULT_PAGE_TITLE = "Find teacher training courses - GOV.UK";
 
 Cypress.Commands.add("checkForDefaultTitle", () => {
   cy.title().should("not.equal", DEFAULT_PAGE_TITLE);

--- a/service_unavailable_page/web/public/internal/index.html
+++ b/service_unavailable_page/web/public/internal/index.html
@@ -2,7 +2,7 @@
 <html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Sorry, there is a problem with the service - Find postgraduate teacher training - GOV.UK</title>
+    <title>Sorry, there is a problem with the service - Find teacher training courses - GOV.UK</title>
     <meta name="robots" content="noindex, nofollow">
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
@@ -30,7 +30,7 @@
             </span>
           </a>
         </div>
-        <div class="govuk-header__product-name">    Find postgraduate teacher training
+        <div class="govuk-header__product-name">    Find teacher training courses
           <strong class="govuk-tag">Beta</strong>
         </div>
       </div>

--- a/spec/features/feature_flags_spec.rb
+++ b/spec/features/feature_flags_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'Feature flags', type: :feature do
   def stub_activate_slack_notification_job
     stub_request(:post, 'https://example.com/webhook')
       .with(
-        body: '{"username":"Find postgraduate teacher training","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was activated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
+        body: '{"username":"Find teacher training courses","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was activated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
         headers: {
           'Connection' => 'close',
           'Host' => 'example.com',
@@ -100,7 +100,7 @@ RSpec.describe 'Feature flags', type: :feature do
   def stub_deactivate_slack_notification_job
     stub_request(:post, 'https://example.com/webhook')
       .with(
-        body: '{"username":"Find postgraduate teacher training","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was deactivated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
+        body: '{"username":"Find teacher training courses","channel":"#twd_apply_test","text":"[TEST] \\u003c/feature-flags|:flags: Feature ‘test_feature‘ was deactivated\\u003e","mrkdwn":true,"icon_emoji":":livecanary:"}',
         headers: {
           'Connection' => 'close',
           'Host' => 'example.com',

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'View pages', type: :feature do
   it 'Navigate to accessibility' do
     visit accessibility_path
 
-    expect(page).to have_text('Accessibility statement for Find postgraduate teacher training')
+    expect(page).to have_text('Accessibility statement for Find teacher training courses')
   end
 
   it 'Navigate to terms' do


### PR DESCRIPTION
Renames the service from 'Find postgraduate teacher training' to 'Find teacher training courses'.

Rationale:

* Apply dropped the word 'postgraduate' long ago, after finding that it wasn't necessary, but we didn't go back and change Find
* It's good to be consistent between Find and Apply
* Find contains Further education courses, which don't always require a degree and aren't postgraduate
* "postgraduate" is an awkward word which not everyone may recognise, particularly non-UK applicants