### PR TITLE
[870] Update course search results title

### DIFF
--- a/app/components/result_summary_component.rb
+++ b/app/components/result_summary_component.rb
@@ -1,0 +1,55 @@
+class ResultSummaryComponent < ViewComponent::Base
+  include ViewHelper
+
+  attr_reader :results
+
+  def initialize(results:)
+    @results = results
+  end
+
+  def call
+    [
+      course_found_text,
+      subject_names,
+      with_location_text,
+      with_england_text,
+      with_provider_text,
+    ].compact.join(' ')
+  end
+
+private
+
+  def subject_names
+    results.subjects.map { |subject| subject[:subject_name].downcase }.to_sentence(last_word_connector: ' and ')
+  end
+
+  def course_found_text
+    case results.course_count
+    when 0
+      'No'
+    when 1
+      '1'
+    else
+      number_with_delimiter(results.course_count)
+    end
+  end
+
+  def course_string_modifier
+    return 'courses found' if results.course_count.zero?
+    return 'course' if results.course_count == 1
+
+    'courses'
+  end
+
+  def with_location_text
+    "#{course_string_modifier} in #{results.location_search}" if results.location_filter?
+  end
+
+  def with_england_text
+    "#{course_string_modifier} in England" if results.england_filter?
+  end
+
+  def with_provider_text
+    "#{course_string_modifier} from #{results.provider}" if results.provider_filter?
+  end
+end

--- a/app/views/results/index.html.erb
+++ b/app/views/results/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :page_title, "#{@number_of_courses_string} found" %>
+<%= content_for :page_title, render(ResultSummaryComponent.new(results: @results_view)) %>
 
 <%= render Results::ResultsComponent.new(
   results: @results_view,

--- a/spec/components/result_summary_component_spec.rb
+++ b/spec/components/result_summary_component_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe ResultSummaryComponent, type: :component do
+  context 'when no courses are found' do
+    it 'renders the correct summary when location is used' do
+      results = instance_double(ResultsView, location_filter?: true, england_filter?: false, provider_filter?: false)
+
+      allow(results).to receive(:location_search).and_return('Brighton')
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(0)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('No art and design courses found in Brighton')
+    end
+
+    it 'renders the correct summary when england is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: true, provider_filter?: false)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(0)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('No art and design courses found in England')
+    end
+
+    it 'renders the correct summary when provider is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: false, provider_filter?: true)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:provider).and_return('University of Brighton')
+      allow(results).to receive(:course_count).and_return(0)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('No art and design courses found from University of Brighton')
+    end
+  end
+
+  context 'when one course is found' do
+    it 'renders the correct summary when location is used' do
+      results = instance_double(ResultsView, location_filter?: true, england_filter?: false, provider_filter?: false)
+
+      allow(results).to receive(:location_search).and_return('Brighton')
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(1)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('1 art and design course in Brighton')
+    end
+
+    it 'renders the correct summary when england is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: true, provider_filter?: false)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(1)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('1 art and design course in England')
+    end
+
+    it 'renders the correct summary when provider is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: false, provider_filter?: true)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:provider).and_return('University of Brighton')
+      allow(results).to receive(:course_count).and_return(1)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('1 art and design course from University of Brighton')
+    end
+  end
+
+  context 'when multiple courses are found' do
+    it 'renders the correct summary when location is used' do
+      results = instance_double(ResultsView, location_filter?: true, england_filter?: false, provider_filter?: false)
+
+      allow(results).to receive(:location_search).and_return('Brighton')
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(2)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('2 art and design courses in Brighton')
+    end
+
+    it 'renders the correct summary when england is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: true, provider_filter?: false)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:course_count).and_return(2)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('2 art and design courses in England')
+    end
+
+    it 'renders the correct summary when provider is used' do
+      results = instance_double(ResultsView, location_filter?: false, england_filter?: false, provider_filter?: true)
+
+      allow(results).to receive(:subjects).and_return([{ subject_name: 'Art and design' }])
+      allow(results).to receive(:provider).and_return('University of Brighton')
+      allow(results).to receive(:course_count).and_return(2)
+
+      page = render_inline(described_class.new(results:))
+
+      expect(page.text).to include('2 art and design courses from University of Brighton')
+    end
+  end
+end


### PR DESCRIPTION
### Context

We recently did some accessibility work to [fix the page titles across Find](https://trello.com/c/GaFrnjBD). As part of this work, we discovered that the course results list page title could be improved.

### Changes proposed in this pull request

- Extract logic for building out the results page title into a component

### Guidance to review

Check the title on the results page builds up the correct string for:

- Location search
- England search
- Provider search

### Trello card

https://trello.com/c/oAdyZoHU/870-update-courses-results-list-title

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
