### PR TITLE
Fix libssl1.1 and libcrypto1.1 vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libssl1.1 and libcrypto1.1
+RUN apk add --no-cache libcrypto1.1=1.1.1q-r0 libssl1.1=1.1.1q-r0
+
 COPY --from=base-image ${FREEDESKTOP_MIME_TYPES_PATH} ${FREEDESKTOP_MIME_TYPES_PATH}
 COPY --from=base-image /app /app
 COPY --from=base-image /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
### Context

Base image vulnerability hightlighted by SNYK scan
https://security.snyk.io/vuln/SNYK-ALPINE315-OPENSSL-2941810 

### Changes proposed in this pull request

Add fixed version in Dockerfile, with note to remove when it has been updated in the base image

### Guidance to review

Check build scan and deploy review app

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
