### PR TITLE
Remove StatusCake alerts

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -12,24 +12,5 @@
   "key_vault_resource_group": "s121p01-shared-rg",
   "key_vault_name": "s121p01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-PRODUCTION",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
-  "statuscake_alerts": {
-    "find-prod": {
-      "website_name": "find-teacher-training-prod",
-      "website_url": "https://www.find-postgraduate-teacher-training.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [
-        204421
-      ],
-      "trigger_rate": 0,
-      "node_locations": [
-        "UKINT",
-        "UK1",
-        "MAN1",
-        "MAN5",
-        "DUB2"
-      ]
-    }
-  }
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION"
 }

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -12,24 +12,5 @@
   "key_vault_resource_group": "s121d01-shared-rg",
   "key_vault_name": "s121d01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-QA",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
-  "statuscake_alerts": {
-    "find-qa": {
-      "website_name": "find-teacher-training-qa",
-      "website_url": "https://qa.find-postgraduate-teacher-training.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [
-        204421
-      ],
-      "trigger_rate": 0,
-      "node_locations": [
-        "UKINT",
-        "UK1",
-        "MAN1",
-        "MAN5",
-        "DUB2"
-      ]
-    }
-  }
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA"
 }

--- a/terraform/workspace_variables/rollover.tfvars.json
+++ b/terraform/workspace_variables/rollover.tfvars.json
@@ -12,24 +12,5 @@
   "key_vault_resource_group": "s121p01-shared-rg",
   "key_vault_name": "s121p01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-ROLLOVER",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER",
-  "statuscake_alerts": {
-    "find-rollover": {
-      "website_name": "find-teacher-training-rollover",
-      "website_url": "https://find-rollover.london.cloudapps.digital/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [
-        204421
-      ],
-      "trigger_rate": 0,
-      "node_locations": [
-        "UKINT",
-        "UK1",
-        "MAN1",
-        "MAN5",
-        "DUB2"
-      ]
-    }
-  }
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-ROLLOVER"
 }

--- a/terraform/workspace_variables/sandbox.tfvars.json
+++ b/terraform/workspace_variables/sandbox.tfvars.json
@@ -12,24 +12,5 @@
   "key_vault_resource_group": "s121p01-shared-rg",
   "key_vault_name": "s121p01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-SANDBOX",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX",
-  "statuscake_alerts": {
-    "find-sandbox": {
-      "website_name": "find-teacher-training-sandbox",
-      "website_url": "https://sandbox.find-postgraduate-teacher-training.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [
-        204421
-      ],
-      "trigger_rate": 0,
-      "node_locations": [
-        "UKINT",
-        "UK1",
-        "MAN1",
-        "MAN5",
-        "DUB2"
-      ]
-    }
-  }
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-SANDBOX"
 }

--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -12,24 +12,5 @@
   "key_vault_resource_group": "s121t01-shared-rg",
   "key_vault_name": "s121t01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-STAGING",
-  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
-  "statuscake_alerts": {
-    "find-staging": {
-      "website_name": "find-teacher-training-staging",
-      "website_url": "https://staging.find-postgraduate-teacher-training.service.gov.uk/ping",
-      "test_type": "HTTP",
-      "check_rate": 60,
-      "contact_group": [
-        204421
-      ],
-      "trigger_rate": 0,
-      "node_locations": [
-        "UKINT",
-        "UK1",
-        "MAN1",
-        "MAN5",
-        "DUB2"
-      ]
-    }
-  }
+  "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING"
 }


### PR DESCRIPTION
Remove the StatusCake alerts before creating them again with the new StatusCake Terraform provider.

### Context

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
