### PR TITLE
[822] Make close filter button more accessible

### DIFF
--- a/app/webpacker/scripts/filter-toggle-button.js
+++ b/app/webpacker/scripts/filter-toggle-button.js
@@ -34,7 +34,12 @@ export const FilterToggleButton = class {
 
   addCloseButton () {
     if (this.options.closeButton) {
-      this.closeButton = $(`<button class="app-filter__close" type="button">${this.options.closeButton.text}</button>`)
+      this.closeButton = $(`
+        <button class="app-filter__close" type="button">
+          ${this.options.closeButton.text}
+          <span class="govuk-visually-hidden"> filter menu</span>
+        </button>
+      `);
       this.closeButton.on('click', $.proxy(this, 'onCloseClick'))
       this.options.closeButton.container.append(this.closeButton)
     }


### PR DESCRIPTION
### Context

https://trello.com/c/dFIVoAea/822-close-filters-button-should-include-visually-hidden-text-close-filter-menu

### Changes proposed in this pull request

Adds a visually hidden text to the button markup

### Guidance to review

- Inspect the markup on the results page
- Test with a screen reader

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
