### PR TITLE
Use subject name not course title for qualifications needed

### DIFF
--- a/app/components/courses/entry_requirements_component.rb
+++ b/app/components/courses/entry_requirements_component.rb
@@ -33,7 +33,7 @@ module Courses
     end
 
     def secondary_advisory(course)
-      "Your degree subject should be in #{course.name} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+      "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
     end
 
     def pending_gcse_content(course)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -17,6 +17,17 @@ class CourseDecorator < Draper::Decorator
     end
   end
 
+  def subject_name_or_names
+    case object.subjects.size
+    when 1
+      object.subjects.first.subject_name
+    when 2
+      "#{object.subjects.first.subject_name} with #{object.subjects.second.subject_name}"
+    else
+      object.name
+    end
+  end
+
   def has_scholarship_and_bursary?
     has_bursary? && has_scholarship?
   end

--- a/spec/components/courses/entry_requirements_component_spec.rb
+++ b/spec/components/courses/entry_requirements_component_spec.rb
@@ -49,11 +49,13 @@ describe Courses::EntryRequirementsComponent, type: :component do
 
   context 'when the provider requires grade 5 and the course is secondary' do
     it 'renders correct message' do
-      course = build(
+      raw_course = build(
         :course,
         provider: build(:provider, provider_code: 'U80'),
         level: 'secondary',
       )
+
+      course = raw_course.decorate
       result = render_inline(described_class.new(course:))
 
       expect(result.text).to include(
@@ -67,12 +69,14 @@ describe Courses::EntryRequirementsComponent, type: :component do
     context 'when the accrediting provider requires grade 5 and the course is secondary' do
       it 'renders correct message' do
         accrediting_provider = build(:provider, provider_code: 'U80')
-        course = build(
+        raw_course = build(
           :course,
           provider: build(:provider),
           accrediting_provider:,
           level: 'secondary',
         )
+
+        course = raw_course.decorate
 
         result = render_inline(described_class.new(course:))
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -160,6 +160,24 @@ describe CourseDecorator do
     end
   end
 
+  describe '#subject_name_or_names' do
+    context 'course has more than one subject' do
+      it "returns both subjects names seperated by a 'with'" do
+        expect(decorated_course.subject_name_or_names).to eq('English with Mathematics')
+      end
+    end
+
+    context 'course has one subject' do
+      subject { build :subject, subject_name: 'Computer Science' }
+
+      let(:course) { build :course, subjects: [subject] }
+
+      it 'return the subject name' do
+        expect(decorated_course.subject_name_or_names).to eq('Computer Science')
+      end
+    end
+  end
+
   describe '#bursary_requirements' do
     subject { decorated_course.bursary_requirements }
 


### PR DESCRIPTION
### Context

Use subject name not course title for qualifications needed to satisfy entry requirements. (This has been done for the new find too [here](https://github.com/DFE-Digital/publish-teacher-training/pull/3077).

The reason for this change is because if support changes the course title, the sentence may not make sense to the candidate.

### Changes proposed in this pull request

Added a new method for this to handle courses with two subjects.

### Guidance to review

- Find a course
- Check the name in this section: `course/{PROVIDER_CODE}/{COURSE_CODE}#section-entry`
- Change the name in support and check the correct subject names still appear. 
- Experiment with multiple subjects


### Trello card

https://trello.com/c/rfYBAaP2/732-pull-through-subject-rather-than-title-into-qualifications-needed-section

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
