### PR TITLE
[799] Update the privacy notice

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -151,7 +151,7 @@
               <%= link_to 'Cookies', cookie_preferences_path, class: 'govuk-footer__link' %>
             </li>
             <li class="govuk-footer__inline-list-item">
-              <%= link_to 'Privacy policy', privacy_path, class: 'govuk-footer__link' %>
+              <%= link_to 'Privacy', privacy_path, class: 'govuk-footer__link' %>
             </li>
             <li class="govuk-footer__inline-list-item">
               <%= link_to 'Terms and conditions', terms_path, class: 'govuk-footer__link' %>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,8 +1,8 @@
-<% content_for :page_title, "Privacy notice" %>
+<% content_for :page_title, "Find postgraduate teacher training privacy notice" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Privacy notice</h1>
+    <h1 class="govuk-heading-xl">Find postgraduate teacher training privacy notice</h1>
 
     <h2 class="govuk-heading-l">Who we are</h2>
     <p class="govuk-body">

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -1,52 +1,71 @@
-<%= content_for :page_title, 'Privacy policy' %>
+<% content_for :page_title, "Privacy notice" %>
 
-<div class="govuk-width-container">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">Privacy policy</h1>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl">Privacy notice</h1>
 
-      <h2 class="govuk-heading-l">Who we are</h2>
-      <p class="govuk-body">This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of ‘Find postgraduate teacher training’.</p>
+    <h2 class="govuk-heading-l">Who we are</h2>
+    <p class="govuk-body">
+      This work is being carried out by Department for Education (DfE) Digital, which is a part of DfE. For the purpose of data protection legislation, the DfE is the data controller for the personal data processed as part of Find postgraduate teacher training (&#8216;Find&#8217;).
+    </p>
 
-      <h2 class="govuk-heading-l">How we will use your information</h2>
-      <p class="govuk-body">We receive your personal data in the form of your IP address and are processing it in order to track traffic to the service and continuously improve our service to better meet users’ needs. In some instances, we may also collect your email address for similar purposes. More information about this work is available if you wish to contact us at <%= bat_contact_mail_to %>.</p>
+    <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+    <p class="govuk-body">In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this service, this processing is necessary to complete a task in the public interest.</p>
 
-      <h3 class="govuk-heading-m">The nature of your personal data we will be using</h3>
-      <p class="govuk-body">The categories of your personal data that we will be using for this project are: IP address and contact information - email address.</p>
+    <h2 class="govuk-heading-l">How we will use your information</h2>
+    <p class="govuk-body">
+      We receive your personal data in the form of your IP address and any postcode which you use to search for courses on the service. We use it to track traffic to the service and continuously improve our service to better meet users&#8217; needs.
+    </p>
+    <p class="govuk-body">
+      If you use other digital services for which the data controller is also the DfE (for example, Apply for postgraduate teacher training, or a Get Into Teaching service), we may use your IP address to understand how you are using these services. This allows us to ensure that public funds are being spent effectively.
+    </p>
+    <p class="govuk-body">
+      In some instances, we may also collect your email address for similar purposes.
+    </p>
 
-      <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
-      <p class="govuk-body">In order for our use of your personal data to be lawful, we need to meet one (or more) conditions in the data protection legislation. For the purpose of this project, this processing is necessary to complete a task in the public interest.</p>
+    <h2 class="govuk-heading-l">What personal information we will store</h2>
+    <p class="govuk-body">The personal data that we collect is:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>your pseudonymised Internet Protocol (IP) address</li>
+      <li>the postcode used to search for courses</li>
+    </ul>
 
-      <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
-      <p class="govuk-body">We will only keep your personal data for as long as we need it for the purpose(s) of this piece of work, after which point it will be securely destroyed. Please note that under data protection legislation and in compliance with the relevant data processing conditions, we can lawfully keep personal data processed purely for research and statistical purposes indefinitely.</p>
+    <h2 class="govuk-heading-l">How long we will keep your personal data</h2>
+    <p class="govuk-body">
+      Neither DfE nor its contracted suppliers will keep your personal data longer than we need it for the purpose(s) of research, security and/or delivery of the service, and in any case not longer than 7 years. Your data will be securely deleted when DfE and its contracted suppliers no longer need it for these purposes, or when 7 years have passed, whichever comes first.
+    </p>
 
-      <h2 class="govuk-heading-l">Your data protection rights</h2>
-      <p class="govuk-body">You have the right:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>to ask us for access to information about you that we hold</li>
-        <li>to have your personal data rectified, if it is inaccurate or incomplete</li>
-        <li>to request the deletion or removal of personal data where there is no compelling reason for its continued processing</li>
-        <li>to restrict our processing of your personal data (i.e. permitting its storage but no further processing)</li>
-        <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
-        <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
-      </ul>
+    <h2 class="govuk-heading-l">Your data protection rights</h2>
+    <p class="govuk-body">You have the right:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>to ask us for access to information about you that we hold</li>
+      <li>to have your personal data rectified, if it is inaccurate or incomplete</li>
+      <li>to request the deletion or removal of personal data where there is no compelling reason for its continued processing</li>
+      <li>to restrict our processing of your personal data (i.e. permitting its storage but no further processing)</li>
+      <li>to object to direct marketing (including profiling) and processing for the purposes of scientific/historical research and statistics</li>
+      <li>not to be subject to decisions based purely on automated processing where it produces a legal or similarly significant effect on you</li>
+    </ul>
+    <p class="govuk-body">
+      You can find more information about how we handle personal data in our <%= govuk_link_to("personal information charter", "https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter") %>.
+    </p>
 
-      <p class="govuk-body">
-        You can find more information about how we handle personal data in our
-        <%= govuk_link_to('personal information charter', 'https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter') %>.
-      </p>
+    <h2 class="govuk-heading-l">Getting help and raising a concern</h2>
+    <p class="govuk-body">
+      If you would like to exercise any of your rights, you can email us at <%= bat_contact_mail_to %>.
+    </p>
+    <p class="govuk-body">
+      You can also use our <%= govuk_link_to "contact form ", "https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&redirectlink=%2Fen&cancelRedirectLink=%2Fen" %> to get in touch with our Data Protection Officer.
+    </p>
+    <p class="govuk-body">
+      If we cannot resolve your issue, you have the right to raise it with the Information Commissioner's Office (ICO) at <%= govuk_link_to "https://ico.org.uk/make-a-complaint/", "https://ico.org.uk/make-a-complaint/" %>.
+    </p>
 
-      <h2 class="govuk-heading-l">The right to lodge a complaint</h2>
-      <p class="govuk-body">
-        You have the right to raise any concerns with the Information Commissioner’s Office (ICO) via their website at
-        <%= govuk_link_to('https://ico.org.uk/make-a-complaint/', 'https://ico.org.uk/make-a-complaint/') %>.
-      </p>
-
-      <h2 class="govuk-heading-l">Last updated</h2>
-      <p class="govuk-body">This version was last updated on 30 April 2018.</p>
-
-      <h2 class="govuk-heading-l">Contact us</h2>
-      <p class="govuk-body">Email <%= bat_contact_mail_to %> if you have any questions about how your personal information will be processed.</p>
-    </div>
+    <h2 class="govuk-heading-l">Keeping our privacy notice up to date</h2>
+    <p class="govuk-body">
+      We&#8217;ll update this privacy notice when required. You should regularly review the notice.
+    </p>
+    <p class="govuk-body">
+      This version was last updated on 14 November 2022.
+    </p>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   get '/terms-conditions', to: 'pages#terms', as: 'terms'
   get '/accessibility', to: 'pages#accessibility', as: 'accessibility'
-  get '/privacy-policy', to: 'pages#privacy', as: 'privacy'
+  get '/privacy', to: 'pages#privacy', as: 'privacy'
 
   get '/cookies', to: 'cookie_preferences#new', as: 'cookie_preferences'
   post '/cookies', to: 'cookie_preferences#create', as: 'create_cookie_preferences'

--- a/spec/features/view_pages_spec.rb
+++ b/spec/features/view_pages_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'View pages' do
   it 'Navigate to privacy' do
     visit privacy_path
 
-    expect(page).to have_text('Privacy policy')
+    expect(page).to have_text('Find postgraduate teacher training privacy notice')
   end
 
   it 'Navigate to accessibility' do


### PR DESCRIPTION
### Context

https://trello.com/c/KabFoz5k/799-update-the-privacy-notice-for-find-and-publish

### Changes proposed in this pull request

Updates the privacy notice as per the docs in the ticket above.

### Guidance to review

https://find-pr-1604.london.cloudapps.digital/privacy-policy

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
