### PR TITLE
[614] Put stop gap for UCL's contact form

### DIFF
--- a/app/components/courses/contact_details_component.html.erb
+++ b/app/components/courses/contact_details_component.html.erb
@@ -10,6 +10,15 @@
         </dd>
       <% end %>
 
+      <!-- Temporary stop gap for https://trello.com/c/vJRKI35V/614-stop-gap-ucl-is-moving-away-from-using-email. BIN it as soon as we have a better solution. -->
+      <% if course.provider.provider_code == "U80" %>
+        <% link = "https://www.ucl.ac.uk/prospective-students/graduate/admissions-enquiries" %>
+        <dt class="app-description-list__label">Contact form</dt>
+        <dd data-qa="provider__email">
+          <%= govuk_link_to link, link %>
+        </dd>
+      <% end %>
+
       <% if course.provider.telephone.present? %>
         <dt class="app-description-list__label">Telephone</dt>
         <dd data-qa="provider__telephone">

--- a/app/components/courses/contact_details_component.html.erb
+++ b/app/components/courses/contact_details_component.html.erb
@@ -3,13 +3,6 @@
 
   <div class="course-basicinfo">
     <dl class="app-description-list">
-      <% if course.provider.email.present? %>
-        <dt class="app-description-list__label">Email</dt>
-        <dd data-qa="provider__email">
-          <%= govuk_mail_to course.provider.email, course.provider.email, title: 'Send email to course contact', aria: { label: 'Send email to course contact' } %>
-        </dd>
-      <% end %>
-
       <!-- Temporary stop gap for https://trello.com/c/vJRKI35V/614-stop-gap-ucl-is-moving-away-from-using-email. BIN it as soon as we have a better solution. -->
       <% if course.provider.provider_code == "U80" %>
         <% link = "https://www.ucl.ac.uk/prospective-students/graduate/admissions-enquiries" %>
@@ -17,6 +10,13 @@
         <dd data-qa="provider__email">
           <%= govuk_link_to link, link %>
         </dd>
+      <% else %>
+        <% if course.provider.email.present? %>
+          <dt class="app-description-list__label">Email</dt>
+          <dd data-qa="provider__email">
+            <%= govuk_mail_to course.provider.email, course.provider.email, title: 'Send email to course contact', aria: { label: 'Send email to course contact' } %>
+          </dd>
+        <% end %>
       <% end %>
 
       <% if course.provider.telephone.present? %>


### PR DESCRIPTION
### Context

https://trello.com/c/vJRKI35V/614-stop-gap-ucl-is-moving-away-from-using-email

### Changes proposed in this pull request

<img width="722" alt="Screenshot 2022-10-10 at 11 30 40" src="https://user-images.githubusercontent.com/616080/194846883-50165424-cc6e-4227-aaba-6c55275ada33.png">

### Guidance to review

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
