### PR TITLE
346 csp external scripts v2

### DIFF
--- a/app/views/layouts/_add_js_enabled_class_to_body.html.erb
+++ b/app/views/layouts/_add_js_enabled_class_to_body.html.erb
@@ -1,0 +1,3 @@
+<%= javascript_tag(nonce: true) do -%>
+  document.body.className = ((document.body.className) ? document.body.className + " js-enabled" : "js-enabled");
+<% end -%>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,9 +20,7 @@
   </head>
 
   <body class="govuk-template__body ">
-    <script>
-      document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
-    </script>
+    <%= render "layouts/add_js_enabled_class_to_body" %>
 
     <% unless hide_cookie_banner? %>
       <% heading_text = 'Cookies on Find postgraduate teacher training' %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,23 +4,38 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap and inline scripts
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
-#
-#   # Report CSP violations to a specified URI. See:
-#   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.font_src    :self, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  'self',
+                       :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
+                       'https://assets.find-postgraduate-teacher-training.service.gov.uk',
+                       'https://www.google-analytics.com',
+                       'https://www.googletagmanager.com'
+
+    policy.connect_src :self,
+                       'https://stats.g.doubleclick.net',
+                       'https://*.sentry.io',
+                       'https://*.google-analytics.com',
+                       'https://*.analytics.google.com'
+
+    policy.style_src   :self,
+                       'https://assets.find-postgraduate-teacher-training.service.gov.uk'
+    policy.frame_src   :self,
+                       'https://www.googletagmanager.com'
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+  #
+  #   # Generate session nonces for permitted importmap and inline scripts
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w[script-src]
+  #
+  #   # Report CSP violations to a specified URI. See:
+  #   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
+  #   # config.content_security_policy_report_only = true
+end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,7 +7,7 @@
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
-    policy.font_src    :self, :data
+    policy.font_src    :self, :data, 'https://*.find-postgraduate-teacher-training.service.gov.uk'
     policy.img_src     :self, :https, :data
     policy.object_src  :none
     policy.script_src  :self,
@@ -21,9 +21,10 @@ Rails.application.configure do
                        'https://*.sentry.io',
                        'https://*.google-analytics.com',
                        'https://*.analytics.google.com'
-    # just a comment
+
     policy.style_src   :self,
                        'https://*.find-postgraduate-teacher-training.service.gov.uk'
+
     policy.frame_src   :self,
                        'https://www.googletagmanager.com'
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
     policy.font_src    :self, :data
     policy.img_src     :self, :https, :data
     policy.object_src  :none
-    policy.script_src  'self',
+    policy.script_src  :self,
                        :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
                        'https://assets.find-postgraduate-teacher-training.service.gov.uk',
                        'https://www.google-analytics.com',

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,8 +12,7 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self,
                        :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
-                       'https://ga-assets.find-postgraduate-teacher-training.service.gov.uk',
-                       'https://assets.find-postgraduate-teacher-training.service.gov.uk',
+                       'https://*.find-postgraduate-teacher-training.service.gov.uk',
                        'https://www.google-analytics.com',
                        'https://www.googletagmanager.com'
 
@@ -24,8 +23,7 @@ Rails.application.configure do
                        'https://*.analytics.google.com'
     # just a comment
     policy.style_src   :self,
-                       'https://ga-assets.find-postgraduate-teacher-training.service.gov.uk',
-                       'https://assets.find-postgraduate-teacher-training.service.gov.uk'
+                       'https://*.find-postgraduate-teacher-training.service.gov.uk'
     policy.frame_src   :self,
                        'https://www.googletagmanager.com'
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
                        'https://*.sentry.io',
                        'https://*.google-analytics.com',
                        'https://*.analytics.google.com'
-
+    # just a comment
     policy.style_src   :self,
                        'https://assets.find-postgraduate-teacher-training.service.gov.uk'
     policy.frame_src   :self,

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,6 +12,7 @@ Rails.application.configure do
     policy.object_src  :none
     policy.script_src  :self,
                        :unsafe_inline, # Backwards compatibility; ignored by modern browsers as we set a nonce for scripts
+                       'https://ga-assets.find-postgraduate-teacher-training.service.gov.uk',
                        'https://assets.find-postgraduate-teacher-training.service.gov.uk',
                        'https://www.google-analytics.com',
                        'https://www.googletagmanager.com'
@@ -23,6 +24,7 @@ Rails.application.configure do
                        'https://*.analytics.google.com'
     # just a comment
     policy.style_src   :self,
+                       'https://ga-assets.find-postgraduate-teacher-training.service.gov.uk',
                        'https://assets.find-postgraduate-teacher-training.service.gov.uk'
     policy.frame_src   :self,
                        'https://www.googletagmanager.com'


### PR DESCRIPTION
### Context
The Git Into Teaching marketing team would like to setup google ads to point to the Find website instead of the current Get into teaching website to improve conversation tracking.

We should setup a content security policy on Find to make sure it only executes script we expect.

What needs to be done
Add a CSP for Find which whitelists scripts from:

Google analytics
Google tag manager
Success
We have a CSP setup

Tech notes
The teaching vacancies app is a good source for an example as they've had to accommodate a similar need for marketing [teaching-vacancies/content_security_policy.rb at main · DFE-Digital/teaching-vacancies](https://github.com/DFE-Digital/teaching-vacancies/blob/main/config/initializers/content_security_policy.rb)

### Changes proposed in this pull request
Add CSP

### Guidance to review
NB self does not include subdomains, eg. 'https://assets.find-postgraduate-teacher-training.service.gov.uk' so they must be wildcarded

### Trello card
[Trello](https://trello.com/c/hWQjYsWh/346-setup-csp-for-external-scripts)
### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
