### PR TITLE
State the 3-year residency rule for apprenticeship courses

### DIFF
--- a/app/components/courses/international_students_component.html.erb
+++ b/app/components/courses/international_students_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-international-students">International candidates</h2>
   <div data-qa="course__international_students">
-    <% if course_is_apprenticeship %>
+    <% if course.apprenticeship? %>
       <p class="govuk-body">To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course.</p>
 
       <p class="govuk-body">EEA nationals with settled or pre-settled status under the
@@ -9,7 +9,7 @@
         EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
     <% end %>
 
-    <p class="govuk-body">You’ll <%= 'also' if course_is_apprenticeship %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+    <p class="govuk-body">You’ll <%= 'also' if course.apprenticeship? %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>

--- a/app/components/courses/international_students_component.html.erb
+++ b/app/components/courses/international_students_component.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-international-students">International candidates</h2>
   <div data-qa="course__international_students">
-    <% if course.apprenticeship? %>
+    <% if apprenticeship? %>
       <p class="govuk-body">To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course.</p>
 
       <p class="govuk-body">EEA nationals with settled or pre-settled status under the
@@ -9,7 +9,7 @@
         EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
     <% end %>
 
-    <p class="govuk-body"><%= course.apprenticeship? ? 'You’ll also' : 'You’ll' %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+    <p class="govuk-body"><%= apprenticeship? ? 'You’ll also' : 'You’ll' %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>

--- a/app/components/courses/international_students_component.html.erb
+++ b/app/components/courses/international_students_component.html.erb
@@ -9,7 +9,7 @@
         EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
     <% end %>
 
-    <p class="govuk-body">You’ll <%= 'also' if course.apprenticeship? %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+    <p class="govuk-body"><%= course.apprenticeship? ? 'You’ll also' : 'You’ll' %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>

--- a/app/components/courses/international_students_component.html.erb
+++ b/app/components/courses/international_students_component.html.erb
@@ -1,8 +1,15 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-international-students">International candidates</h2>
   <div data-qa="course__international_students">
+    <% if course_is_apprenticeship %>
+      <p class="govuk-body">To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course.</p>
 
-    <p class="govuk-body">You’ll need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
+      <p class="govuk-body">EEA nationals with settled or pre-settled status under the
+        <%= govuk_link_to('EU Settlement Scheme', 'https://www.gov.uk/settled-status-eu-citizens-families') %> who have lived continuously in the
+        EEA, Switzerland, Gibraltar, or the UK for at least the previous 3 years will also be eligible.</p>
+    <% end %>
+
+    <p class="govuk-body">You’ll <%= 'also' if course_is_apprenticeship %> need the <%= right_required %> in the UK. You already have this if, for example, you:</p>
 
     <ul class="govuk-list govuk-list--bullet">
       <li>are an Irish citizen</li>

--- a/app/components/courses/international_students_component.rb
+++ b/app/components/courses/international_students_component.rb
@@ -24,5 +24,9 @@ module Courses
     def sponsorship_availability
       @sponsorship_availability ||= course.public_send("can_sponsor_#{visa_type}") ? :available : :not_available
     end
+
+    def course_is_apprenticeship
+      @course.apprenticeship?
+    end
   end
 end

--- a/app/components/courses/international_students_component.rb
+++ b/app/components/courses/international_students_component.rb
@@ -4,6 +4,8 @@ module Courses
 
     attr_reader :course
 
+    delegate :apprenticeship?, to: :course
+
     def initialize(course:)
       super
       @course = course
@@ -23,10 +25,6 @@ module Courses
 
     def sponsorship_availability
       @sponsorship_availability ||= course.public_send("can_sponsor_#{visa_type}") ? :available : :not_available
-    end
-
-    def course_is_apprenticeship
-      @course.apprenticeship?
     end
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -90,7 +90,7 @@ class CourseDecorator < Draper::Decorator
   end
 
   def apprenticeship?
-    object.funding_type == 'apprenticeship' ? 'Yes' : 'No'
+    object.funding_type == 'apprenticeship'
   end
 
   def length

--- a/spec/components/courses/international_students_component_spec.rb
+++ b/spec/components/courses/international_students_component_spec.rb
@@ -12,7 +12,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to study' do
-      expect(rendered_component).to have_text('You’ll need the right to study in the UK')
+      expect(rendered_component).to have_text('You’ll  need the right to study in the UK')
     end
 
     it 'tells candidates sponsorship is not available' do
@@ -31,11 +31,19 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to study' do
-      expect(rendered_component).to have_text('You’ll need the right to study in the UK')
+      expect(rendered_component).to have_text('You’ll  need the right to study in the UK')
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
       expect(rendered_component).to have_text('Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
+    end
+
+    it 'does not tell candidates the 3-year residency rule' do
+      expect(rendered_component).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+    end
+
+    it 'does not tell candidates about settled and pre-settled status' do
+      expect(rendered_component).not_to have_text('EEA nationals with settled or pre-settled status under the')
     end
   end
 
@@ -50,7 +58,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
+      expect(rendered_component).to have_text('You’ll  need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
@@ -69,11 +77,37 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
+      expect(rendered_component).to have_text('You’ll  need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship is not available' do
       expect(rendered_component).to have_text('Sponsorship is not available for this course')
+    end
+
+    it 'does not tell candidates the 3-year residency rule' do
+      expect(rendered_component).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+    end
+
+    it 'does not tell candidates about settled and pre-settled status' do
+      expect(rendered_component).not_to have_text('EEA nationals with settled or pre-settled status under the')
+    end
+  end
+
+  context 'when the course is an apprenticeship' do
+    before do
+      course = build(
+        :course,
+        funding_type: 'apprenticeship',
+      )
+      render_inline(described_class.new(course: CourseDecorator.new(course)))
+    end
+
+    it 'tells candidates the 3-year residency rule' do
+      expect(rendered_component).to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+    end
+
+    it 'tells candidates about settled and pre-settled status' do
+      expect(rendered_component).to have_text('EEA nationals with settled or pre-settled status under the')
     end
   end
 end

--- a/spec/components/courses/international_students_component_spec.rb
+++ b/spec/components/courses/international_students_component_spec.rb
@@ -12,7 +12,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to study' do
-      expect(rendered_component).to have_text('You’ll  need the right to study in the UK')
+      expect(rendered_component).to have_text('You’ll need the right to study in the UK')
     end
 
     it 'tells candidates sponsorship is not available' do
@@ -31,7 +31,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to study' do
-      expect(rendered_component).to have_text('You’ll  need the right to study in the UK')
+      expect(page.text).to have_text('You’ll need the right to study in the UK')
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
@@ -58,7 +58,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll  need the right to work in the UK')
+      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
@@ -77,7 +77,7 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll  need the right to work in the UK')
+      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship is not available' do

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -52,7 +52,7 @@ describe CourseDecorator do
   end
 
   it 'returns if course is an apprenticeship' do
-    expect(decorated_course.apprenticeship?).to eq('No')
+    expect(decorated_course.apprenticeship?).to be(false)
   end
 
   it 'returns course length' do


### PR DESCRIPTION
### Context

State the 3-year residency rule for apprenticeship courses.

### Changes proposed in this pull request

- Change the `apprenticeship?` method to return true or false (previously unused)
- Utilise this in the view component to render the 3-year text if the course is an apprenticeship
- Add the word `also` if the course is an apprenticeship (as there is content before this now).

### Guidance to review

- Check `#section-international-students` for apprenticeship courses and ensure the new content is there and is correct.
- Repeat for fee paying and salaried courses and ensure the new content is not present. 

### Trello card

https://trello.com/c/ib4fAScn/756-update-guidance-for-international-candidates

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
