### PR TITLE
[825] Add visually hidden text to errors linked to no keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -644,4 +644,4 @@ RUBY VERSION
    ruby 3.1.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/app/views/result_filters/location/_form.html.erb
+++ b/app/views/result_filters/location/_form.html.erb
@@ -22,6 +22,7 @@
         <div class="govuk-form-group" id="search-options">
           <% if flash[:error] and location_error? === false and provider_error? === false %>
             <p class="govuk-error-message">
+              <span class="govuk-visually-hidden">Error: </span>
               <% if flash[:error].kind_of?(Array) %>
                 <%= flash[:error].last %>
               <% else %>


### PR DESCRIPTION
### Context

https://trello.com/b/yOZLQ2IK/find-pub-sprint-board

### Changes proposed in this pull request

- Adds visually hidden text to inline error message when linked to no fields (eg submitting without an option on start page)

### Guidance to review

https://find-pr-1618.london.cloudapps.digital/

- Submit without entering a value on start page and check markup (do the same for other forms)

Corresponding find migration PR https://github.com/DFE-Digital/publish-teacher-training/pull/3146

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
