### PR TITLE
Add study_mode to course show page

### DIFF
--- a/app/components/courses/summary_component.html.erb
+++ b/app/components/courses/summary_component.html.erb
@@ -13,7 +13,7 @@
   <% end %>
   <% if length.present? %>
     <dt class="app-description-list__label">Course length</dt>
-    <dd data-qa="course__length"><%= length %></dd>
+    <dd data-qa="course__length"><%= course_length_with_study_mode_row %></dd>
   <% end %>
   <% if applications_open_from.present? %>
     <dt class="app-description-list__label">Date you can apply from</dt>

--- a/app/components/courses/summary_component.rb
+++ b/app/components/courses/summary_component.rb
@@ -13,7 +13,8 @@ module Courses
              :outcome,
              :start_date,
              :secondary_course?,
-             :level, to: :course
+             :level,
+             :study_mode, to: :course
 
     def initialize(course)
       @course = course
@@ -25,6 +26,10 @@ module Courses
       else
         age_range_in_years.humanize
       end
+    end
+
+    def course_length_with_study_mode_row
+      "#{length} - #{study_mode.humanize.downcase}"
     end
   end
 end

--- a/spec/components/courses/summary_component_spec.rb
+++ b/spec/components/courses/summary_component_spec.rb
@@ -81,4 +81,88 @@ describe Courses::SummaryComponent, type: :component do
       expect(result.css('[data-qa="course__age_range"]').text).to eq('3 to 7')
     end
   end
+
+  context '1 year full time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '1 year',
+        study_mode: 'full_time',
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('1 year - full time')
+    end
+  end
+
+  context '1 year part time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '1 year',
+        study_mode: 'part_time',
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('1 year - part time')
+    end
+  end
+
+  context '2 year part time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '2 year',
+        study_mode: 'part_time',
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('2 year - part time')
+    end
+  end
+
+  context '2 year full time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '2 year',
+        study_mode: 'full_time',
+      ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('2 year - full time')
+    end
+  end
+
+  context '2 year full time or part time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '2 year',
+        study_mode: 'full_time_or_part_time',
+        ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('2 year - full time or part time')
+    end
+  end
+
+  context '1 year full time or part time course' do
+    it 'render the correct course_length_with_study_mode_row' do
+      course = build(
+        :course,
+        provider: build(:provider),
+        course_length: '1 year',
+        study_mode: 'full_time_or_part_time',
+        ).decorate
+
+      result = render_inline(described_class.new(course))
+      expect(result.css('[data-qa="course__length"]').text).to eq('1 year - full time or part time')
+    end
+  end
 end

--- a/spec/components/courses/summary_component_spec.rb
+++ b/spec/components/courses/summary_component_spec.rb
@@ -55,7 +55,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context 'secondary course' do
-    it 'render the age range and level' do
+    it 'renders the age range and level' do
       course = build(
         :course,
         provider: build(:provider),
@@ -68,7 +68,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context 'non-secondary course' do
-    it 'render the age range only' do
+    it 'renders the age range only' do
       course = build(
         :course,
         provider: build(:provider),
@@ -83,7 +83,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '1 year full time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),
@@ -97,7 +97,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '1 year part time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),
@@ -111,7 +111,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '2 year part time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),
@@ -125,7 +125,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '2 year full time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),
@@ -139,7 +139,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '2 year full time or part time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),
@@ -153,7 +153,7 @@ describe Courses::SummaryComponent, type: :component do
   end
 
   context '1 year full time or part time course' do
-    it 'render the correct course_length_with_study_mode_row' do
+    it 'renders the correct course_length_with_study_mode_row' do
       course = build(
         :course,
         provider: build(:provider),

--- a/spec/components/courses/summary_component_spec.rb
+++ b/spec/components/courses/summary_component_spec.rb
@@ -145,7 +145,7 @@ describe Courses::SummaryComponent, type: :component do
         provider: build(:provider),
         course_length: '2 year',
         study_mode: 'full_time_or_part_time',
-        ).decorate
+      ).decorate
 
       result = render_inline(described_class.new(course))
       expect(result.css('[data-qa="course__length"]').text).to eq('2 year - full time or part time')
@@ -159,7 +159,7 @@ describe Courses::SummaryComponent, type: :component do
         provider: build(:provider),
         course_length: '1 year',
         study_mode: 'full_time_or_part_time',
-        ).decorate
+      ).decorate
 
       result = render_inline(described_class.new(course))
       expect(result.css('[data-qa="course__length"]').text).to eq('1 year - full time or part time')

--- a/spec/features/courses/show_spec.rb
+++ b/spec/features/courses/show_spec.rb
@@ -136,7 +136,7 @@ describe 'Course show' do
       )
 
       expect(course_page.length).to have_content(
-        decorated_course.length,
+        '1 year - full time',
       )
 
       expect(course_page.applications_open_from).to have_content(


### PR DESCRIPTION
### Context

A recent accessibility update on Find to expand PGCE, PGDE and QTS abbreviations has meant we have removed the study mode (full-time and part-time) from the lede paragraph.

### Changes proposed in this pull request

Add the study mode tadjacent to the course length in the summary list on the course details.

### Guidance to review

Take a look at the show page for various study modes and course lengths.

### Trello card

https://trello.com/b/yOZLQ2IK/find-pub-sprint-board

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
