### PR TITLE
Fix prod AZ credential in deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -244,11 +244,11 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          azure_credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
           environment: production
           sha: ${{ github.sha }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
-          terraform-state-access-key: ${{ secrets[format('TERRAFORM_STATE_ACCESS_KEY_{0}', matrix.environment)] }}
+          terraform-state-access-key: ${{ secrets.TERRAFORM_STATE_ACCESS_KEY_PRODUCTION }}
 
   deploy-after-production:
     name: Parallel deployment After production


### PR DESCRIPTION
### Context

fix prod AZ secret in deploy workflow, caused by parallel deploy PR

**Required to unblock prod deploy**

### Changes proposed in this pull request

remove matrix.environment references in prod deploy step

### Guidance to review

check workflow config

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
