### PR TITLE
ignore cloudfront proxy IPs for request.remote_ip

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,6 +93,10 @@ gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.2.1'
 # For outgoing http requests
 gem 'http'
 
+group :production do
+  gem 'cloudfront-rails'
+end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    cloudfront-rails (0.4.0)
+      railties (> 4.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     config (4.0.0)
@@ -571,6 +573,7 @@ DEPENDENCIES
   byebug
   canonical-rails
   capybara (>= 2.15)
+  cloudfront-rails
   config
   dfe-analytics!
   draper


### PR DESCRIPTION
Up until now, when retrieving the IP of the client we've been getting the CloudFront proxy IPs. The `cloudfront-rails` gem retrieves and caches the list of CloudFront IPs, and configures Rails to ignore them when retrieving the client IP via `request.remote_ip`.

This is required by `dfe-analytics` to help us better understand who is
using our services (using psuedo-anonymisation).

### Guidance to review

This has been tested locally by taking the gem line out of the production group, and making a request with X-Forwarded-For headers that include an IP from CloudFront. Without this gem installed, the CloudFront IP is returned by `request.remote_ip`.

```
curl -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" http://localhost:3002/ip
Your IP: 3.11.53.10
```

Without it, this IP is ignored:

```
curl -H "X-Forwarded-For: 123.12.34.123, 3.11.53.10, 10.1.2.3" http://localhost:3002/ip
Your IP: 123.12.34.123
```

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
