### PR TITLE
Bump Terraform to 1.3.1 to fix dependabot errors

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2.3"
+  required_version = "1.2.3"
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
### Context
Dependabot was displaying errors when on 1.2.3 when trying to update the azurerm provider version. Bumping to 1.2.8 didn't work on another repo so moving to the latest 1.3.1 which keeps the compatibility promise with 1.x, and should resolve the error showed in dependabot.

### Changes proposed in this pull request
Bump Terraform to 1.3.1

### Guidance to review

### Trello card
https://trello.com/c/sttrWYO5

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
