### PR TITLE
Revert "Bump dfe-analytics from v1.3.2 to v1.4.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'skylight'
 gem 'view_component'
 gem 'govuk-components', '~> 3.0.6'
 
-gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.4.0'
+gem 'dfe-analytics', github: 'DFE-Digital/dfe-analytics', tag: 'v1.3.2'
 
 # For outgoing http requests
 gem 'http'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/DFE-Digital/dfe-analytics.git
-  revision: 6e355be3bd65890887e2cdbc0588ff2a00a892e5
-  tag: v1.4.0
+  revision: 6dc16420e0b5c6b2b722887589b0bc2212798802
+  tag: v1.3.2
   specs:
-    dfe-analytics (1.4.0)
+    dfe-analytics (1.3.2)
       google-cloud-bigquery (~> 1.38)
       request_store_rails (~> 2)
 
@@ -297,7 +297,7 @@ GEM
     jsonapi-renderer (0.2.2)
     jsonapi-serializable (0.3.1)
       jsonapi-renderer (~> 0.2.0)
-    jwt (2.5.0)
+    jwt (2.4.1)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)


### PR DESCRIPTION
Reverts DFE-Digital/find-teacher-training#1482 as it breaks build with:

<img width="1413" alt="Screenshot 2022-09-05 at 12 21 00" src="https://user-images.githubusercontent.com/616080/188437689-cd77b56c-bc3f-4094-95aa-439937dca92e.png">
