### PR TITLE
[940] Setup GTM

### DIFF
--- a/app/views/layouts/_gtm.html.erb
+++ b/app/views/layouts/_gtm.html.erb
@@ -1,0 +1,7 @@
+<script>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','<%= Settings.google_tag_manager.tracking_id %>');
+</script>

--- a/app/views/layouts/_gtm.html.erb
+++ b/app/views/layouts/_gtm.html.erb
@@ -1,4 +1,4 @@
-<script>
+<script nonce='<%= request.session.id %>'>
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,11 +17,13 @@
     <%= stylesheet_pack_tag 'application' %>
     <%= content_for(:head) %>
 
+    <%= render("layouts/gtm") %>
   </head>
 
   <body class="govuk-template__body ">
     <%= render "layouts/add_js_enabled_class_to_body" %>
 
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<%= Settings.google_tag_manager.tracking_id %>" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <% unless hide_cookie_banner? %>
       <% heading_text = 'Cookies on Find postgraduate teacher training' %>
       <%= govuk_cookie_banner(

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,6 @@ background_jobs:
     cron: "0 * * * *" # hourly
     class: "SyncProvidersJob"
     queue: sync_providers
+
+google_tag_manager:
+  tracking_id: change-me

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,3 +8,6 @@ valid_referers:
 basic_auth_username: replace_me
 basic_auth_password: replace_me
 STATE_CHANGE_SLACK_URL: replace_me
+
+google_tag_manager:
+  tracking_id: GTM-TP73392

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -5,6 +5,3 @@ teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk
 valid_referers:
   - https://qa.find-postgraduate-teacher-training.education.gov.uk
-
-google_tag_manager:
-  tracking_id: GTM-TP73392

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -5,3 +5,6 @@ teacher_training_api:
   base_url: https://api.publish-teacher-training-courses.service.gov.uk
 valid_referers:
   - https://qa.find-postgraduate-teacher-training.education.gov.uk
+
+google_tag_manager:
+  tracking_id: GTM-TP73392


### PR DESCRIPTION
### Context

The marketing team would like to test the new tags before they go live.

### Changes proposed in this pull request

This PR extracts some of work from this one https://github.com/DFE-Digital/find-teacher-training/pull/1437 (specifically adding the GTM script itself).

### Guidance to review

Maheera has clarified that the marketing team are able to test the tags without enabling them live on their end via GTM

### Trello card

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [x] Tested by running locally
