### PR TITLE
remove prod routes 

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -13,6 +13,7 @@
   "key_vault_name": "s121p01-shared-kv-01",
   "key_vault_app_secret_name": "FIND-APP-SECRETS-PRODUCTION",
   "key_vault_infra_secret_name": "BAT-INFRA-SECRETS-PRODUCTION",
+  "disable_routes": true,
   "statuscake_alerts": {
     "find-prod": {
       "website_name": "find-teacher-training-prod",


### PR DESCRIPTION
### Context

For the findpub merge, remove find routes from production
To be merged AFTER the routes have been removed from terraform state and moved to publish

### Changes proposed in this pull request

Set "disable_routes": true in production.tfvars.json

### Guidance to review

deploy-plan

### Trello card

### Checklist

- [ ] Rebased `main`
- [ ] Cleaned commit history
- [ ] Tested by running locally
