### PR TITLE
Remove manual add of zlib r3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,6 @@ RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
 
-# Remove once base image ruby:3.1-alpine3.15 has been updated with latest zlib
-RUN apk add --no-cache zlib=1.2.12-r3
-
 COPY --from=base-image ${FREEDESKTOP_MIME_TYPES_PATH} ${FREEDESKTOP_MIME_TYPES_PATH}
 COPY --from=base-image /app /app
 COPY --from=base-image /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
### Context

The base package has been updated with r3 therefore we no longer need to
manually add this.

### Changes proposed in this pull request

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
