### PR TITLE
Remove qa from deploy workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -119,7 +119,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile --severity-threshold=high
+          args: --file=Dockerfile --severity-threshold=high --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -213,7 +213,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        environment: [qa,staging]
+        environment: [staging]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
### Context

QA has been migrated to publish, so it will be removed from the deploy workflow

Also add --exclude-app-vulns to the SNYK scan step in the build workflow,
as SNYK have changed the default to scan app vulnerabilities 

### Changes proposed in this pull request

Update the build-and-deploy workflow and remove qa 

### Guidance to review

Check syntax
Check qa doesn't deploy on merge
Check SNYK doesn't scan app vulnerabilities

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
