### PR TITLE
Upgrade Terraform to 0.14.11

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -49,10 +49,10 @@ runs:
       env:
         DEPLOY_ENV: ${{ inputs.environment }}
 
-    - name: Use Terraform v0.13.5
+    - name: Use Terraform v0.14.11
       uses: hashicorp/setup-terraform@v1.3.2
       with:
-        terraform_version: 0.13.5
+        terraform_version: 0.14.11
 
     - uses: azure/login@v1.3.0
       id: login_azure

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.0.2
 
-      - name: Setup Terraform v0.13.5
+      - name: Setup Terraform v0.14.11
         uses: hashicorp/setup-terraform@v2.0.0
         with:
-          terraform_version: 0.13.5
+          terraform_version: 0.14.11
 
       - name: Set Environment variables
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 2.7.5
 yarn 1.22.4
 nodejs 16.13.2
-terraform 0.13.5
+terraform 0.14.11
 redis 7.0.0

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -67,11 +67,11 @@ SETTINGS__GOOGLE__MAPS_API_KEY:
 SETTINGS__SKYLIGHT_AUTH_TOKEN:
 ```
 ### Download and install terraform
-The project uses terraform 0.13.5, [download](https://www.terraform.io/downloads.html) and verify you have the correct terraform version configured.
-Please make sure you are on `0.13.5`, if not there is a chance the state file could get corrupted.
+The project uses terraform 0.14.11, [download](https://www.terraform.io/downloads.html) and verify you have the correct terraform version configured.
+Please make sure you are on `0.14.11`, if not there is a chance the state file could get corrupted.
 Download and install on Linux machines:
 ```sh
-	wget -qO terraform.zip https://releases.hashicorp.com/terraform/0.13.5/terraform_0.13.5_linux_amd64.zip
+	wget -qO terraform.zip https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip
 	sudo unzip -o terraform.zip -d /usr/local/bin
 	terraform version
 ```

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,60 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudfoundry-community/cloudfoundry" {
+  version     = "0.12.6"
+  constraints = "0.12.6"
+  hashes = [
+    "h1:WQcXdseDBK7HXsjDmk7XdnEecy/TUwceVmDoTj3uMe8=",
+    "zh:002815059dd934574b0eaa856a3fccc75749f389802aef3b62a5016c5927061d",
+    "zh:0b047a19d0270d47098a5812f48998cde1177a7c5b9615d8308d342a8ae06dea",
+    "zh:1368a05d79d574ad6b8ec6522de8a8a2fadb37b32a8ada4ddc27cb094b071f53",
+    "zh:43e787c6d96d9410aa61c169d2001bca9dea26947966439b9723db6281b5c8bd",
+    "zh:4e5baa37fef83418927f24976b4d0e064071aa81f0a2e0082cd8ea70bf70fe78",
+    "zh:793f864fe00cc792538782ab01a5dadcedddaa18ff051ac3bc492355943e71b6",
+    "zh:9ad31aac0f224c31c9e6289c064f6fc644a9b1e7b7492850a32777a798b4c09f",
+    "zh:a56a1e8169c3588f2aa9009773062e5d32b72ab8d0a0f64399e687accb2ea781",
+    "zh:ac2e06479f05e4cfeec9690a6e39b8e24effcd26596395f5525061f7109a8b7b",
+    "zh:bb97bc6c8a012bd79b05b81393c9e3dd7a0095e63fa2636aa9267b0594c6adee",
+    "zh:ea1a735c8d3f88ad9e4e91130bc3db341ed245ee38d2bdcbc7df37b878794933",
+    "zh:f4d00b7122071a9ca7b73073eb0dfcce9b8bb71beac9e5f4c986da3359115e07",
+    "zh:f8057c0560d75d41c4588776bfb58dd07e8428991845ef36ae2142d10011dfdd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.45.1"
+  constraints = "2.45.1"
+  hashes = [
+    "h1:fHWHWrf6l5P2IAYGPyt1trkeEwpSLwwK1+30EHNQplQ=",
+    "zh:257cc6e06e7b4f5eb7b8e5999ed59a984a16d2c7582da01c4318be4270d3274f",
+    "zh:49dffa76925d3db2634668630d5cdc33d80b7ffbdc39787b180ed41ee657a4fa",
+    "zh:6d1c28e9e35e7a6ff6a7ce57a5ffe34213c263ff135f2aa2900474f51568037b",
+    "zh:80c0f6c5e83ce57a08a8552b4b9b8b1f4d42a7bc3b050a408e003cbe20e55272",
+    "zh:9a30b2821d5ee4a7aa2145f6467639f414a5851e7c658346d57b94bde56c7ec4",
+    "zh:a6ba84564b768b821726fe2fc34763bece99e2ef190420a49e6c94e7a86d279e",
+    "zh:c32d250618b841aac2ef5c1af40d9f4d551162957d5f9c2106851e9363b37b4d",
+    "zh:cc4af260a0d017a6fcda436c8ddb9e5d049ec9a38d51d141498ebaeeadd1fa22",
+    "zh:e0cfe4d5a9a19d02ab19123ad9bccde8e0f87f130bd3d93760e651968f6da637",
+    "zh:e65803c7d2625ad2217543f177494b4fcb737c391e21649cfb167541aa9a9d64",
+  ]
+}
+
+provider "registry.terraform.io/statuscakedev/statuscake" {
+  version     = "1.0.1"
+  constraints = "1.0.1"
+  hashes = [
+    "h1:YOpR2SMftsGw5IeWphloDytm/2h5CH1YonsBpsjRfyc=",
+    "zh:202f23eb15bd2900ab8f93be8a04bdf04321202ed1a969d9590f993faefd342a",
+    "zh:27a8c66ebe0c5436416259371e9eaf00282d45d9966e0c989e9a5fe92d97ac8c",
+    "zh:4632f7d7862fe6e475e96c9cded12221e3c6849c2421e7ea60a80dd189144008",
+    "zh:4ef7e1839fa71de967cfccfdd3e33a7f5a36f67f048322861210089c8ec03c2f",
+    "zh:51670fc6a1861fb3e80f00999e78420c8aec830e8141d58109db0cecece87e85",
+    "zh:6d760d682550ab34c2f1bb3af7b3a9afcaaf9ef589a84587fb85f37b0e4916db",
+    "zh:737605db52be4e79ce78bc448ea691080746ab89f119c73324040da04691a1d9",
+    "zh:b135bda364bad5b1ff5c6e652a832a93b4dac579dd6983fdb3bb0bc9f315f622",
+    "zh:bead0801de80e9736b5ac1604d7e2ca18759b7266df60dfa29921e56df613966",
+    "zh:c8ac03fc938cd438addba11dd8674b153eb16e5450bf2edb8c669f0cfc3c7c24",
+    "zh:e48c0536b185d8ebac7a3861f7cbbd28e1312fb4201586f4946cd0e6ffdb58ab",
+  ]
+}

--- a/terraform/modules/statuscake/providers.tf
+++ b/terraform/modules/statuscake/providers.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     statuscake = {
-      source  = "terraform-providers/statuscake"
-      version = ">= 1.0.0"
+      source  = "StatusCakeDev/statuscake"
+      version = "1.0.1"
     }
   }
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.13.3"
+  required_version = "~> 0.14.11"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
@@ -10,15 +10,15 @@ terraform {
       version = "0.12.6"
     }
     statuscake = {
-      source  = "terraform-providers/statuscake"
-      version = "1.0.0"
+      source  = "StatusCakeDev/statuscake"
+      version = "1.0.1"
     }
   }
-  backend azurerm {
+  backend "azurerm" {
   }
 }
 
-provider azurerm {
+provider "azurerm" {
   features {}
 
   skip_provider_registration = true
@@ -28,7 +28,7 @@ provider azurerm {
   tenant_id                  = try(local.azure_credentials.tenantId, null)
 }
 
-module paas {
+module "paas" {
   source = "./modules/paas"
 
   cf_api_url                = local.cf_api_url
@@ -49,12 +49,12 @@ module paas {
   app_environment_variables = local.paas_app_environment_variables
 }
 
-provider statuscake {
+provider "statuscake" {
   username = local.infra_secrets.STATUSCAKE_USERNAME
   apikey   = local.infra_secrets.STATUSCAKE_PASSWORD
 }
 
-module statuscake {
+module "statuscake" {
   source = "./modules/statuscake"
 
   alerts = var.statuscake_alerts


### PR DESCRIPTION
To align with other BAT services we should keep the Terraform versions the same.

### Context

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
