### PR TITLE
Add a non breaking space

### DIFF
--- a/app/components/location_subject_filter_component.html.erb
+++ b/app/components/location_subject_filter_component.html.erb
@@ -13,6 +13,6 @@
         @results.filter_params_for(root_path),
         class: 'govuk-link--no-visited-state govuk-!-margin-left-4',
         data: { qa: 'link' }) do %>
-    Change <span class="govuk-visually-hidden"><%= @results.provider_filter? ? 'subject or provider' : 'subject or location' %></span>
+    Change <span class="govuk-visually-hidden">&nbsp;<%= @results.provider_filter? ? 'subject or provider' : 'subject or location' %></span>
   <% end %>
 </p>

--- a/app/components/location_subject_filter_component.html.erb
+++ b/app/components/location_subject_filter_component.html.erb
@@ -13,6 +13,6 @@
         @results.filter_params_for(root_path),
         class: 'govuk-link--no-visited-state govuk-!-margin-left-4',
         data: { qa: 'link' }) do %>
-    Change <span class="govuk-visually-hidden">&nbsp;<%= @results.provider_filter? ? 'subject or provider' : 'subject or location' %></span>
+    Change<span class="govuk-visually-hidden"> <%= @results.provider_filter? ? 'subject or provider' : 'subject or location' %></span>
   <% end %>
 </p>


### PR DESCRIPTION
### Context

Add a non breaking space to the visually hidden span for the change link on the results page.

### Guidance to review

### Trello card

https://trello.com/c/bhhQCnd6/826-add-non-breaking-space-between-change-and-the-visually-hidden-text-on-the-search-results-page

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
