### PR TITLE
Update results page ordering options

### DIFF
--- a/app/components/results/sort_by_component.html.erb
+++ b/app/components/results/sort_by_component.html.erb
@@ -7,7 +7,7 @@
       <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
       <%= form.select(
         :sortby,
-        options_for_select(results.sort_options, selected: params['sortby'] || "A" ),
+        options_for_select(results.sort_options, selected: params['sortby'] || "course_asc" ),
         {},
         {
           class: 'govuk-select',

--- a/app/components/results/sort_by_component.html.erb
+++ b/app/components/results/sort_by_component.html.erb
@@ -7,7 +7,7 @@
       <%= form.label(:sortby, 'Sorted by', class: 'govuk-label govuk-!-display-inline-block') %>
       <%= form.select(
         :sortby,
-        options_for_select(results.sort_options, selected: params['sortby'].to_i || 0),
+        options_for_select(results.sort_options, selected: params['sortby'] || "A" ),
         {},
         {
           class: 'govuk-select',

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -157,10 +157,10 @@ class ResultsView
 
   def sort_options
     [
-      ['Course name (A-Z)', 'A', { 'data-qa': 'sort-form__options__ascending_course' }],
-      ['Course name (Z-A)', 'B', { 'data-qa': 'sort-form__options__descending_course' }],
-      ['Training provider (A-Z)', 'C', { 'data-qa': 'sort-form__options__ascending_provider' }],
-      ['Training provider (Z-A)', 'D', { 'data-qa': 'sort-form__options__descending_provider' }],
+      ['Course name (A-Z)', 'course_asc', { 'data-qa': 'sort-form__options__ascending_course' }],
+      ['Course name (Z-A)', 'course_desc', { 'data-qa': 'sort-form__options__descending_course' }],
+      ['Training provider (A-Z)', 'provider_asc', { 'data-qa': 'sort-form__options__ascending_provider' }],
+      ['Training provider (Z-A)', 'provider_desc', { 'data-qa': 'sort-form__options__descending_provider' }],
     ]
   end
 
@@ -169,15 +169,15 @@ class ResultsView
       base_query = course_query(include_location: location_filter?)
       base_query = if sort_by_distance?
                      base_query.order(:distance)
-                   elsif query_parameters[:sortby] == 'B'
+                   elsif query_parameters[:sortby] == 'course_desc'
                      base_query
                                     .order(name: :desc)
                                     .order('provider.provider_name': :asc)
-                   elsif query_parameters[:sortby] == 'C'
+                   elsif query_parameters[:sortby] == 'provider_asc'
                      base_query
                                     .order('provider.provider_name': :asc)
                                     .order(order: :asc)
-                   elsif query_parameters[:sortby] == 'D'
+                   elsif query_parameters[:sortby] == 'provider_desc'
                      base_query
                                     .order('provider.provider_name': :desc)
                                     .order(order: :asc)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -176,11 +176,11 @@ class ResultsView
                    elsif query_parameters[:sortby] == 'provider_asc'
                      base_query
                                     .order('provider.provider_name': :asc)
-                                    .order(order: :asc)
+                                    .order(name: :asc)
                    elsif query_parameters[:sortby] == 'provider_desc'
                      base_query
                                     .order('provider.provider_name': :desc)
-                                    .order(order: :asc)
+                                    .order(name: :asc)
                    else
                      base_query
                        .order(name: :asc)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -171,16 +171,16 @@ class ResultsView
                      base_query.order(:distance)
                    elsif query_parameters[:sortby] == 'course_desc'
                      base_query
-                                    .order(name: :desc)
-                                    .order('provider.provider_name': :asc)
+                      .order(name: :desc)
+                      .order('provider.provider_name': :asc)
                    elsif query_parameters[:sortby] == 'provider_asc'
                      base_query
-                                    .order('provider.provider_name': :asc)
-                                    .order(name: :asc)
+                      .order('provider.provider_name': :asc)
+                      .order(name: :asc)
                    elsif query_parameters[:sortby] == 'provider_desc'
                      base_query
-                                    .order('provider.provider_name': :desc)
-                                    .order(name: :asc)
+                      .order('provider.provider_name': :desc)
+                      .order(name: :asc)
                    else
                      base_query
                        .order(name: :asc)

--- a/app/view_objects/results_view.rb
+++ b/app/view_objects/results_view.rb
@@ -157,23 +157,35 @@ class ResultsView
 
   def sort_options
     [
-      ['Training provider (A-Z)', 0, { 'data-qa': 'sort-form__options__ascending' }],
-      ['Training provider (Z-A)', 1, { 'data-qa': 'sort-form__options__descending' }],
+      ['Course name (A-Z)', 'A', { 'data-qa': 'sort-form__options__ascending_course' }],
+      ['Course name (Z-A)', 'B', { 'data-qa': 'sort-form__options__descending_course' }],
+      ['Training provider (A-Z)', 'C', { 'data-qa': 'sort-form__options__ascending_provider' }],
+      ['Training provider (Z-A)', 'D', { 'data-qa': 'sort-form__options__descending_provider' }],
     ]
   end
 
   def courses
     @courses ||= begin
       base_query = course_query(include_location: location_filter?)
-
       base_query = if sort_by_distance?
                      base_query.order(:distance)
+                   elsif query_parameters[:sortby] == 'B'
+                     base_query
+                                    .order(name: :desc)
+                                    .order('provider.provider_name': :asc)
+                   elsif query_parameters[:sortby] == 'C'
+                     base_query
+                                    .order('provider.provider_name': :asc)
+                                    .order(order: :asc)
+                   elsif query_parameters[:sortby] == 'D'
+                     base_query
+                                    .order('provider.provider_name': :desc)
+                                    .order(order: :asc)
                    else
                      base_query
-                       .order('provider.provider_name': results_order)
                        .order(name: :asc)
+                       .order('provider.provider_name': :asc)
                    end
-
       base_query
         .page(query_parameters[:page] || 1)
         .per(results_per_page)
@@ -348,12 +360,6 @@ private
   end
 
   attr_reader :query_parameters
-
-  def results_order
-    return :desc if query_parameters[:sortby] == '1'
-
-    :asc
-  end
 
   def qualifications_parameters
     { 'qualifications' => query_parameters['qualifications'].presence || %w[QtsOnly PgdePgceWithQts Other] }

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -61,7 +61,7 @@ describe 'results' do
       end
     end
 
-    context 'provider descending' do
+    context 'descending' do
       let(:sort) { '-provider.provider_name,order' }
       let(:params) { { sortby: 'D', l: '2' } }
 
@@ -70,11 +70,11 @@ describe 'results' do
       end
 
       it 'is automatically selected' do
-        expect(results_page.sort_form.options.descending).to be_selected
+        expect(results_page.sort_form.options.provider_descending).to be_selected
       end
 
       it 'can be changed to ascending' do
-        results_page.sort_form.options.ascending.select_option
+        results_page.sort_form.options.provider_ascending.select_option
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
@@ -84,7 +84,7 @@ describe 'results' do
       end
     end
 
-    context 'provider ascending' do
+    context 'ascending' do
       let(:sort) { 'provider.provider_name,order' }
       let(:params) { { sortby: 'C', l: '2' } }
 
@@ -93,15 +93,82 @@ describe 'results' do
       end
 
       it 'is automatically selected' do
-        expect(results_page.sort_form.options.ascending).to be_selected
+        expect(results_page.sort_form.options.provider_ascending).to be_selected
       end
 
       it 'can be changed to descending' do
-        results_page.sort_form.options.descending.select_option
+        results_page.sort_form.options.provider_descending.select_option
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
           'sortby' => 'D',
+          'l' => '2',
+        )
+      end
+    end
+  end
+
+  context 'course sorting' do
+    let(:course_ascending_stub) do
+      stub_courses(
+        query: results_page_parameters('sort' => 'name,provider.provider_name'),
+        course_count: 10,
+      )
+    end
+
+    let(:course_descending_stub) do
+      stub_courses(
+        query: results_page_parameters('sort' => '-name,provider.provider_name'),
+        course_count: 10,
+      )
+    end
+
+    before do
+      course_ascending_stub
+      course_descending_stub
+    end
+
+    context 'descending' do
+      let(:sort) { '-name,provider.provider_name' }
+      let(:params) { { sortby: 'B', l: '2' } }
+
+      it 'requests that the backend sorts the data' do
+        expect(course_descending_stub).to have_been_requested
+      end
+
+      it 'is automatically selected' do
+        expect(results_page.sort_form.options.course_descending).to be_selected
+      end
+
+      it 'can be changed to ascending' do
+        results_page.sort_form.options.course_ascending.select_option
+        results_page.sort_form.submit.click
+
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          'sortby' => 'A',
+          'l' => '2',
+        )
+      end
+    end
+
+    context 'ascending' do
+      let(:sort) { 'name,provider.provider_name' }
+      let(:params) { { sortby: 'A', l: '2' } }
+
+      it 'requests that the backend sorts the data' do
+        expect(course_ascending_stub).to have_been_requested
+      end
+
+      it 'is automatically selected' do
+        expect(results_page.sort_form.options.course_ascending).to be_selected
+      end
+
+      it 'can be changed to descending' do
+        results_page.sort_form.options.course_descending.select_option
+        results_page.sort_form.submit.click
+
+        expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
+          'sortby' => 'B',
           'l' => '2',
         )
       end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -34,14 +34,14 @@ describe 'results' do
   context 'provider sorting' do
     let(:provider_ascending_stub) do
       stub_courses(
-        query: results_page_parameters('sort' => 'provider.provider_name,order'),
+        query: results_page_parameters('sort' => 'provider.provider_name,name'),
         course_count: 10,
       )
     end
 
     let(:provider_descending_stub) do
       stub_courses(
-        query: results_page_parameters('sort' => '-provider.provider_name,order'),
+        query: results_page_parameters('sort' => '-provider.provider_name,name'),
         course_count: 10,
       )
     end
@@ -62,7 +62,7 @@ describe 'results' do
     end
 
     context 'descending' do
-      let(:sort) { '-provider.provider_name,order' }
+      let(:sort) { '-provider.provider_name,name' }
       let(:params) { { sortby: 'provider_desc', l: '2' } }
 
       it 'requests that the backend sorts the data' do
@@ -85,7 +85,7 @@ describe 'results' do
     end
 
     context 'ascending' do
-      let(:sort) { 'provider.provider_name,order' }
+      let(:sort) { 'provider.provider_name,name' }
       let(:params) { { sortby: 'provider_asc', l: '2' } }
 
       it 'requests that the backend sorts the data' do

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -63,7 +63,7 @@ describe 'results' do
 
     context 'descending' do
       let(:sort) { '-provider.provider_name,order' }
-      let(:params) { { sortby: 'D', l: '2' } }
+      let(:params) { { sortby: 'provider_desc', l: '2' } }
 
       it 'requests that the backend sorts the data' do
         expect(provider_descending_stub).to have_been_requested
@@ -78,7 +78,7 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => 'C',
+          'sortby' => 'provider_asc',
           'l' => '2',
         )
       end
@@ -86,7 +86,7 @@ describe 'results' do
 
     context 'ascending' do
       let(:sort) { 'provider.provider_name,order' }
-      let(:params) { { sortby: 'C', l: '2' } }
+      let(:params) { { sortby: 'provider_asc', l: '2' } }
 
       it 'requests that the backend sorts the data' do
         expect(provider_ascending_stub).to have_been_requested
@@ -101,7 +101,7 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => 'D',
+          'sortby' => 'provider_desc',
           'l' => '2',
         )
       end
@@ -130,7 +130,7 @@ describe 'results' do
 
     context 'descending' do
       let(:sort) { '-name,provider.provider_name' }
-      let(:params) { { sortby: 'B', l: '2' } }
+      let(:params) { { sortby: 'course_desc', l: '2' } }
 
       it 'requests that the backend sorts the data' do
         expect(course_descending_stub).to have_been_requested
@@ -145,7 +145,7 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => 'A',
+          'sortby' => 'course_asc',
           'l' => '2',
         )
       end
@@ -153,7 +153,7 @@ describe 'results' do
 
     context 'ascending' do
       let(:sort) { 'name,provider.provider_name' }
-      let(:params) { { sortby: 'A', l: '2' } }
+      let(:params) { { sortby: 'course_asc', l: '2' } }
 
       it 'requests that the backend sorts the data' do
         expect(course_ascending_stub).to have_been_requested
@@ -168,7 +168,7 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => 'B',
+          'sortby' => 'course_desc',
           'l' => '2',
         )
       end

--- a/spec/features/results_spec.rb
+++ b/spec/features/results_spec.rb
@@ -6,7 +6,7 @@ describe 'results' do
   include ActiveJob::TestHelper
 
   let(:results_page) { PageObjects::Page::Results.new }
-  let(:sort) { 'provider.provider_name,name' }
+  let(:sort) { 'name,provider.provider_name' }
   let(:params) { nil }
   let(:base_parameters) { results_page_parameters('sort' => sort) }
 
@@ -32,28 +32,28 @@ describe 'results' do
   end
 
   context 'provider sorting' do
-    let(:ascending_stub) do
+    let(:provider_ascending_stub) do
       stub_courses(
-        query: results_page_parameters('sort' => 'provider.provider_name,name'),
+        query: results_page_parameters('sort' => 'provider.provider_name,order'),
         course_count: 10,
       )
     end
 
-    let(:descending_stub) do
+    let(:provider_descending_stub) do
       stub_courses(
-        query: results_page_parameters('sort' => '-provider.provider_name,name'),
+        query: results_page_parameters('sort' => '-provider.provider_name,order'),
         course_count: 10,
       )
     end
 
     before do
-      ascending_stub
-      descending_stub
+      provider_ascending_stub
+      provider_descending_stub
     end
 
     describe 'hides ordering' do
       let(:base_parameters) { results_page_parameters('sort' => sort, 'filter[provider.provider_name]' => '2AT') }
-      let(:sort) { 'provider.provider_name,name' }
+      let(:sort) { 'name,provider.provider_name' }
       let(:params) { { l: '3', query: '2AT' } }
 
       it 'does not display the sort form' do
@@ -61,12 +61,12 @@ describe 'results' do
       end
     end
 
-    context 'descending' do
-      let(:sort) { '-provider.provider_name,name' }
-      let(:params) { { sortby: '1', l: '2' } }
+    context 'provider descending' do
+      let(:sort) { '-provider.provider_name,order' }
+      let(:params) { { sortby: 'D', l: '2' } }
 
       it 'requests that the backend sorts the data' do
-        expect(descending_stub).to have_been_requested
+        expect(provider_descending_stub).to have_been_requested
       end
 
       it 'is automatically selected' do
@@ -78,18 +78,18 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => '0',
+          'sortby' => 'C',
           'l' => '2',
         )
       end
     end
 
-    context 'ascending' do
-      let(:sort) { 'provider.provider_name,name' }
-      let(:params) { { sortby: '0', l: '2' } }
+    context 'provider ascending' do
+      let(:sort) { 'provider.provider_name,order' }
+      let(:params) { { sortby: 'C', l: '2' } }
 
       it 'requests that the backend sorts the data' do
-        expect(ascending_stub).to have_been_requested
+        expect(provider_ascending_stub).to have_been_requested
       end
 
       it 'is automatically selected' do
@@ -101,7 +101,7 @@ describe 'results' do
         results_page.sort_form.submit.click
 
         expect(Rack::Utils.parse_nested_query(URI(current_url).query)).to eq(
-          'sortby' => '1',
+          'sortby' => 'D',
           'l' => '2',
         )
       end

--- a/spec/support/page_objects/page/results.rb
+++ b/spec/support/page_objects/page/results.rb
@@ -82,8 +82,8 @@ module PageObjects
 
       class SortFormSection < SitePrism::Section
         section :options, '[data-qa="sort-form__options"]' do
-          element :ascending, '[data-qa="sort-form__options__ascending"]'
-          element :descending, '[data-qa="sort-form__options__descending"]'
+          element :ascending, '[data-qa="sort-form__options__ascending_provider"]'
+          element :descending, '[data-qa="sort-form__options__descending_provider"]'
           element :distance, '[data-qa="sort-form__options__distance"]'
         end
         element :submit, '[data-qa="sort-form__submit"]'

--- a/spec/support/page_objects/page/results.rb
+++ b/spec/support/page_objects/page/results.rb
@@ -82,8 +82,10 @@ module PageObjects
 
       class SortFormSection < SitePrism::Section
         section :options, '[data-qa="sort-form__options"]' do
-          element :ascending, '[data-qa="sort-form__options__ascending_provider"]'
-          element :descending, '[data-qa="sort-form__options__descending_provider"]'
+          element :course_ascending, '[data-qa="sort-form__options__ascending_course"]'
+          element :course_descending, '[data-qa="sort-form__options__descending_course"]'
+          element :provider_ascending, '[data-qa="sort-form__options__ascending_provider"]'
+          element :provider_descending, '[data-qa="sort-form__options__descending_provider"]'
           element :distance, '[data-qa="sort-form__options__distance"]'
         end
         element :submit, '[data-qa="sort-form__submit"]'

--- a/spec/support/results_page_parameters.rb
+++ b/spec/support/results_page_parameters.rb
@@ -11,6 +11,6 @@ def results_page_parameters(parameters = {})
       },
     'page[page]' => 1,
     'page[per_page]' => 30,
-    'sort' => 'provider.provider_name,name',
+    'sort' => 'name,provider.provider_name',
   }.merge(parameters)
 end

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -770,10 +770,10 @@ describe ResultsView do
       it {
         expect(results_view).to eq(
           [
-            ['Course name (A-Z)', 'A', { 'data-qa': 'sort-form__options__ascending_course' }],
-            ['Course name (Z-A)', 'B', { 'data-qa': 'sort-form__options__descending_course' }],
-            ['Training provider (A-Z)', 'C', { 'data-qa': 'sort-form__options__ascending_provider' }],
-            ['Training provider (Z-A)', 'D', { 'data-qa': 'sort-form__options__descending_provider' }],
+            ['Course name (A-Z)', 'course_asc', { 'data-qa': 'sort-form__options__ascending_course' }],
+            ['Course name (Z-A)', 'course_desc', { 'data-qa': 'sort-form__options__descending_course' }],
+            ['Training provider (A-Z)', 'provider_asc', { 'data-qa': 'sort-form__options__ascending_provider' }],
+            ['Training provider (Z-A)', 'provider_desc', { 'data-qa': 'sort-form__options__descending_provider' }],
           ],
         )
       }

--- a/spec/view_objects/results_view_spec.rb
+++ b/spec/view_objects/results_view_spec.rb
@@ -770,8 +770,10 @@ describe ResultsView do
       it {
         expect(results_view).to eq(
           [
-            ['Training provider (A-Z)', 0, { 'data-qa': 'sort-form__options__ascending' }],
-            ['Training provider (Z-A)', 1, { 'data-qa': 'sort-form__options__descending' }],
+            ['Course name (A-Z)', 'A', { 'data-qa': 'sort-form__options__ascending_course' }],
+            ['Course name (Z-A)', 'B', { 'data-qa': 'sort-form__options__descending_course' }],
+            ['Training provider (A-Z)', 'C', { 'data-qa': 'sort-form__options__ascending_provider' }],
+            ['Training provider (Z-A)', 'D', { 'data-qa': 'sort-form__options__descending_provider' }],
           ],
         )
       }


### PR DESCRIPTION
### Context

We are adding the ability to sort the results page on Find by course name.

### Changes proposed in this pull request

- **Add course ordering (A-Z)**

If identical course, ordering falls back to the provider, if identical providers, ordering falls back to the course code

- **Add course ordering (Z-A)**

If identical course, ordering falls back to the provider, if identical providers, ordering falls back to the course code

- **Update provider ordering (A-Z)**

If identical provider, ordering falls back to the course, if identical courses, ordering falls back to the course code

- **Update provider ordering (Z-A)**

If identical provider, ordering falls back to the course, if identical courses, ordering falls back to the course code

### Guidance to review

Search for a few courses and check that the hierarchy above is correct.

### Trello card

https://trello.com/c/QrMrqrVS/897-sort-courses-by-course-name-find

### Checklist

- [x] Rebased `main`
- [x] Cleaned commit history
- [ ] Tested by running locally
