### PR TITLE
#103 Entry requirements standard 'subject knowledge' text not appearing on course page

### DIFF
--- a/app/components/courses/entry_requirements_component.html.erb
+++ b/app/components/courses/entry_requirements_component.html.erb
@@ -12,6 +12,12 @@
       </p>
     <% end %>
 
+    <% if course.level == 'secondary' %>
+      <p class="govuk-body">
+        <%= secondary_advisory(course) %>
+      </p>
+    <% end %>
+
     <p class="govuk-body">
       <%= required_gcse_content(course) %>
     </p>

--- a/app/components/courses/entry_requirements_component.rb
+++ b/app/components/courses/entry_requirements_component.rb
@@ -32,6 +32,10 @@ module Courses
       end
     end
 
+    def secondary_advisory(course)
+      "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+    end
+
     def pending_gcse_content(course)
       if course.accept_pending_gcse
         'We’ll consider candidates with pending GCSEs.'

--- a/spec/components/courses/entry_requirements_component_spec.rb
+++ b/spec/components/courses/entry_requirements_component_spec.rb
@@ -29,7 +29,7 @@ describe Courses::EntryRequirementsComponent, type: :component do
     end
   end
 
-  context 'when the provider requires grade 4 and the course is secondary' do
+  context 'when the provider requires grade 4 and the course is primary' do
     it 'renders correct message' do
       course = build(
         :course,
@@ -40,6 +40,9 @@ describe Courses::EntryRequirementsComponent, type: :component do
 
       expect(result.text).to include(
         'Grade 4 (C) or above in English, maths and science, or equivalent qualification.',
+      )
+      expect(result.text).not_to include(
+        "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
       )
     end
   end
@@ -55,6 +58,9 @@ describe Courses::EntryRequirementsComponent, type: :component do
 
       expect(result.text).to include(
         'Grade 5 (C) or above in English and maths, or equivalent qualification.',
+      )
+      expect(result.text).to include(
+        "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way",
       )
     end
 


### PR DESCRIPTION
### Context
# Overview

When structured entry requirements was released during rollover in 2021, provider free text descriptions of entry requirements was replaced with content rendered based on questions that providers answered, plus some free text fields. We state on Publish that "Candidates will be advised that their degree subject should match or be closely related to [subject]", however, we did not release the required change to present this guidance on Find. 

## What happened?

Candidate team omitted to include the text detailed in the (design write up)[https://bat-design-history.netlify.app/find-teacher-training/standardised-entry-requirement-descriptions/].

"Your degree subject should be in [course subject] or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."

It DOES render on the Publish preview, but not on Find courses in prod. 

## What was supposed to happen? 

The above text should be displayed on all Secondary courses. The impact of this error is that all Secondary courses without additional free text do not  communicate subject knowledge requirements to candidates. 

Out of 11,888 courses, 2,013 have an additional degree subject requirement, meaning the majority of courses don't make subject knowledge requirements clear. 

## Technical notes

Publish design history entry for degree entry requirements - https://bat-design-history.netlify.app/publish-teacher-training-courses/degree-entry-requirements/

Find design history entry for standardised entry requirements - https://bat-design-history.netlify.app/publish-teacher-training-courses/degree-entry-requirements/

## Who knows about this? 
@tomcrookssmith @frankieroberto3 @simonwhatley_dfe 

## Links

Slack thread - https://ukgovernmentdfe.slack.com/archives/C03EM9URG0N/p1653580475363369

### Changes proposed in this pull request
Conditional display of missing paragraph on course entry requirements section
### Guidance to review
![Screenshot 2022-06-08 at 11 22 14](https://user-images.githubusercontent.com/4527528/172603665-58e3883c-1378-4225-a2ca-90ae5285eb9e.png)

### Trello card

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
