### PR TITLE
[0866] Updating information about bursaries and scholarships

### DIFF
--- a/app/components/courses/financial_support/scholarship_and_bursary_component.rb
+++ b/app/components/courses/financial_support/scholarship_and_bursary_component.rb
@@ -8,18 +8,38 @@ module Courses
       delegate :scholarship_amount,
                :bursary_amount,
                :has_early_career_payments?,
-               :subject_name, to: :course
+               to: :course
 
       def initialize(course)
         @course = course
       end
 
       def scholarship_body
-        I18n.t("scholarships.#{subject_name.downcase}.body", default: nil)
+        I18n.t("scholarships.#{subject_with_scholarship}.body", default: nil)
       end
 
       def scholarship_url
-        I18n.t("scholarships.#{subject_name.downcase}.url", default: nil)
+        I18n.t("scholarships.#{subject_with_scholarship}.url", default: nil)
+      end
+
+    private
+
+      SUBJECT_WITH_SCHOLARSHIPS = [
+        %w[F1 chemistry],
+        %w[11 computing],
+        %w[G1 mathematics],
+        %w[F3 physics],
+        %w[15 french],
+        %w[17 german],
+        %w[22 spanish],
+      ].freeze
+
+      def subject_with_scholarship
+        @subject_with_scholarship ||= SUBJECT_WITH_SCHOLARSHIPS.detect do |subject_code, _subject_name|
+          course.subjects.any? do |subject|
+            subject.subject_code == subject_code
+          end
+        end&.second
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,15 +121,11 @@ en:
     mathematics:
       body: Institute of Mathematics and its Applications
       url: https://teachingmathsscholars.org/eligibilitycriteria
-    french:
+    french: &british_council
       body: British Council
       url: https://www.britishcouncil.org/
-    german:
-      body: British Council
-      url: https://www.britishcouncil.org/
-    spanish:
-      body: British Council
-      url: https://www.britishcouncil.org/
+    german: *british_council
+    spanish: *british_council
   find:
     international_candidates:
       skilled_worker_visa:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -121,6 +121,15 @@ en:
     mathematics:
       body: Institute of Mathematics and its Applications
       url: https://teachingmathsscholars.org/eligibilitycriteria
+    french:
+      body: British Council
+      url: https://www.britishcouncil.org/
+    german:
+      body: British Council
+      url: https://www.britishcouncil.org/
+    spanish:
+      body: British Council
+      url: https://www.britishcouncil.org/
   find:
     international_candidates:
       skilled_worker_visa:

--- a/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
@@ -40,31 +40,35 @@ describe Courses::FinancialSupport::ScholarshipAndBursaryComponent, type: :compo
     end
 
     context 'when course has a scholarship' do
-      let(:course) {
-        build(:course,
-              subjects: [
-                build(:subject,
-                      subject_name: 'chemistry',
-                      scholarship: 2000,
-                      bursary_amount: 3000,
-                      early_career_payments: 2000),
-              ]).decorate
-      }
+      shared_examples 'subject with scholarship' do |subject_trait, scholarship_body, scholarship_url|
+        context "#{subject_trait} subject" do
+          let(:course) { build(:course, subjects:).decorate }
 
-      it 'renders link to scholarship body' do
-        render_inline(described_class.new(course))
+          let(:subjects) { [build(:subject, subject_trait)] }
 
-        expect(rendered_component).to have_text('For a scholarship, you’ll need to apply through the Royal Society of Chemistry')
-        expect(rendered_component).to have_link('Check whether you’re eligible for a scholarship and find out how to apply', href: 'https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/')
+          it 'renders link to scholarship body' do
+            render_inline(described_class.new(course))
+
+            expect(rendered_component).to have_text("For a scholarship, you’ll need to apply through the #{scholarship_body}")
+            expect(rendered_component).to have_link('Check whether you’re eligible for a scholarship and find out how to apply', href: scholarship_url)
+          end
+        end
       end
+
+      include_examples 'subject with scholarship', :physics, 'Institute of Physics', 'https://www.iop.org/about/support-grants/iop-teacher-training-scholarships'
+      include_examples 'subject with scholarship', :chemistry, 'Royal Society of Chemistry', 'https://www.rsc.org/prizes-funding/funding/teacher-training-scholarships/'
+      include_examples 'subject with scholarship', :computing, 'Chartered Institute for IT', 'https://www.bcs.org/qualifications-and-certifications/training-and-scholarships-for-teachers/bcs-computer-teacher-scholarships/'
+      include_examples 'subject with scholarship', :mathematics, 'Institute of Mathematics and its Applications', 'https://teachingmathsscholars.org/eligibilitycriteria'
+      include_examples 'subject with scholarship', :french, 'British Council', 'https://www.britishcouncil.org/'
+      include_examples 'subject with scholarship', :german, 'British Council', 'https://www.britishcouncil.org/'
+      include_examples 'subject with scholarship', :spanish, 'British Council', 'https://www.britishcouncil.org/'
     end
 
     context 'when course has scholarship but we don\'t have a institution to obtain further info from' do
       let(:course) {
         build(:course,
               subjects: [
-                build(:subject,
-                      subject_name: 'french',
+                build(:subject, :design_and_technology,
                       scholarship: 2000,
                       bursary_amount: 3000,
                       early_career_payments: 2000),

--- a/spec/factories/subjects.rb
+++ b/spec/factories/subjects.rb
@@ -63,5 +63,35 @@ FactoryBot.define do
       subject_name { 'Design and technology' }
       subject_code { 'DT' }
     end
+
+    trait :chemistry do
+      subject_name { 'Chemistry' }
+      subject_code { 'F1' }
+    end
+
+    trait :computing do
+      subject_name { 'Computing' }
+      subject_code { '11' }
+    end
+
+    trait :mathematics do
+      subject_name { 'Mathematics' }
+      subject_code { 'G1' }
+    end
+
+    trait :physics do
+      subject_name { 'Physics' }
+      subject_code { 'F3' }
+    end
+
+    trait :german do
+      subject_name { 'German' }
+      subject_code { '17' }
+    end
+
+    trait :spanish do
+      subject_name { 'Spanish' }
+      subject_code { '22' }
+    end
   end
 end


### PR DESCRIPTION
### Context
Information about bursaries and scholarships

### Changes proposed in this pull request
Added scholarships info for applicable subjects

### Guidance to review

It shoud show up for 

- Chemistry
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/Q774#section-financial-support
- Computing
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/D526#section-financial-support
- Mathematics
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/A949#section-financial-support
- Physics
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/M064#section-financial-support
- French
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/A568#section-financial-support 
- German
  - https://find-pr-1641.london.cloudapps.digital/course/2AL/L288#section-financial-support
- Spanish
  - https://find-pr-1641.london.cloudapps.digital/course/2CG/Z848#section-financial-support

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
