### PR TITLE
Remove routes from staging

### DIFF
--- a/terraform/workspace_variables/staging.tfvars.json
+++ b/terraform/workspace_variables/staging.tfvars.json
@@ -13,6 +13,7 @@
   "key_vault_name": "s121t01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-STAGING",
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-STAGING",
+  "disable_routes": true,
   "statuscake_alerts": {
     "find-staging": {
       "website_name": "find-teacher-training-staging",


### PR DESCRIPTION
### Context

For the findpub merge, remove find routes from staging
To be merged AFTER the routes have been removed from terraform state and moved to publish

### Changes proposed in this pull request

Set "disable_routes": true in staging tfvars.json

### Guidance to review

deploy-plan

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
