### PR TITLE
Don't capitalise subjects unless the subject is a language

### DIFF
--- a/app/components/courses/entry_requirements_component.rb
+++ b/app/components/courses/entry_requirements_component.rb
@@ -35,7 +35,7 @@ module Courses
     end
 
     def secondary_advisory(course)
-      "Your degree subject should be in #{course.subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
+      "Your degree subject should be in #{course.computed_subject_name_or_names} or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way."
     end
 
     def pending_gcse_content(course)

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -17,14 +17,18 @@ class CourseDecorator < Draper::Decorator
     end
   end
 
-  def subject_name_or_names
-    case object.subjects.size
-    when 1
-      object.subjects.first.subject_name
-    when 2
-      "#{object.subjects.first.subject_name} with #{object.subjects.second.subject_name}"
+  def computed_subject_name_or_names
+    language_subjects_codes = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
+
+    if number_of_subjects(1) && language_subjects_codes.include?(object.subjects.first.subject_code)
+      first_subject_name(object)
+    elsif number_of_subjects(1) && language_subjects_codes.exclude?(object.subjects.first.subject_code)
+      first_subject_name(object).downcase
+    elsif number_of_subjects(2)
+      transformed_subjects = object.subjects.map { |subject| language_subjects_codes.include?(subject.subject_code) ? subject.subject_name : subject.subject_name.downcase }
+      "#{transformed_subjects.first} with #{transformed_subjects.second}"
     else
-      object.name
+      object.name.gsub('Modern Languages', 'modern languages')
     end
   end
 
@@ -170,5 +174,13 @@ private
     return false unless /with/.match?(object.name)
 
     exclusions.any? { |e| e.match?(object.name) }
+  end
+
+  def number_of_subjects(number)
+    object.subjects.size == number
+  end
+
+  def first_subject_name(object)
+    object.subjects.first.subject_name
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -1,6 +1,8 @@
 class CourseDecorator < Draper::Decorator
   delegate_all
 
+  LANGUAGE_SUBJECT_CODES = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
+
   def name_and_code
     "#{object.name} (#{object.course_code})"
   end
@@ -18,14 +20,12 @@ class CourseDecorator < Draper::Decorator
   end
 
   def computed_subject_name_or_names
-    language_subjects_codes = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
-
-    if (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.include?(object.subjects.first.subject_code)
-      first_subject_name(object)
-    elsif (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.exclude?(object.subjects.first.subject_code)
-      first_subject_name(object).downcase
-    elsif number_of_subjects(2)
-      transformed_subjects = object.subjects.map { |subject| language_subjects_codes.include?(subject.subject_code) ? subject.subject_name : subject.subject_name.downcase }
+    if (number_of_subjects == 1 || modern_languages_other?) && LANGUAGE_SUBJECT_CODES.include?(subjects.first.subject_code)
+      first_subject_name
+    elsif (number_of_subjects == 1 || modern_languages_other?) && LANGUAGE_SUBJECT_CODES.exclude?(subjects.first.subject_code)
+      first_subject_name.downcase
+    elsif number_of_subjects == 2
+      transformed_subjects = subjects.map { |subject| LANGUAGE_SUBJECT_CODES.include?(subject.subject_code) ? subject.subject_name : subject.subject_name.downcase }
       "#{transformed_subjects.first} with #{transformed_subjects.second}"
     else
       object.name.gsub('Modern Languages', 'modern languages')
@@ -176,15 +176,23 @@ private
     exclusions.any? { |e| e.match?(object.name) }
   end
 
-  def number_of_subjects(number)
-    object.subjects.size == number
+  def number_of_subjects
+    subjects.size
   end
 
-  def first_subject_name(object)
-    object.subjects.first.subject_name
+  def first_subject_name
+    subjects.first.subject_name
   end
 
-  def modern_languages_other(object)
-    object.subjects.any? { |subject| subject.subject_code == '24' }
+  def modern_languages_other?
+    subjects.any? { |subject| subject.subject_code == modern_languages_other_id }
+  end
+
+  def modern_languages_other_id
+    '24'
+  end
+
+  def main_subject_is_modern_languages?
+    main_subject.id == SecondarySubject.modern_languages.id
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -20,9 +20,9 @@ class CourseDecorator < Draper::Decorator
   def computed_subject_name_or_names
     language_subjects_codes = %w[Q3 A0 15 16 17 18 19 20 21 22].freeze
 
-    if number_of_subjects(1) && language_subjects_codes.include?(object.subjects.first.subject_code)
+    if (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.include?(object.subjects.first.subject_code)
       first_subject_name(object)
-    elsif number_of_subjects(1) && language_subjects_codes.exclude?(object.subjects.first.subject_code)
+    elsif (number_of_subjects(1) || modern_languages_other(object)) && language_subjects_codes.exclude?(object.subjects.first.subject_code)
       first_subject_name(object).downcase
     elsif number_of_subjects(2)
       transformed_subjects = object.subjects.map { |subject| language_subjects_codes.include?(subject.subject_code) ? subject.subject_name : subject.subject_name.downcase }
@@ -182,5 +182,9 @@ private
 
   def first_subject_name(object)
     object.subjects.first.subject_name
+  end
+
+  def modern_languages_other(object)
+    object.subjects.any? { |subject| subject.subject_code == '24' }
   end
 end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -212,6 +212,16 @@ describe CourseDecorator do
         expect(decorated_course.computed_subject_name_or_names).to eq('modern languages with French')
       end
     end
+
+    context 'course is modern languages (other)' do
+      subject { build(:subject, :modern_languages) }
+
+      let(:course) { build(:course, subjects: [subject, build(:subject, subject_name: 'Modern languages (other)', subject_code: '24')]) }
+
+      it 'return one modern languages' do
+        expect(decorated_course.computed_subject_name_or_names).to eq('modern languages')
+      end
+    end
   end
 
   describe '#bursary_requirements' do

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -179,7 +179,7 @@ describe CourseDecorator do
   describe '#subject_name_or_names' do
     context 'course has more than one subject' do
       it "returns both subjects names seperated by a 'with'" do
-        expect(decorated_course.subject_name_or_names).to eq('English with Mathematics')
+        expect(decorated_course.computed_subject_name_or_names).to eq('English with mathematics')
       end
     end
 
@@ -189,7 +189,27 @@ describe CourseDecorator do
       let(:course) { build(:course, subjects: [subject]) }
 
       it 'return the subject name' do
-        expect(decorated_course.subject_name_or_names).to eq('Computer Science')
+        expect(decorated_course.computed_subject_name_or_names).to eq('computer science')
+      end
+    end
+
+    context 'course has a language subject' do
+      subject { build(:subject, :english) }
+
+      let(:course) { build(:course, subjects: [subject]) }
+
+      it 'return the capitalised subject name' do
+        expect(decorated_course.computed_subject_name_or_names).to eq('English')
+      end
+    end
+
+    context 'course is modern languages' do
+      subject { build(:subject, :modern_languages) }
+
+      let(:course) { build(:course, subjects: [subject, build(:subject, :french)]) }
+
+      it 'return lowercase modern languages and capitalised language' do
+        expect(decorated_course.computed_subject_name_or_names).to eq('modern languages with French')
       end
     end
   end


### PR DESCRIPTION
### Context

In the entry requirements section, subjects which are also not a language should not be capitalised. 

### Screenshot

<img width="673" alt="image" src="https://user-images.githubusercontent.com/50492247/201092397-29b4b1db-fdc5-4970-9e4d-cc76eaa85bef.png">


### Changes proposed in this pull request

- Add the subject codes which are a language to an array.
- Use this array to downcase all other subject names in the view.
- Ensure modern languages is not capitalised (using gsub).

### Guidance to review

- View the entry requirements on courses with the following criteria, and ensure the capitalisation is correct.
- A course with a single language subject, e.g https://find-pr-1591.london.cloudapps.digital/course/2CG/W273#section-entry
- A course with a single non language subject, e.g https://find-pr-1591.london.cloudapps.digital/course/2CG/Q774#section-entry
- A course with two subjects, one language and one non language, e.g: https://find-pr-1591.london.cloudapps.digital/course/M80/2N9G#section-entry
- A modern languages course, e.g: https://find-pr-1591.london.cloudapps.digital/course/2BD/33P3#section-entry
- A modern languages other course, e.g: https://find-pr-1591.london.cloudapps.digital/course/1MN/27YL#section-entry

### Trello card

https://trello.com/c/DF7m5hX6/786-change-subject-to-lower-case-in-qualifications-needed-section

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
