### PR TITLE
Remove qa routes from code

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -30,7 +30,7 @@ resource cloudfoundry_app web_app {
   dynamic "routes" {
     for_each = local.web_app_routes
     content {
-      route = routes.value
+      route = routes.value.id
     }
   }
 
@@ -76,18 +76,24 @@ resource cloudfoundry_app worker_app {
 }
 
 resource cloudfoundry_route web_app_cloudapps_digital_route {
+  count = var.disable_routes == false ? 1 : 0
+
   domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
 }
 
 resource cloudfoundry_route web_app_service_gov_uk_route {
+  count = var.disable_routes == false ? 1 : 0
+
   domain   = data.cloudfoundry_domain.find_service_gov_uk.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.service_gov_uk_host_names[var.app_environment_config]
 }
 
 resource "cloudfoundry_route" "web_app_assets_service_gov_uk_route" {
+  count = var.disable_routes == false ? 1 : 0
+
   domain   = data.cloudfoundry_domain.find_service_gov_uk.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.assets_host_names[var.app_environment_config]

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -32,6 +32,8 @@ variable app_environment_variables { type = map }
 
 variable "enable_external_logging" {}
 
+variable "disable_routes" {}
+
 locals {
   app_name_suffix           = var.app_environment_config != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
   web_app_name              = "find-${local.app_name_suffix}"
@@ -63,10 +65,10 @@ locals {
     prod     = "assets"
     review   = "${local.app_name_suffix}-assets"
   }
-  web_app_routes = [
-    cloudfoundry_route.web_app_service_gov_uk_route.id,
-    cloudfoundry_route.web_app_cloudapps_digital_route.id,
-    cloudfoundry_route.web_app_assets_service_gov_uk_route.id
-  ]
+  web_app_routes = flatten([
+    cloudfoundry_route.web_app_service_gov_uk_route,
+    cloudfoundry_route.web_app_cloudapps_digital_route,
+    cloudfoundry_route.web_app_assets_service_gov_uk_route
+  ])
   logging_service_bindings = var.enable_external_logging ? [cloudfoundry_user_provided_service.logging.id] : []
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -48,6 +48,7 @@ module "paas" {
   logstash_url              = local.infra_secrets.LOGSTASH_URL
   app_environment_variables = local.paas_app_environment_variables
   enable_external_logging   = var.paas_enable_external_logging
+  disable_routes            = var.disable_routes
 }
 
 provider "statuscake" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,6 +34,8 @@ variable key_vault_infra_secret_name {}
 
 variable azure_credentials { default = null }
 
+variable "disable_routes" { default = false }
+
 #StatusCake
 variable statuscake_alerts {
   type    = map

--- a/terraform/workspace_variables/qa.tfvars.json
+++ b/terraform/workspace_variables/qa.tfvars.json
@@ -13,6 +13,7 @@
   "key_vault_name": "s121d01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-QA",
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-QA",
+  "disable_routes": true,
   "statuscake_alerts": {
     "find-qa": {
       "website_name": "find-teacher-training-qa",


### PR DESCRIPTION
### Context
For the find migration to publish
Routes will be removed from find tf state and code so they can be managed from publish instead

Steps are 
- take a note of the route guids as they will be used for import in publish
- remove routes from tf state (terraform state rm) 
- remove route mappings from webapp in tf state (terraform pull, edit, terraform push)
- merge this pr

### Changes proposed in this pull request
Add variable disable_routes
If variable not null for an env, then routes will not be created

### Guidance to review

make qa deploy-plan

### Trello card

https://trello.com/c/txVxNL4S/744-findpub-merge

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
