### PR TITLE
[0132] Move fees and financial support sections the other way around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ terraform/**/*.base64
 .rubocop-https*
 
 /.vscode/*
+
+# Redis
+dump.rdb

--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ ruby 2.7.5
 yarn 1.22.17
 nodejs 16.13.2
 terraform 0.13.5
+redis 7.0.0

--- a/app/components/courses/fees_and_financial_support_component.html.erb
+++ b/app/components/courses/fees_and_financial_support_component.html.erb
@@ -1,5 +1,10 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-financial-support">Fees and financial support</h2>
+
+  <% if has_fees? %>
+    <%= render Courses::FeesComponent.new(course) %>
+  <% end %>
+
   <%= render AdviceComponent.new(title: 'Financial support from the government') do %>
     <% if salaried? %>
       <%= render partial: 'courses/financial_support/salaried' %>
@@ -12,10 +17,6 @@
     <% else %>
       <%= render partial: 'courses/financial_support/loan' %>
     <% end %>
-  <% end %>
-
-  <% if has_fees? %>
-    <%= render Courses::FeesComponent.new(course) %>
   <% end %>
 
   <% if financial_support.present? %>


### PR DESCRIPTION
### Context
Fees and financial support sections

### Changes proposed in this pull request
Move fees and financial support sections the other way around

### Guidance to review
#### Before 1
![image](https://user-images.githubusercontent.com/470137/172604856-852735bf-c0b5-4033-976d-7a5856425ad1.png)

#### Before 2
![image](https://user-images.githubusercontent.com/470137/172610604-173daac5-6220-428a-af1d-0df788d4b482.png)

#### Before 3
![image](https://user-images.githubusercontent.com/470137/172610318-890b20d1-d212-4f81-a07b-5a9fa191ee63.png)

#### Before 4
![image](https://user-images.githubusercontent.com/470137/172610908-e137eb77-c3bb-429d-b3da-5e476ab32d67.png)
#### After 1
![image](https://user-images.githubusercontent.com/470137/172604987-91df555c-2ee9-4721-9bfe-cae8da96753b.png)
#### After 2
![image](https://user-images.githubusercontent.com/470137/172610551-20b5fd1e-ef04-424e-a16e-efeec2326053.png)
#### After 3
![image](https://user-images.githubusercontent.com/470137/172610453-2fd48b84-bf02-4db5-942d-b9a938ef9404.png)
#### After 4
![image](https://user-images.githubusercontent.com/470137/172610805-1f0b1764-4fb6-4f7a-ae76-f294296dcf3f.png)

### Trello card

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
