### PR TITLE
load cloudfront-rails in envs that use CloudFront

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.2.1'
 # For outgoing http requests
 gem 'http'
 
-group :production do
+group :production, :qa, :sandbox, :staging do
   gem 'cloudfront-rails'
 end
 


### PR DESCRIPTION
This allows us to send the correct IPs to the analytics platform.

### Context

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
