### PR TITLE
[0892] Add level next to age range if a secondary course

### DIFF
--- a/app/components/courses/summary_component.html.erb
+++ b/app/components/courses/summary_component.html.erb
@@ -9,7 +9,7 @@
   <%= render Courses::QualificationsSummaryComponent.new(outcome) %>
   <% if age_range_in_years.present? %>
     <dt class="app-description-list__label">Age range</dt>
-    <dd data-qa="course__age_range"><%= age_range_in_years.humanize %></dd>
+    <dd data-qa="course__age_range"><%= age_range_in_years_row %></dd>
   <% end %>
   <% if length.present? %>
     <dt class="app-description-list__label">Course length</dt>

--- a/app/components/courses/summary_component.rb
+++ b/app/components/courses/summary_component.rb
@@ -11,10 +11,20 @@ module Courses
              :length,
              :applications_open_from,
              :outcome,
-             :start_date, to: :course
+             :start_date,
+             :secondary_course?,
+             :level, to: :course
 
     def initialize(course)
       @course = course
+    end
+
+    def age_range_in_years_row
+      if secondary_course?
+        "#{age_range_in_years.humanize} - #{level}"
+      else
+        age_range_in_years.humanize
+      end
     end
   end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -150,6 +150,10 @@ class CourseDecorator < Draper::Decorator
     object.campaign_name&.to_sym == :engineers_teach_physics
   end
 
+  def secondary_course?
+    object.level.to_sym == :secondary
+  end
+
 private
 
   def find_max(attribute)

--- a/spec/components/courses/summary_component_spec.rb
+++ b/spec/components/courses/summary_component_spec.rb
@@ -53,4 +53,32 @@ describe Courses::SummaryComponent, type: :component do
       )
     end
   end
+
+  context 'secondary course' do
+    it 'render the age range and level' do
+      course = build(
+        :course,
+        provider: build(:provider),
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.css('[data-qa="course__age_range"]').text).to eq('11 to 16 - secondary')
+    end
+  end
+
+  context 'non-secondary course' do
+    it 'render the age range only' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        level: 'primary',
+        age_range_in_years: '3_to_7',
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+
+      expect(result.css('[data-qa="course__age_range"]').text).to eq('3 to 7')
+    end
+  end
 end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -32,7 +32,8 @@ describe CourseDecorator do
           last_published_at: '2019-03-05T14:42:34Z',
           recruitment_cycle: current_recruitment_cycle,
           has_vacancies?: true,
-          campaign_name:)
+          campaign_name:,
+          level:)
   end
   let(:start_date) { Time.zone.local(2019) }
   let(:site) { build(:site) }
@@ -46,6 +47,7 @@ describe CourseDecorator do
       include: %i[sites provider accrediting_provider recruitment_cycle subjects],
     )
   end
+  let(:level) { 'secondary' }
 
   let(:decorated_course) { course.decorate }
 
@@ -92,6 +94,22 @@ describe CourseDecorator do
 
     context 'campaign_name is set to engineers_teach_physics' do
       let(:campaign_name) { 'engineers_teach_physics' }
+
+      it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '#secondary_course?' do
+    subject { decorated_course.secondary_course? }
+
+    context 'level is not set to secondary' do
+      let(:level) { %w[primary further_education].sample }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'level is set to secondary' do
+      let(:level) { 'secondary' }
 
       it { is_expected.to be_truthy }
     end


### PR DESCRIPTION
### Context
Course level and age range

### Changes proposed in this pull request
Add level next to age range if a secondary course

### Guidance to review
`secondary` should show up on courses that has level secondary

https://find-pr-1654.london.cloudapps.digital/course/2E1/Z785

![image](https://user-images.githubusercontent.com/470137/208620324-d59b695b-5496-4c47-b2c6-90a8b857db13.png)

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
