### PR TITLE
[0780] Sort by training provider in search results not working

### DIFF
--- a/app/components/results/sort_by_component.html.erb
+++ b/app/components/results/sort_by_component.html.erb
@@ -2,7 +2,7 @@
   <% if results.location_filter? %>
     <p class="govuk-body">Sorted by distance</p>
   <% else %>
-    <%= form_with(url: results_path, method: 'get', skip_enforcing_utf8: true, class: 'app-search-results-header__sort', data: { qa: 'sort-form' }) do |form| %>
+    <%= form_with(id: :sortby_form, url: results_path, method: 'get', skip_enforcing_utf8: true, class: 'app-search-results-header__sort', data: { qa: 'sort-form' }) do |form| %>
       <%= render 'shared/hidden_fields', form: form, exclude_keys: %w[sortby] %>
       <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
       <%= form.select(
@@ -11,7 +11,6 @@
         {},
         {
           class: 'govuk-select',
-          onchange: 'this.form.submit()',
           role: 'listbox',
           data: { qa: 'sort-form__options' },
         },

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -171,7 +171,7 @@ class ResultsView
                    else
                      base_query
                        .order('provider.provider_name': results_order)
-                       .order(name: results_order)
+                       .order(name: :asc)
                    end
 
       base_query

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -57,4 +57,4 @@ loadAnalytics();
 
 new initCookieBanner();
 
-initSortBy({sortby_form_id: "sortby_form", sortby_form_select_class: "govuk-select"});
+initSortBy({sortbyFormId: "sortby_form", sortbyFormSelectClass: "govuk-select"});

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -11,6 +11,7 @@ import initAutocomplete from "scripts/autocomplete";
 import {initCachedProvidersAutocomplete} from "scripts/cached-providers-autocomplete";
 import toggle from "scripts/toggle";
 import { FilterToggleButton } from "scripts/filter-toggle-button"
+import initSortBy from "scripts/sort-by"
 import { loadAnalytics } from "scripts/analytics.js";
 import initCookieBanner from "scripts/cookie-banner";
 
@@ -55,3 +56,5 @@ initCachedProvidersAutocomplete();
 loadAnalytics();
 
 new initCookieBanner();
+
+initSortBy({sortby_form_id: "sortby_form", sortby_form_select_class: "govuk-select"});

--- a/app/webpacker/scripts/sort-by.js
+++ b/app/webpacker/scripts/sort-by.js
@@ -1,24 +1,18 @@
-const initSortBy = ({sortby_form_id, sortby_form_select_class}) => {
-  const sortby_form = document.getElementById(sortby_form_id);
+const initSortBy = ({sortbyFormId, sortbyFormSelectClass}) => {
+  const sortby_form = document.getElementById(sortbyFormId);
   if (!sortby_form) return;
 
-  const sort_by_form_select = sortby_form.getElementsByClassName(sortby_form_select_class)[0];
-
+  const sortByFormSelect = sortby_form.getElementsByClassName(sortbyFormSelectClass)[0];
 
   try {
-    if(sort_by_form_select) {
-      sort_by_form_select.onchange = () => {
-        console.log("asasd")
-        sortby_form.submit();}
+    if(sortByFormSelect) {
+      sortByFormSelect.onchange = () => {
+        sortby_form.submit();
+      }
     }
   } catch(err) {
-    console.error(`Failed to initialise ${sortby_form_select_id} sort by:`, err);
+    console.error(`Failed to initialise ${sortbyFormSelectClass} sort by:`, err);
   }
 };
 
 export default initSortBy;
-
-
-
-
-

--- a/app/webpacker/scripts/sort-by.js
+++ b/app/webpacker/scripts/sort-by.js
@@ -1,0 +1,24 @@
+const initSortBy = ({sortby_form_id, sortby_form_select_class}) => {
+  const sortby_form = document.getElementById(sortby_form_id);
+  if (!sortby_form) return;
+
+  const sort_by_form_select = sortby_form.getElementsByClassName(sortby_form_select_class)[0];
+
+
+  try {
+    if(sort_by_form_select) {
+      sort_by_form_select.onchange = () => {
+        console.log("asasd")
+        sortby_form.submit();}
+    }
+  } catch(err) {
+    console.error(`Failed to initialise ${sortby_form_select_id} sort by:`, err);
+  }
+};
+
+export default initSortBy;
+
+
+
+
+

--- a/app/webpacker/scripts/sort-by.spec.js
+++ b/app/webpacker/scripts/sort-by.spec.js
@@ -22,7 +22,7 @@ describe('initSortBy', () => {
 
       expect(document.querySelector(".govuk-select").onchange).toBeNull();
 
-      initSortBy({sortby_form_id: "form", sortby_form_select_class: "govuk-select"});
+      initSortBy({sortbyFormId: "form", sortbyFormSelectClass: "govuk-select"});
 
       expect(document.querySelector(".govuk-select").onchange).toBeTruthy();
     })

--- a/app/webpacker/scripts/sort-by.spec.js
+++ b/app/webpacker/scripts/sort-by.spec.js
@@ -1,0 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import initSortBy from "./sort-by";
+
+const templateHTML = `
+        <form id="form">
+          <select class="govuk-select">
+            <option value>Select a option</option>
+          </select>
+        </form>`;
+
+describe('initSortBy', () => {
+
+  beforeEach(() => {
+    document.body.innerHTML = templateHTML
+  })
+
+  describe('onchange ', () => {
+    it('has been attached', () => {
+
+      expect(document.querySelector(".govuk-select").onchange).toBeNull();
+
+      initSortBy({sortby_form_id: "form", sortby_form_select_class: "govuk-select"});
+
+      expect(document.querySelector(".govuk-select").onchange).toBeTruthy();
+    })
+  })
+})

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -41,7 +41,7 @@ describe 'results' do
 
     let(:descending_stub) do
       stub_courses(
-        query: results_page_parameters('sort' => '-provider.provider_name,-name'),
+        query: results_page_parameters('sort' => '-provider.provider_name,name'),
         course_count: 10,
       )
     end
@@ -62,7 +62,7 @@ describe 'results' do
     end
 
     context 'descending' do
-      let(:sort) { '-provider.provider_name,-name' }
+      let(:sort) { '-provider.provider_name,name' }
       let(:params) { { sortby: '1', l: '2' } }
 
       it 'requests that the backend sorts the data' do


### PR DESCRIPTION
### Context

Sort by training provider in search results not working

### Changes proposed in this pull request
Fixed js issues
Amended course ordering

### Guidance to review


![image](https://user-images.githubusercontent.com/470137/201902061-7320a94f-4bd9-48fe-8332-b22f46835fff.png)


When sorting by training provider ascending
Then sort by provider ascending (a to z)
and sort by course name ascending (a to z)

When sorting by training provider descending
Then sort by provider descending (z to a)
and sort by course name ascending (a to z)


See 
https://find-pr-1600.london.cloudapps.digital/results?age_group=secondary&fulltime=false&hasvacancies=true&l=2&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&senCourses=false&subject_codes%5B%5D=08&subject_codes%5B%5D=11&sortby=1

Uses 
https://github.com/DFE-Digital/publish-teacher-training/pull/3128

### Trello card

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
