### PR TITLE
246 update dates on current point in the recruitment cycle page

### DIFF
--- a/app/helpers/current_point_in_recruitment_cycle_helper.rb
+++ b/app/helpers/current_point_in_recruitment_cycle_helper.rb
@@ -16,6 +16,6 @@ module CurrentPointInRecruitmentCycleHelper
   end
 
   def hint_text_for_today_is_after_find_opens
-    "#{I18n.t('cycles.today_is_after_find_opens.description')} (#{CycleTimetable.find_opens.next_year.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_after_find_opens.description')} (#{CycleTimetable.find_reopens.to_formatted_s(:govuk_date)})"
   end
 end

--- a/app/helpers/current_point_in_recruitment_cycle_helper.rb
+++ b/app/helpers/current_point_in_recruitment_cycle_helper.rb
@@ -1,21 +1,21 @@
 module CurrentPointInRecruitmentCycleHelper
   def hint_text_for_mid_cycle
-    "#{I18n.t('cycles.today_is_mid_cycle.description')} (#{CycleTimetable.find_opens.to_formatted_s(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_mid_cycle.description')} (#{CycleTimetable.find_opens.to_fs(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)})"
   end
 
   def hint_text_for_after_apply_1_deadline_passed
-    "#{I18n.t('cycles.today_is_after_apply_1_deadline_passed.description')} (#{CycleTimetable.apply_1_deadline.to_formatted_s(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_after_apply_1_deadline_passed.description')} (#{CycleTimetable.apply_1_deadline.to_fs(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)})"
   end
 
   def hint_text_for_after_apply_2_deadline_passed
-    "#{I18n.t('cycles.today_is_after_apply_2_deadline_passed.description')} (#{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)} to #{CycleTimetable.find_closes.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_after_apply_2_deadline_passed.description')} (#{CycleTimetable.apply_2_deadline.to_fs(:govuk_date)} to #{CycleTimetable.find_closes.to_fs(:govuk_date)})"
   end
 
   def hint_text_for_today_is_after_find_closes
-    "#{I18n.t('cycles.today_is_after_find_closes.description')} (#{CycleTimetable.find_closes.to_formatted_s(:govuk_date)} to #{CycleTimetable.find_reopens.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_after_find_closes.description')} (#{CycleTimetable.find_closes.to_fs(:govuk_date)} to #{CycleTimetable.find_reopens.to_fs(:govuk_date)})"
   end
 
   def hint_text_for_today_is_after_find_opens
-    "#{I18n.t('cycles.today_is_after_find_opens.description')} (#{CycleTimetable.find_reopens.to_formatted_s(:govuk_date)})"
+    "#{I18n.t('cycles.today_is_after_find_opens.description')} (#{CycleTimetable.find_reopens.to_fs(:govuk_date)})"
   end
 end

--- a/app/helpers/current_point_in_recruitment_cycle_helper.rb
+++ b/app/helpers/current_point_in_recruitment_cycle_helper.rb
@@ -1,0 +1,21 @@
+module CurrentPointInRecruitmentCycleHelper
+  def hint_text_for_mid_cycle
+    "#{I18n.t('cycles.today_is_mid_cycle.description')} (#{CycleTimetable.find_opens.to_formatted_s(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)})"
+  end
+
+  def hint_text_for_after_apply_1_deadline_passed
+    "#{I18n.t('cycles.today_is_after_apply_1_deadline_passed.description')} (#{CycleTimetable.apply_1_deadline.to_formatted_s(:govuk_date)} to #{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)})"
+  end
+
+  def hint_text_for_after_apply_2_deadline_passed
+    "#{I18n.t('cycles.today_is_after_apply_2_deadline_passed.description')} (#{CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date)} to #{CycleTimetable.find_closes.to_formatted_s(:govuk_date)})"
+  end
+
+  def hint_text_for_today_is_after_find_closes
+    "#{I18n.t('cycles.today_is_after_find_closes.description')} (#{CycleTimetable.find_closes.to_formatted_s(:govuk_date)} to #{CycleTimetable.find_reopens.to_formatted_s(:govuk_date)})"
+  end
+
+  def hint_text_for_today_is_after_find_opens
+    "#{I18n.t('cycles.today_is_after_find_opens.description')} (#{CycleTimetable.find_opens.next_year.to_formatted_s(:govuk_date)})"
+  end
+end

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -148,79 +148,14 @@ class CycleTimetable
     CYCLE_DATES[year]
   end
 
-  def self.fake_schedules
-    {
-      today_is_mid_cycle: {
-        current_year => {
-          find_opens: 7.days.ago,
-          apply_opens: 6.days.ago,
-          first_deadline_banner: 1.day.ago,
-          apply_1_deadline: 1.day.from_now,
-          apply_2_deadline: 2.days.from_now,
-          find_closes: 3.days.from_now,
-        },
-        next_year => {
-          find_opens: 6.days.from_now,
-          apply_opens: 7.days.from_now,
-        },
-      },
-      today_is_after_apply_1_deadline_passed: {
-        current_year => {
-          find_opens: 7.days.ago,
-          apply_opens: 6.days.ago,
-          first_deadline_banner: 3.days.ago,
-          apply_1_deadline: 1.day.ago,
-          apply_2_deadline: 2.days.from_now,
-          find_closes: 3.days.from_now,
-        },
-        next_year => {
-          find_opens: 6.days.from_now,
-          apply_opens: 7.days.from_now,
-        },
-      },
-      today_is_after_apply_2_deadline_passed: {
-        current_year => {
-          find_opens: 7.days.ago,
-          apply_opens: 6.days.ago,
-          first_deadline_banner: 4.days.ago,
-          apply_1_deadline: 3.days.ago,
-          apply_2_deadline: 1.day.ago,
-          find_closes: 1.day.from_now,
-        },
-        next_year => {
-          find_opens: 6.days.from_now,
-          apply_opens: 7.days.from_now,
-        },
-      },
-      today_is_after_find_closes: {
-        current_year => {
-          find_opens: 7.days.ago,
-          apply_opens: 6.days.ago,
-          first_deadline_banner: 5.days.ago,
-          apply_1_deadline: 4.days.ago,
-          apply_2_deadline: 2.days.ago,
-          find_closes: 1.day.ago,
-        },
-        next_year => {
-          find_opens: 6.days.from_now,
-          apply_opens: 7.days.from_now,
-        },
-      },
-      today_is_after_find_opens: {
-        current_year => {
-          find_opens: 9.days.ago,
-          apply_opens: 8.days.from_now,
-          first_deadline_banner: 7.days.ago,
-          apply_1_deadline: 6.days.ago,
-          apply_2_deadline: 5.days.ago,
-          find_closes: 4.days.ago,
-        },
-        next_year => {
-          find_opens: 1.day.ago,
-          apply_opens: 2.days.from_now,
-        },
-      },
-    }
+  def self.fake_point_in_recruitment_cycle
+    %i[
+      today_is_mid_cycle
+      today_is_after_apply_1_deadline_passed
+      today_is_after_apply_2_deadline_passed
+      today_is_after_find_closes
+      today_is_after_find_opens
+    ]
   end
 
   private_class_method :last_recruitment_cycle_year?

--- a/app/services/cycle_timetable.rb
+++ b/app/services/cycle_timetable.rb
@@ -47,7 +47,7 @@ class CycleTimetable
     end
 
     # If the cycle switcher has been set to 'find has reopened' then
-    # we want request next year's courses from the TTAPI
+    # we want to request next year's courses from the TTAPI
     if SiteSetting.cycle_schedule == :today_is_after_find_opens
       current_year + 1
     else
@@ -92,6 +92,8 @@ class CycleTimetable
   end
 
   def self.find_down?
+    return true if current_cycle_schedule == :today_is_after_find_closes
+
     Time.zone.now.between?(find_closes, find_reopens)
   end
 
@@ -102,25 +104,25 @@ class CycleTimetable
   end
 
   def self.show_apply_1_deadline_banner?
+    return true if current_cycle_schedule == :today_is_mid_cycle
+
     Time.zone.now.between?(first_deadline_banner, apply_1_deadline)
   end
 
   def self.show_apply_2_deadline_banner?
+    return true if current_cycle_schedule == :today_is_after_apply_1_deadline_passed
+
     Time.zone.now.between?(apply_1_deadline, apply_2_deadline)
   end
 
   def self.show_cycle_closed_banner?
+    return true if current_cycle_schedule == :today_is_after_apply_2_deadline_passed
+
     Time.zone.now.between?(apply_2_deadline, find_closes)
   end
 
   def self.date(name, year = current_year)
-    schedule = if current_cycle_schedule == :real
-                 real_schedule_for(year)
-               else
-                 fake_schedules.fetch(current_cycle_schedule).fetch(year)
-               end
-
-    schedule.fetch(name)
+    real_schedule_for(year).fetch(name)
   end
 
   def self.last_recruitment_cycle_year?(year)

--- a/app/views/switcher/cycles.html.erb
+++ b/app/views/switcher/cycles.html.erb
@@ -4,14 +4,13 @@
   <%= form_with model: ChangeCycleForm.new, url: switch_cycle_schedule_path, method: :post do |f| %>
     <%= f.govuk_radio_buttons_fieldset :cycle_schedule_name,
       legend: { text: 'Current point in the recruitment cycle' } do %>
-
       <%= f.govuk_radio_button :cycle_schedule_name, 'real', label: { text: t('cycles.real.name') }, hint: { text: t('cycles.real.description') } %>
-
       <%= f.govuk_radio_divider %>
-
-      <% (CycleTimetable.fake_point_in_recruitment_cycle.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
-        <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
-      <% end %>
+      <%= f.govuk_radio_button :cycle_schedule_name, 'today_is_mid_cycle', label: { text: t('cycles.today_is_mid_cycle.name') }, hint: { text:  hint_text_for_mid_cycle } %>
+      <%= f.govuk_radio_button :cycle_schedule_name, 'today_is_after_apply_1_deadline_passed', label: { text: t('cycles.today_is_after_apply_1_deadline_passed.name') }, hint: { text:  hint_text_for_after_apply_1_deadline_passed } %>
+      <%= f.govuk_radio_button :cycle_schedule_name, 'today_is_after_apply_2_deadline_passed', label: { text: t('cycles.today_is_after_apply_2_deadline_passed.name') }, hint: { text:  hint_text_for_after_apply_2_deadline_passed } %>
+      <%= f.govuk_radio_button :cycle_schedule_name, 'today_is_after_find_closes', label: { text: t('cycles.today_is_after_find_closes.name') }, hint: { text:  hint_text_for_today_is_after_find_closes } %>
+      <%= f.govuk_radio_button :cycle_schedule_name, 'today_is_after_find_opens', label: { text: t('cycles.today_is_after_find_opens.name') }, hint: { text:  hint_text_for_today_is_after_find_opens } %>
     <% end %>
 
     <%= f.govuk_submit 'Update point in recruitment cycle' %>

--- a/app/views/switcher/cycles.html.erb
+++ b/app/views/switcher/cycles.html.erb
@@ -9,7 +9,7 @@
 
       <%= f.govuk_radio_divider %>
 
-      <% (CycleTimetable.fake_schedules.keys.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
+      <% (CycleTimetable.fake_point_in_recruitment_cycle.map(&:to_s) - %w[real]).each_with_index do |option, i | %>
         <%= f.govuk_radio_button :cycle_schedule_name, option, label: { text: t("cycles.#{option}.name") }, hint: { text: t("cycles.#{option}.description") }, link_errors: i.zero? %>
       <% end %>
     <% end %>

--- a/app/views/switcher/cycles.html.erb
+++ b/app/views/switcher/cycles.html.erb
@@ -31,8 +31,6 @@
 
 <h2 class="govuk-heading-m">Deadlines</h2>
 
-<p class="govuk-body">(Today is <%= Time.zone.today.to_formatted_s(:govuk_date) %>)</p>
-
 <%= render Utility::SummaryListComponent.new(rows: {
   'Apply 1 deadline' => CycleTimetable.apply_1_deadline.to_formatted_s(:govuk_date),
   'Apply 2 deadline' => CycleTimetable.apply_2_deadline.to_formatted_s(:govuk_date),


### PR DESCRIPTION
### Context

The dates on the `Current point in the recruitment cycle` are incorrect. This is because we did not know the dates at the time and used random ones. 

### Changes proposed in this pull request

- Update these dates to the real dates that we use in production. 

- Remove todays date.

- Update hint text under ` Current point in the recruitment cycle` for each option to include the new two dates they are now referring to.

### Guidance to review

### Trello card

https://trello.com/c/7FoKmr6z/246-update-dates-on-current-point-in-the-recruitment-cycle-page

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
