### PR TITLE
Fix zlib vulnerability CVE-2022-37434

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
-# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libssl1.1 and libcrypto1.1
-RUN apk add --no-cache libcrypto1.1=1.1.1q-r0 libssl1.1=1.1.1q-r0 ncurses-terminfo-base=6.3_p20211120-r1
+# Remove once base image ruby:3.1-alpine3.15 has been updated with latest zlib
+RUN apk add --no-cache zlib=1.2.12-r3
 
 COPY --from=base-image ${FREEDESKTOP_MIME_TYPES_PATH} ${FREEDESKTOP_MIME_TYPES_PATH}
 COPY --from=base-image /app /app


### PR DESCRIPTION
### Context
Snyk highlighted a zlib vulnerability CVE-2022-37434 in the docker image. This adds the fixed package manually until the base image gets updated.

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
