### PR TITLE
Implement engineers teach physics filter on Find

### DIFF
--- a/app/view_objects/result_filters/filters_view.rb
+++ b/app/view_objects/result_filters/filters_view.rb
@@ -50,6 +50,10 @@ module ResultFilters
       params[:can_sponsor_visa] == 'true'
     end
 
+    def engineers_teach_physics_checked?
+      params[:engineers_teach_physics] == 'true'
+    end
+
     def has_vacancies_checked?
       params[:hasvacancies] == 'true'
     end

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -95,6 +95,10 @@ class ResultsView
     query_parameters['can_sponsor_visa'].present? && query_parameters['can_sponsor_visa'].downcase == 'true'
   end
 
+  def engineers_teach_physics_courses?
+    query_parameters['engineers_teach_physics'].present? && query_parameters['engineers_teach_physics'].downcase == 'true'
+  end
+
   def number_of_extra_subjects
     return 37 if number_of_subjects_selected == MAXIMUM_NUMBER_OF_SUBJECTS
 
@@ -481,6 +485,7 @@ private
     base_query = base_query.where(study_type:) if study_type.present?
     base_query = base_query.where(degree_grade: degree_grade_types) if degree_required?
     base_query = base_query.where(can_sponsor_visa: true) if visa_courses?
+    base_query = base_query.where(engineers_teach_physics: true) if engineers_teach_physics_courses?
     base_query = base_query.where(qualification: qualification.join(',')) unless all_qualifications?
     base_query = base_query.where(subjects: subject_codes.join(',')) if subject_codes.any?
     base_query = base_query.where(send_courses: true) if send_courses?

--- a/app/views/result_filters/_all.html.erb
+++ b/app/views/result_filters/_all.html.erb
@@ -4,6 +4,7 @@
   </div>
 
   <div class="app-filter__content">
+    <%= render 'result_filters/engineers_teach_physics_filter', form: form %>
     <%= render 'result_filters/send_filter', form: form %>
     <%= render 'result_filters/vacancy_filter', form: form %>
     <%= render 'result_filters/study_type_filter', form: form %>

--- a/app/views/result_filters/_engineers_teach_physics_filter.html.erb
+++ b/app/views/result_filters/_engineers_teach_physics_filter.html.erb
@@ -1,0 +1,18 @@
+<% if params["subject_codes"]&.include?("F3") %>
+  <fieldset class="govuk-fieldset app-filter__group" data-qa="filters__engineers_teach_physics">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Engineers teach physics</legend>
+    <div class="govuk-checkboxes govuk-checkboxes--small">
+      <div class="govuk-checkboxes__item" data-qa="subject">
+        <%= form.check_box(
+              :engineers_teach_physics,
+              { checked: @filters_view.engineers_teach_physics_checked?, data: { qa: 'engineers_teach_physics__checkbox' }, class: 'govuk-checkboxes__input' },
+              'true',
+              nil,
+              ) %>
+        <%= form.label(:subjects, :engineers_teach_physics, class: 'govuk-label govuk-checkboxes__label') do %>
+          Only show Engineers teach physics courses
+        <% end %>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/spec/features/result_page_filters/engineers_teach_physics_spec.rb
+++ b/spec/features/result_page_filters/engineers_teach_physics_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+RSpec.feature 'Engineers teach physics' do
+  include StubbedRequests::SubjectAreas
+  include StubbedRequests::Courses
+  include StubbedRequests::Subjects
+  include FiltersFeatureSpecsHelper
+
+  let(:location_page) { PageObjects::Page::Search::Location.new }
+  let(:start_page) { PageObjects::Page::Start.new }
+  let(:age_group_page) { PageObjects::Page::Search::AgeGroup.new }
+  let(:subject_page) { PageObjects::Page::Search::SubjectPage.new }
+
+  before do
+    stub_subjects
+    stub_subject_areas
+
+    given_i_visit_the_start_page
+    when_i_select_the_across_england_radio_button
+    and_i_click_continue
+    and_i_select_the_secondary_radio_button
+    and_i_click_continue
+  end
+
+  scenario 'Candidate searches for physics subject' do
+    stub_courses_request('F3')
+    and_i_select_the_secondary_subject('Physics')
+    and_i_click_find_courses
+    then_i_see_that_the_etp_checkbox_is_unchecked
+  end
+
+  scenario 'Candidate searches for any other subject' do
+    stub_courses_request('W1')
+    and_i_select_the_secondary_subject('Art and design')
+    and_i_click_find_courses
+    then_i_dont_see_the_etp_checkbox
+  end
+
+  def given_i_visit_the_start_page
+    start_page.load
+  end
+
+  def when_i_select_the_across_england_radio_button
+    location_page.across_england.choose
+  end
+
+  def and_i_click_continue
+    click_button 'Continue'
+  end
+
+  def and_i_select_the_secondary_radio_button
+    age_group_page.secondary.choose
+  end
+
+  def and_i_select_the_secondary_subject(subject)
+    check subject
+  end
+
+  def and_i_click_find_courses
+    subject_page.find_courses.click
+  end
+
+  def stub_courses_request(subject)
+    stub_courses(query: results_page_parameters({ 'filter[subjects]' => subject }), course_count: 10)
+  end
+
+  def then_i_see_that_the_etp_checkbox_is_unchecked
+    expect(results_page.engineers_teach_physics_filter.legend.text).to eq('Engineers teach physics')
+    expect(results_page.engineers_teach_physics_filter.checkbox.checked?).to be(false)
+    expect(results_page).to have_text('Only show Engineers teach physics courses')
+  end
+
+  def then_i_dont_see_the_etp_checkbox
+    expect(results_page).not_to have_text('Only show Engineers teach physics courses')
+  end
+end

--- a/spec/support/page_objects/page/results.rb
+++ b/spec/support/page_objects/page/results.rb
@@ -70,6 +70,11 @@ module PageObjects
         element :checkbox, 'input[name="can_sponsor_visa"]'
       end
 
+      class EngineersTeachPhysicsSection < SitePrism::Section
+        element :legend, 'legend'
+        element :checkbox, 'input[name="engineers_teach_physics"]'
+      end
+
       class FundingSection < SitePrism::Section
         element :legend, 'legend'
         element :checkbox, 'input[name="funding"]'
@@ -99,6 +104,7 @@ module PageObjects
       section :degree_required_filter, RequiredDegreeSection, '[data-qa="filters__degree_required"]'
       section :send_filter, SendSection, '[data-qa="filters__send"]'
       section :visa_filter, VisaSection, '[data-qa="filters__visa"]'
+      section :engineers_teach_physics_filter, EngineersTeachPhysicsSection, '[data-qa="filters__engineers_teach_physics"]'
       section :area_and_provider_filter, LocationAndProviderSection, '[data-qa="filters__area_and_provider"]'
 
       element :heading, '[data-qa="heading"]'

--- a/spec/support/page_objects/page/search/age_group.rb
+++ b/spec/support/page_objects/page/search/age_group.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Page
+    module Search
+      class AgeGroup < SitePrism::Page
+        set_url '/results/filter/age-groups{?query*}'
+
+        element :secondary, '#search-age-groups-form-age-group-secondary-field'
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/page/search/subject_page.rb
+++ b/spec/support/page_objects/page/search/subject_page.rb
@@ -24,7 +24,7 @@ module PageObjects
 
         sections :subject_areas, SubjectAreaSection, '[data-qa="subject_area"]'
         section :send_area, SubjectAreaSection, '[data-qa="send_area"]'
-        element :continue, '[data-qa="continue"]'
+        element :find_courses, '.govuk-button'
       end
     end
   end


### PR DESCRIPTION
### Context

In line with the "Engineers teach physics" work, we are adding a filter on Find to search for only these courses. This filter will appear when searching for the "Physics" subject.

These are the frontend changes, see: https://github.com/DFE-Digital/publish-teacher-training/pull/3086 for the backend changes.

### Changes proposed in this pull request

- Add UI for filter checkbox
- Only render the checkbox if the "Physics" subject has been chosen

### Guidance to review

- Checkout this branch along with the respective branch on the TTAPI [here](https://github.com/DFE-Digital/publish-teacher-training/pull/3086)
- Perform a search for a Physics course on Find
- Try out the new filter

### Trello card

https://trello.com/c/BkHrpSF2/733-add-etp-filter-to-find

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
