### PR TITLE
Remove subjects from ignored list

### DIFF
--- a/app/form_objects/search/subjects_form.rb
+++ b/app/form_objects/search/subjects_form.rb
@@ -6,9 +6,6 @@ module Search
 
     validates :subject_codes, presence: true
 
-    # These subjects don’t currently match any courses, and so can be dropped.
-    IGNORED_SUBJECTS = ['Philosophy', 'Modern Languages', 'Ancient Hebrew', 'Ancient Greek'].freeze
-
     def primary_subjects
       primary_subjects = subject_areas.find { |sa| sa.id == 'PrimarySubject' }.subjects
 
@@ -19,7 +16,7 @@ module Search
 
     def secondary_subjects
       secondary_subjects = subject_areas.find { |sa| sa.id == 'SecondarySubject' }.subjects
-        .reject { |sa| IGNORED_SUBJECTS.include?(sa.subject_name) }
+        .reject { |sa| ['Modern Languages'].include?(sa.subject_name) }
       modern_languages_subjects = subject_areas.find { |sa| sa.id == 'ModernLanguagesSubject' }.subjects
 
       (secondary_subjects + modern_languages_subjects).sort_by(&:subject_name)

--- a/spec/features/search/new_flow/across_england/secondary_spec.rb
+++ b/spec/features/search/new_flow/across_england/secondary_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature 'Searching across England' do
     when_i_select_the_secondary_radio_button
     and_i_click_continue
     then_i_should_see_the_subjects_form
-    and_i_should_not_see_hidden_subjects
+    and_i_should_not_see_modern_languages
     and_the_correct_subjects_form_page_url_and_query_params_are_present
 
     when_i_click_back
@@ -89,9 +89,7 @@ RSpec.feature 'Searching across England' do
     expect(page).to have_content('Which secondary subjects do you want to teach?')
   end
 
-  def and_i_should_not_see_hidden_subjects
-    expect(page).not_to have_content('Ancient Hebrew')
-    expect(page).not_to have_content('Philosophy')
+  def and_i_should_not_see_modern_languages
     expect(page).not_to have_content('Modern Languages')
   end
 


### PR DESCRIPTION
### Context

Remove Ancient greek, Hebrew and Philosophy from the ignored list. We handle empty states on the course list, not by hiding subjects.

### Changes proposed in this pull request

- Remove the `IGNORED_SUBJECTS` array and only reject modern languages.

### Guidance to review

- Perform a search on Find and ensure that you now see Ancient greek, Hebrew and Philosophy (you should see no courses with these subjects).
- Create these courses and search for them and ensure the courses created appear in the search.

### Trello card

https://trello.com/c/sm9C5o55/776-add-ancient-greek-ancient-hebrew-and-philosophy-back-to-subjects-list-in-find

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
