### PR TITLE
[701] Pin Github actions to the major version

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -50,11 +50,11 @@ runs:
         DEPLOY_ENV: ${{ inputs.environment }}
 
     - name: Use Terraform v1.2.3
-      uses: hashicorp/setup-terraform@v1.3.2
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: 1.2.3
 
-    - uses: azure/login@v1.3.0
+    - uses: azure/login@v1
       id: login_azure
       with:
         creds: ${{ inputs.azure_credentials }}
@@ -97,7 +97,7 @@ runs:
 
     - name: Upload Cypress screenshot and videos
       if:   steps.run_cypress.outcome == 'success' || steps.run_cypress.outcome == 'failure' || steps.run_cypress.outcome == 'cancelled'
-      uses: actions/upload-artifact@v2.3.1
+      uses: actions/upload-artifact@v2
       with:
         name: smoke-test-${{ inputs.environment }}
         path: |

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Set Environment variable
         run: echo "IMAGE_TAG=${{ needs.build.outputs.image_tag }}" >> $GITHUB_ENV
@@ -177,7 +177,7 @@ jobs:
           ref: ${{ needs.build.outputs.image_tag }}
 
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Deploy App to Review environment
         id: deploy_review
@@ -216,7 +216,7 @@ jobs:
         environment: [qa,staging]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Deploy app to ${{ matrix.environment }}
         id: deploy_app_before_production
@@ -238,7 +238,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Deploy app to production
         id: deploy_app
@@ -264,7 +264,7 @@ jobs:
         environment: [sandbox,rollover]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Deploy app to ${{ matrix.environment }}
         id: deploy_app_after_production

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Set Environment variable
         run: |
@@ -48,7 +48,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: github.actor != 'dependabot[bot]'
-        uses: docker/login-action@v2.0.0
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Setup Terraform v1.2.3
-        uses: hashicorp/setup-terraform@v2.0.0
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.2.3
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v3
 
       - name: Deploy App to ${{ github.event.inputs.environment }} environment
         id: deploy_app


### PR DESCRIPTION
### Context
Dependabot is creating too many distracting PRs

### Changes proposed in this pull request
Pin to the major version and let the workflow use the latest minor version

### Guidance to review
Check the workflow run

### Trello card
https://trello.com/c/BYSSVCNY

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
