### PR TITLE
reset SNYK default app scan setting

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -119,7 +119,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile --severity-threshold=high
+          args: --file=Dockerfile --severity-threshold=high --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -86,7 +86,7 @@ jobs:
           SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
         with:
           image: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
-          args: --file=Dockerfile
+          args: --file=Dockerfile --exclude-app-vulns
 
       - name: Push ${{ env.DOCKER_IMAGE }} images
         if: ${{ success() }}


### PR DESCRIPTION
### Context

SNYK have changed the default setting for scanning app vulnerabilities
https://snyk.io/blog/securing-container-applications-using-the-snyk-cli/

We only check o/s image vulnerabilities with SNYK, so need to reset this to the previous setting

### Changes proposed in this pull request

Add --exclude-app-vulns to the SNYK scan step in the build workflows

### Guidance to review

Check the build workflows

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
