### PR TITLE
Replace `rendered_component` with `page`

### DIFF
--- a/spec/components/courses/financial_support/bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/bursary_component_spec.rb
@@ -10,12 +10,12 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
     end
 
     it 'renders bursary details' do
-      expect(rendered_component).to have_text('You could be eligible for a bursary of £3,000')
+      expect(page).to have_text('You could be eligible for a bursary of £3,000')
     end
 
     context 'bursary requirements' do
       it 'renders bursary requirements' do
-        expect(rendered_component).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
+        expect(page).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
       end
     end
 
@@ -26,14 +26,14 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
         let(:course) { build(:course, subjects: [build(:subject, :modern_languages, bursary_amount: 3000)]).decorate }
 
         it 'does not render duplicate bursary requirements' do
-          expect(rendered_component).not_to have_css('ul.govuk-list.govuk-list--bullet', text: 'a degree of 2:2 or above in any subject')
+          expect(page).not_to have_css('ul.govuk-list.govuk-list--bullet', text: 'a degree of 2:2 or above in any subject')
           expect(described_class.new(course).duplicate_requirement(requirement)).to be_truthy
         end
       end
 
       context 'requirement and bursary_first_line_ending are not identical' do
         it 'renders both requirement and bursary first line ending' do
-          expect(rendered_component).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
+          expect(page).to have_text('To be eligible for a bursary you’ll need a 2:2 degree in any subject')
           expect(described_class.new(course).duplicate_requirement(requirement)).to be_falsey
         end
       end
@@ -46,7 +46,7 @@ describe Courses::FinancialSupport::BursaryComponent, type: :component do
 
       render_inline(described_class.new(course))
 
-      expect(rendered_component).not_to have_text('You’ll get a bursary of £3,000')
+      expect(page).not_to have_text('You’ll get a bursary of £3,000')
     end
   end
 end

--- a/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
+++ b/spec/components/courses/financial_support/scholarship_and_bursary_component_spec.rb
@@ -49,8 +49,8 @@ describe Courses::FinancialSupport::ScholarshipAndBursaryComponent, type: :compo
           it 'renders link to scholarship body' do
             render_inline(described_class.new(course))
 
-            expect(rendered_component).to have_text("For a scholarship, you’ll need to apply through the #{scholarship_body}")
-            expect(rendered_component).to have_link('Check whether you’re eligible for a scholarship and find out how to apply', href: scholarship_url)
+            expect(page).to have_text("For a scholarship, you’ll need to apply through the #{scholarship_body}")
+            expect(page).to have_link('Check whether you’re eligible for a scholarship and find out how to apply', href: scholarship_url)
           end
         end
       end

--- a/spec/components/courses/international_students_component_spec.rb
+++ b/spec/components/courses/international_students_component_spec.rb
@@ -12,11 +12,11 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to study' do
-      expect(rendered_component).to have_text('You’ll need the right to study in the UK')
+      expect(page).to have_text('You’ll need the right to study in the UK')
     end
 
     it 'tells candidates sponsorship is not available' do
-      expect(rendered_component).to have_text('Sponsorship is not available for this course')
+      expect(page).to have_text('Sponsorship is not available for this course')
     end
   end
 
@@ -35,15 +35,15 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
-      expect(rendered_component).to have_text('Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
+      expect(page).to have_text('Before you apply for this course, contact us to check Student visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
     end
 
     it 'does not tell candidates the 3-year residency rule' do
-      expect(rendered_component).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+      expect(page).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
     end
 
     it 'does not tell candidates about settled and pre-settled status' do
-      expect(rendered_component).not_to have_text('EEA nationals with settled or pre-settled status under the')
+      expect(page).not_to have_text('EEA nationals with settled or pre-settled status under the')
     end
   end
 
@@ -58,11 +58,11 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
+      expect(page).to have_text('You’ll need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship may be available, but they should check' do
-      expect(rendered_component).to have_text('Before you apply for this course, contact us to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
+      expect(page).to have_text('Before you apply for this course, contact us to check Skilled Worker visa sponsorship is available. If it is, and you get a place on this course, we’ll help you apply for your visa.')
     end
   end
 
@@ -77,19 +77,19 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates they’ll need the right to work' do
-      expect(rendered_component).to have_text('You’ll need the right to work in the UK')
+      expect(page).to have_text('You’ll need the right to work in the UK')
     end
 
     it 'tells candidates visa sponsorship is not available' do
-      expect(rendered_component).to have_text('Sponsorship is not available for this course')
+      expect(page).to have_text('Sponsorship is not available for this course')
     end
 
     it 'does not tell candidates the 3-year residency rule' do
-      expect(rendered_component).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+      expect(page).not_to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
     end
 
     it 'does not tell candidates about settled and pre-settled status' do
-      expect(rendered_component).not_to have_text('EEA nationals with settled or pre-settled status under the')
+      expect(page).not_to have_text('EEA nationals with settled or pre-settled status under the')
     end
   end
 
@@ -103,11 +103,11 @@ describe Courses::InternationalStudentsComponent, type: :component do
     end
 
     it 'tells candidates the 3-year residency rule' do
-      expect(rendered_component).to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
+      expect(page).to have_text('To apply for this teaching apprenticeship course, you’ll need to have lived in the UK for at least 3 years before the start of the course')
     end
 
     it 'tells candidates about settled and pre-settled status' do
-      expect(rendered_component).to have_text('EEA nationals with settled or pre-settled status under the')
+      expect(page).to have_text('EEA nationals with settled or pre-settled status under the')
     end
   end
 end


### PR DESCRIPTION
### Context

Replace `rendered_component` with `page`. 

rendered_component is deprecated and will be removed in v3.0.0

### Guidance to review

Did I miss anything?

### Trello card

https://trello.com/c/kr1APKaZ/917-refactor-renderedcomponent-deprecation-notice

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
